### PR TITLE
Leave pushing and deciding a pull request to Bertan

### DIFF
--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Where a command starts, where its arguments end, and how many commands a
+# string holds. Sourced by no-git-push.sh and no-pr-decisions.sh.
+#
+# This exists because of what the defects in PR #35 turned out to have in
+# common. Every one of them, found by Bertan or by the assistant, was the same
+# question answered differently in a different place -- how far around a matched
+# token to look:
+#
+#   - the anchor required column zero, so an indented command was not a command
+#   - wrapper re-admission sufficed for a heredoc and did nothing for sh -c
+#   - the option scope was the whole line, so `ls --all && git push` read as --all
+#   - narrowing it to one command cut at a newline, so a backslash continuation
+#     made every push look bare, which is the permitted shape
+#   - and it found the first command only, so a second one after ; or && was
+#     never examined at all
+#
+# Two of those were introduced by the fix to the previous two. The rule was
+# re-derived in about a dozen regular expressions across two files, so fixing it
+# in one place kept opening it in another. It is derived once here instead, and
+# the probe suite points at these functions directly.
+#
+# The answers are approximate on purpose. Splitting more eagerly than a shell
+# would yields extra command candidates, which can only refuse more; it never
+# hides one. That is the safe direction for a guard whose failure mode, twice
+# now, has been to report the permitted answer.
+
+# Reduce a raw command to lines that can be scanned: heredoc bodies dropped,
+# line continuations joined.
+#
+# A heredoc body is data, not commands. This repository writes dev-log entries
+# and commit messages through a quoted heredoc, and those texts name the very
+# commands the hooks refuse; grep anchors ^ per line, so a line of prose
+# beginning with one read as a command position, and an early version of the
+# hooks refused the commit that introduced them.
+#
+# Joining runs after dropping, so a backslash at the end of the line before a
+# heredoc terminator cannot swallow the terminator and hide what follows.
+cs_normalise() {
+  awk '
+    ind { if ($0 == d) ind = 0; next }
+    {
+      if (match($0, /<<-?[[:space:]]*[^[:space:];|&<>()]+/)) {
+        d = substr($0, RSTART, RLENGTH)
+        sub(/^<<-?[[:space:]]*/, "", d)
+        gsub(/[\047"]/, "", d)
+        ind = 1
+      }
+      print
+    }' \
+  | awk '
+    {
+      line = $0
+      while (line ~ /\\$/) {
+        sub(/\\$/, "", line)
+        if ((getline nxt) > 0) line = line nxt; else break
+      }
+      print line
+    }'
+}
+
+# Print one command per line, with anything that precedes the command word
+# removed, so a caller matches on ^ and never has to describe a command
+# position again.
+#
+# Separators are ; && || | ( ) and a backtick. The backtick is there because
+# $( ) was closed by the paren and its twin was not -- the same asymmetry
+# GIT_DIR= had against --git-dir.
+#
+# Removed prefixes: environment assignments, and the wrapper words that run
+# another command with their own options. A caller that cares about the
+# assignments themselves must look at the un-split text; no-git-push.sh does,
+# for GIT_DIR= and GIT_WORK_TREE=.
+cs_split() {
+  sed -e 's/&&/\n/g' -e 's/||/\n/g' -e 's/[;&|()`]/\n/g' \
+  | awk '
+    {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      changed = 1
+      while (changed) {
+        changed = 0
+        if (match(line, /^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+/)) {
+          line = substr(line, RSTART + RLENGTH)
+          changed = 1
+        }
+        if (match(line, /^(env|command|xargs|nohup|nice|time|stdbuf|ionice)[[:space:]]+/)) {
+          line = substr(line, RSTART + RLENGTH)
+          while (match(line, /^-[^[:space:]]*[[:space:]]+/)) {
+            line = substr(line, RSTART + RLENGTH)
+          }
+          changed = 1
+        }
+      }
+      sub(/[[:space:]]+$/, "", line)
+      if (line != "") print line
+    }'
+}
+
+# Print the arguments of a git subcommand and succeed, or print nothing and fail
+# if this command is not `git <subcommand>`. Global options are skipped,
+# including the two that take a separate value: without that, -C /path ends the
+# match before the subcommand is reached.
+#
+# The exit status is what distinguishes `git push` -- a push whose argument list
+# is empty, and the permitted shape -- from a command that is not a push at all.
+# A caller testing the printed text instead would have to re-derive the rule,
+# which is the habit this file exists to end.
+cs_git_args() {
+  awk -v want="$1" '
+    BEGIN { found = 0 }
+    {
+      line = $0
+      if (line !~ /^git([[:space:]]|$)/) next
+      sub(/^git[[:space:]]*/, "", line)
+      while (match(line, /^(-[cC][[:space:]]+[^[:space:]]+|--(git-dir|work-tree|namespace|exec-path)=[^[:space:]]*|-[^[:space:]]+)[[:space:]]+/)) {
+        line = substr(line, RSTART + RLENGTH)
+      }
+      if (line !~ "^" want "([[:space:]]|$)") next
+      sub("^" want "[[:space:]]*", "", line)
+      print line
+      found = 1
+      exit
+    }
+    END { exit(found ? 0 : 1) }'
+}

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -28,6 +28,14 @@
 # after `then`, `do`, `else`, `{` or `!` is at a command position and was not
 # treated as one. Each of the three hid every command that followed it.
 #
+# A third review found the heredoc question wrong a third time, and that is the
+# number that settled it. `git commit -m "fix <<EOF handling"` contains no
+# heredoc -- inside double quotes `<<` is text -- and the rest of the command
+# was dropped. Three wrong answers, each silent and each in the permitting
+# direction, is evidence about the question rather than about the answers: it
+# cannot be got exact by looking more carefully, because that is what the
+# previous two attempts were. The drop is a fail-safe now. See cs_normalise.
+#
 # The answers are approximate on purpose. Splitting more eagerly than a shell
 # would yields extra command candidates, which can only refuse more; it never
 # hides one. That is the safe direction for a guard whose failure mode, twice
@@ -53,12 +61,26 @@
 # tabs from the terminator, which an exact comparison never matched, so that
 # heredoc did not end either. Either one turned a `git push --mirror` or a
 # `gh pr merge` on a following line into nothing at all.
+#
+# Those were the second and third answers to the same question, and a fourth
+# followed them: `git commit -m "fix <<EOF handling"` has no heredoc in it at
+# all -- inside double quotes `<<` is text -- and the opener was matched
+# anywhere on the line, quotes included. So the drop is no longer trusted to be
+# right. A heredoc that never reaches its terminator was not a heredoc, and the
+# lines held for it are given back at END rather than lost.
+#
+# That is the answer this question should have had from the start: the exact
+# version has been got wrong three times, and each time the failure was silent
+# and in the permitting direction. The fail-safe costs a genuinely unterminated
+# heredoc being scanned as commands -- which bash would refuse to run anyway --
+# and it is the direction this file takes everywhere else.
 cs_normalise() {
   awk '
     ind {
       line = $0
       if (dash) sub(/^\t+/, "", line)
-      if (line == d) ind = 0
+      held[++nheld] = $0
+      if (line == d) { ind = 0; nheld = 0 }
       next
     }
     {
@@ -74,7 +96,10 @@ cs_normalise() {
         ind = 1
       }
       print
-    }' \
+    }
+    # The terminator never arrived, so this was not a heredoc and the lines were
+    # dropped in error. Give them back.
+    END { for (i = 1; i <= nheld; i++) print held[i] }' \
   | awk '
     {
       line = $0

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -20,6 +20,14 @@
 # in one place kept opening it in another. It is derived once here instead, and
 # the probe suite points at these functions directly.
 #
+# A second review found three more of the same shape, and all three were here
+# rather than spread across the hooks, which is the point of the file. Two were
+# the heredoc question answered too loosely -- a here-string read as a heredoc,
+# and a tab-indented <<- terminator never recognised, so that heredoc never
+# ended. One was the command-position question answered too narrowly: a command
+# after `then`, `do`, `else`, `{` or `!` is at a command position and was not
+# treated as one. Each of the three hid every command that followed it.
+#
 # The answers are approximate on purpose. Splitting more eagerly than a shell
 # would yields extra command candidates, which can only refuse more; it never
 # hides one. That is the safe direction for a guard whose failure mode, twice
@@ -36,12 +44,31 @@
 #
 # Joining runs after dropping, so a backslash at the end of the line before a
 # heredoc terminator cannot swallow the terminator and hide what follows.
+#
+# Dropping is the one step here that hides commands rather than exposing them,
+# so what counts as a heredoc has to be exact in both directions -- and it was
+# wrong in both. `<<<` is a here-string: the operator regex matched its second
+# and third `<`, took the here-string's own text for a terminator that never
+# arrives, and dropped the rest of the command. `<<-` lets bash strip leading
+# tabs from the terminator, which an exact comparison never matched, so that
+# heredoc did not end either. Either one turned a `git push --mirror` or a
+# `gh pr merge` on a following line into nothing at all.
 cs_normalise() {
   awk '
-    ind { if ($0 == d) ind = 0; next }
+    ind {
+      line = $0
+      if (dash) sub(/^\t+/, "", line)
+      if (line == d) ind = 0
+      next
+    }
     {
-      if (match($0, /<<-?[[:space:]]*[^[:space:];|&<>()]+/)) {
-        d = substr($0, RSTART, RLENGTH)
+      # A here-string is not a heredoc. Blanked at its own width, so a real
+      # heredoc later on the same line is still found where it stands.
+      scan = $0
+      gsub(/<<</, "   ", scan)
+      if (match(scan, /<<-?[[:space:]]*[^[:space:];|&<>()]+/)) {
+        d = substr(scan, RSTART, RLENGTH)
+        dash = (d ~ /^<<-/)
         sub(/^<<-?[[:space:]]*/, "", d)
         gsub(/[\047"]/, "", d)
         ind = 1
@@ -67,10 +94,22 @@ cs_normalise() {
 # $( ) was closed by the paren and its twin was not -- the same asymmetry
 # GIT_DIR= had against --git-dir.
 #
-# Removed prefixes: environment assignments, and the wrapper words that run
-# another command with their own options. A caller that cares about the
-# assignments themselves must look at the un-split text; no-git-push.sh does,
-# for GIT_DIR= and GIT_WORK_TREE=.
+# Removed prefixes: environment assignments, the shell's own control words, and
+# the wrapper words that run another command with their own options. A caller
+# that cares about the assignments themselves must look at the un-split text;
+# no-git-push.sh does, for GIT_DIR= and GIT_WORK_TREE=.
+#
+# The control words are here because a separator is not the only thing a command
+# can follow. `if true; then git push --mirror origin; fi` splits correctly and
+# still left `then` standing in front of the command word, so the anchor never
+# saw a push at all; `do`, `else`, `elif`, `{` and `!` each did the same. They
+# are removed rather than matched around, so every caller keeps anchoring at ^.
+#
+# The trade, taken knowingly and probed as such: a quoted string holding a
+# separator and then one of these words in front of a refused command now reads
+# as that command, so `git commit -m "wait; then git push --all origin"` is
+# refused. That is the direction this file has taken throughout -- a blocked
+# comment is visible and one edit away, a silently permitted push is neither.
 cs_split() {
   sed -e 's/&&/\n/g' -e 's/||/\n/g' -e 's/[;&|()`]/\n/g' \
   | awk '
@@ -81,6 +120,10 @@ cs_split() {
       while (changed) {
         changed = 0
         if (match(line, /^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+/)) {
+          line = substr(line, RSTART + RLENGTH)
+          changed = 1
+        }
+        if (match(line, /^([{}!]|if|then|elif|else|fi|while|until|for|do|done|case|esac|select|function|coproc)([[:space:]]+|$)/)) {
           line = substr(line, RSTART + RLENGTH)
           changed = 1
         }

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -19,96 +19,59 @@
 # convenience in front of one. main is different -- there the policy is the same
 # for both, and the branch ruleset is the right mechanism.
 #
+# Finding commands in the text is lib/command-scan.sh's job, not this file's.
+# Every defect found in PR #35 was that question answered differently in a
+# different place; it is answered once there now.
+#
 # no-commit-to-main.sh independently refuses pushes whose destination is main.
 # It is left in place: it carries the narrower message, and it still stands if
 # this file is disabled.
 #
 # This stops mistakes, not adversaries.
+. "$(dirname "$0")/lib/command-scan.sh"
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+SCAN=$(printf '%s\n' "$COMMAND" | cs_normalise)
+CMDS=$(printf '%s\n' "$SCAN" | cs_split)
 
-# A heredoc body is data, not commands. This repository writes dev-log entries
-# and commit messages through a quoted heredoc, and those texts name the very
-# commands refused here. grep anchors ^ per line, so a line of prose beginning
-# with one of them read as a command position, and an earlier version of this
-# hook refused the commit that introduced it. Bodies are dropped before
-# matching.
-SCAN=$(echo "$COMMAND" | awk '
-  ind { if ($0 == d) ind = 0; next }
-  {
-    if (match($0, /<<-?[[:space:]]*[^[:space:];|&<>()]+/)) {
-      d = substr($0, RSTART, RLENGTH)
-      sub(/^<<-?[[:space:]]*/, "", d)
-      gsub(/[\047"]/, "", d)
-      ind = 1
-    }
-    print
-  }')
-
-# A backslash-newline is a line continuation, not a command separator. The
-# argument scope further down runs from push to the next separator, a newline
-# ended it, and an empty scope fell through to the bare-push case -- the
-# permitted one. So `git push \` followed by `--mirror origin` read as an
-# ordinary bare push and would have deleted every remote branch absent locally.
-# Continuations are joined before anything is matched. Reported on PR #35.
-SCAN=$(printf '%s\n' "$SCAN" | awk '
-  {
-    line = $0
-    while (line ~ /\\$/) {
-      sub(/\\$/, "", line)
-      if ((getline nxt) > 0) line = line nxt; else break
-    }
-    print line
-  }')
-
-# Dropping bodies is itself a bypass: `sh -c "..."` and a heredoc fed to a shell
-# both carry real commands inside text that was just discarded.
-WRAPPED=
-if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
-  WRAPPED=1
-fi
+REFUSE="Blocked: git push. An agent may push only the branch of the linked worktree it is working in, so that it can open a pull request."
 
 # A push inside a wrapper is refused outright, with no worktree exception. The
 # payload sits in quotes where no command position exists, so the destination
 # cannot be read; permitting a push whose target is unknown is not the same as
-# permitting this branch.
-if [ -n "$WRAPPED" ] \
+# permitting this branch. Matched on the raw command, quotes and heredoc bodies
+# included, because that is where the payload still is.
+#
+# This runs before asking whether there is a push, and must: a wrapped push has
+# no command word for the tokeniser to find, so the question would answer no and
+# the hook would leave. Ordering it the other way let all four wrapper forms
+# through, which the probe suite caught.
+if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))' \
    && echo "$COMMAND" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?push([^-A-Za-z0-9_]|$)'; then
   echo "Blocked: git push inside a shell wrapper. The destination cannot be read through a quoted payload, so the worktree exception does not apply. Push plainly from the worktree, or leave it to Bertan." >&2
   exit 2
 fi
 
-# A command sits at a command position: the start of a line -- leading
-# whitespace included -- or after ; && || | or an opening paren.
-#
-# Leading whitespace is load-bearing. The anchor first written here required
-# column zero, which fixed the heredoc false positive and silently gave up every
-# indented push: a push inside an if or a for loop is written indented, and that
-# is the accident this hook exists to stop. Reported on PR #35 and fixed there.
-#
-# The cost is one false positive, accepted knowingly: a quoted multi-line string
-# that is not a heredoc, whose continuation line begins with the command. A
-# blocked comment is visible and one edit away; a permitted push is neither.
-#
-# The -c/-C branch lets `git -C /path push` through the global-option run;
-# without it the option's separate value ends the match before push is reached.
-if ! echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)'; then
-  exit 0
-fi
-
-REFUSE="Blocked: git push. An agent may push only the branch of the linked worktree it is working in, so that it can open a pull request."
+# Is there a push here at all? A command with no push in it costs one pass and
+# leaves without an opinion.
+HAVE_PUSH=
+while IFS= read -r CMD; do
+  if cs_git_args push <<<"$CMD" >/dev/null; then HAVE_PUSH=1; break; fi
+done <<CMDLIST
+$CMDS
+CMDLIST
+[ -n "$HAVE_PUSH" ] || exit 0
 
 # Where the hook runs is the session's directory, which is not necessarily where
 # the command will run. Anything that moves the push elsewhere is refused rather
-# than assessed: cd and pushd, and git redirected by option or by environment.
-# GIT_DIR= and GIT_WORK_TREE= are the environment spelling of --git-dir and
-# --work-tree and were missed when only the option form was refused.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*(cd|pushd|popd)([^-A-Za-z0-9_]|$)'; then
+# than assessed. The environment spellings are read from the un-split text,
+# because cs_split removes assignments to find the command word behind them.
+if printf '%s\n' "$CMDS" | grep -qE '^(cd|pushd|popd)([^-A-Za-z0-9_]|$)'; then
   echo "$REFUSE This command changes directory first, so where the push would land cannot be judged from here." >&2
   exit 2
 fi
-if echo "$SCAN" | grep -qE '(GIT_DIR|GIT_WORK_TREE|GIT_COMMON_DIR)=' \
-   || echo "$SCAN" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?(-C|--git-dir|--work-tree)([[:space:]]|=)'; then
+if echo "$SCAN" | grep -qE '(GIT_DIR|GIT_WORK_TREE|GIT_COMMON_DIR)='; then
   echo "$REFUSE This command points git at another directory, so where the push would land cannot be judged from here." >&2
   exit 2
 fi
@@ -130,56 +93,6 @@ if [ "$CURRENT" = "main" ] || echo "$CURRENT" | grep -qE '^dev-[0-9]+$'; then
   exit 2
 fi
 
-# Everything after the first push on the matched line, up to the next shell
-# separator, is the push's own arguments. Every check below reads these rather
-# than the whole command, so an unrelated flag elsewhere on the line -- the -f
-# of `rm -f x && git push` -- is not mistaken for the push's own.
-PUSH_LINE=$(echo "$SCAN" | grep -m1 -E '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)')
-ARGS=${PUSH_LINE#*push}
-# The scope ends at a shell separator, and a closing paren is one: without it
-# the ) of `(git push)` was read as the push's remote.
-ARGS=$(printf '%s' "$ARGS" | sed 's/[;&|)].*//' | tr -d '\042\047')
-
-# Joining above consumes a backslash that ends a line, including one with no
-# continuation line after it, which is simply a bare push. A backslash surviving
-# here is one the join did not recognise -- trailed by whitespace, say -- and
-# what follows it cannot be read. An empty scope is the permitted case, so an
-# unreadable one is refused rather than allowed to look empty.
-if printf '%s' "$ARGS" | grep -q '\\[[:space:]]*$'; then
-  echo "$REFUSE The arguments continue past where this check can read them." >&2
-  exit 2
-fi
-
-# Whole-repository and tag forms name no branch at all. Refusing branches by
-# name was the shape of this check before, and a denylist cannot see a spelling
-# that names nothing: `git push --all origin` advanced main and dev-05 from any
-# worktree, and --mirror deleted every remote branch absent locally, closing
-# open pull requests. Reported on PR #35.
-if printf ' %s ' "$ARGS" | grep -qE '[[:space:]](--all|--mirror|--tags|--follow-tags|--prune|--delete|-d)([[:space:]]|=|$)'; then
-  echo "$REFUSE That form pushes or deletes refs wholesale rather than naming this branch." >&2
-  exit 2
-fi
-
-# A forced push rewrites what the remote already has, which for this branch is
-# the history an open pull request is showing. --force-with-lease is refused
-# with the rest: it makes the rewrite safe against clobbering someone else's
-# work, not against rewriting a PR under its reviewer. The short form may be
-# bundled with other single-letter options, as -fu, so any single-dash token
-# containing f counts.
-if printf ' %s ' "$ARGS" | grep -qE '[[:space:]](--force|--force-with-lease|--force-if-includes|-[A-Za-z]*f[A-Za-z]*)([[:space:]]|=|$)'; then
-  echo "$REFUSE That is a forced push, which rewrites history the open pull request is showing. Add a commit instead." >&2
-  exit 2
-fi
-
-if printf '%s' "$ARGS" | grep -q '[*]'; then
-  echo "$REFUSE A wildcard refspec does not name this branch." >&2
-  exit 2
-fi
-
-# What remains must positively name this branch: the first bare token is the
-# remote and every later one is a refspec, whose source and destination must
-# both be this branch or HEAD.
-
 names_this_branch() {
   case "$1" in
     HEAD|"$CURRENT"|"refs/heads/$CURRENT") return 0 ;;
@@ -187,51 +100,106 @@ names_this_branch() {
   esac
 }
 
-SKIP=
-REMOTE_SEEN=
-REFSPEC_SEEN=
-for TOK in $ARGS; do
-  if [ -n "$SKIP" ]; then SKIP=; continue; fi
-  case "$TOK" in
-    -o|--push-option|--repo|--receive-pack|--exec) SKIP=1; continue ;;
-    -*) continue ;;
-  esac
-  # The first bare token is the remote. Nothing required it to be one, so a URL
-  # or a typo'd name was admitted whenever the refspec happened to name this
-  # branch. It reaches none of Bertan's branches, but an invented remote is the
-  # shape of mistake this file is for. Raised on PR #35.
-  if [ -z "$REMOTE_SEEN" ]; then
-    REMOTE_SEEN=1
-    if ! git remote | grep -qxF "$TOK"; then
-      echo "$REFUSE $TOK is not a remote of this repository." >&2
-      exit 2
-    fi
-    continue
-  fi
-  REFSPEC_SEEN=1
-  # A leading + on a refspec is the other spelling of --force.
-  case "$TOK" in
-    +*)
-      echo "$REFUSE A leading + forces the push, which rewrites history the open pull request is showing." >&2
-      exit 2 ;;
-  esac
-  SPEC=$TOK
-  case "$SPEC" in
-    *:*) SRC=${SPEC%%:*}; DST=${SPEC#*:} ;;
-    *)   SRC=$SPEC; DST=$SPEC ;;
-  esac
-  if ! names_this_branch "$SRC" || ! names_this_branch "$DST"; then
-    echo "$REFUSE This names $SPEC, not $CURRENT." >&2
-    exit 2
-  fi
-done
+# One push's arguments. Returns 1 with a reason on stderr if it is not a plain,
+# unforced push naming this branch.
+check_push() {
+  local CMD="$1" ARGS="$2" TOK SPEC SRC DST SKIP REMOTE_SEEN REFSPEC_SEEN
 
-# With no refspec the destination comes from push.default. Every value but
-# matching pushes the current branch alone; matching pushes every branch whose
-# name exists on both sides, which would carry dev-NN along without naming it.
-if [ -z "$REFSPEC_SEEN" ] && [ "$(git config --get push.default 2>/dev/null)" = "matching" ]; then
-  echo "$REFUSE push.default is matching, so a push naming no refspec would carry other branches with it." >&2
-  exit 2
-fi
+  if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])(-C|--git-dir|--work-tree)([[:space:]]|=)'; then
+    echo "$REFUSE This command points git at another directory, so where the push would land cannot be judged from here." >&2
+    return 1
+  fi
+
+  # Joining consumes a backslash that ends a line, including one with nothing
+  # after it, which is a bare push and stays permitted. A backslash surviving
+  # here is one the join did not recognise, and what follows cannot be read. An
+  # empty argument list is the permitted case, so an unreadable one is refused
+  # rather than left to look empty.
+  if printf '%s' "$ARGS" | grep -q '\\[[:space:]]*$'; then
+    echo "$REFUSE The arguments continue past where this check can read them." >&2
+    return 1
+  fi
+
+  # Whole-repository and tag forms name no branch at all, and refusing branches
+  # by name -- the shape of this check before PR #35 -- could not see a spelling
+  # that named none. `git push --all origin` advanced main and dev-05 from any
+  # worktree, and --mirror deleted every remote branch absent locally.
+  if printf ' %s ' "$ARGS" | grep -qE '[[:space:]](--all|--mirror|--tags|--follow-tags|--prune|--delete|-d)([[:space:]]|=|$)'; then
+    echo "$REFUSE That form pushes or deletes refs wholesale rather than naming this branch." >&2
+    return 1
+  fi
+
+  # Forcing rewrites what the remote already has, which for this branch is the
+  # history the open pull request is showing. --force-with-lease is refused with
+  # the rest: it guards against clobbering another person's work, not against
+  # rewriting a branch under its reviewer. The short form may be bundled with
+  # other single-letter options, as -fu.
+  if printf ' %s ' "$ARGS" | grep -qE '[[:space:]](--force|--force-with-lease|--force-if-includes|-[A-Za-z]*f[A-Za-z]*)([[:space:]]|=|$)'; then
+    echo "$REFUSE That is a forced push, which rewrites history the open pull request is showing. Add a commit instead." >&2
+    return 1
+  fi
+
+  if printf '%s' "$ARGS" | grep -q '[*]'; then
+    echo "$REFUSE A wildcard refspec does not name this branch." >&2
+    return 1
+  fi
+
+  SKIP=
+  REMOTE_SEEN=
+  REFSPEC_SEEN=
+  for TOK in $ARGS; do
+    if [ -n "$SKIP" ]; then SKIP=; continue; fi
+    case "$TOK" in
+      -o|--push-option|--repo|--receive-pack|--exec) SKIP=1; continue ;;
+      -*) continue ;;
+    esac
+    # The first bare token is the remote. Nothing required it to be one, so a
+    # URL or a typo was admitted whenever the refspec named this branch.
+    if [ -z "$REMOTE_SEEN" ]; then
+      REMOTE_SEEN=1
+      if ! git remote | grep -qxF "$TOK"; then
+        echo "$REFUSE $TOK is not a remote of this repository." >&2
+        return 1
+      fi
+      continue
+    fi
+    REFSPEC_SEEN=1
+    case "$TOK" in
+      +*)
+        echo "$REFUSE A leading + forces the push, which rewrites history the open pull request is showing." >&2
+        return 1 ;;
+    esac
+    case "$TOK" in
+      *:*) SRC=${TOK%%:*}; DST=${TOK#*:} ;;
+      *)   SRC=$TOK; DST=$TOK ;;
+    esac
+    if ! names_this_branch "$SRC" || ! names_this_branch "$DST"; then
+      echo "$REFUSE This names $TOK, not $CURRENT." >&2
+      return 1
+    fi
+  done
+
+  # With no refspec the destination comes from push.default. Every value but
+  # matching pushes the current branch alone; matching pushes every branch whose
+  # name exists on both sides, which would carry dev-NN along without naming it.
+  if [ -z "$REFSPEC_SEEN" ] && [ "$(git config --get push.default 2>/dev/null)" = "matching" ]; then
+    echo "$REFUSE push.default is matching, so a push naming no refspec would carry other branches with it." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+# Every push, not the first. Scoping to one occurrence meant
+# `git push origin my-branch && git push --all origin` passed on the strength of
+# its first half. Reported on PR #35.
+while IFS= read -r CMD; do
+  if ARGS=$(cs_git_args push <<<"$CMD"); then
+    ARGS=$(printf '%s' "$ARGS" | tr -d '\042\047')
+    check_push "$CMD" "$ARGS" || exit 2
+  fi
+done <<CMDLIST
+$CMDS
+CMDLIST
 
 exit 0

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -15,11 +15,10 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 
 # A heredoc body is data, not commands. This repository writes dev-log entries
 # and commit messages through a quoted heredoc, and those texts name the very
-# commands refused here. grep anchors ^ per line, so a wrapped line of prose
-# beginning with one of them read as a command position and the rule forbade
-# writing about itself -- observed when an earlier version of this hook blocked
-# the commit that introduced it. Bodies are dropped before matching; a heredoc
-# fed to a shell is caught by the wrapper rule below, on the raw command.
+# commands refused here. grep anchors ^ per line, so a line of prose beginning
+# with one of them read as a command position, and an earlier version of this
+# hook refused the commit that introduced it. Bodies are dropped before
+# matching.
 SCAN=$(echo "$COMMAND" | awk '
   ind { if ($0 == d) ind = 0; next }
   {
@@ -32,24 +31,47 @@ SCAN=$(echo "$COMMAND" | awk '
     print
   }')
 
-# A real command sits at a command position: start of line, or after ; && || |
-# or an opening paren. Matching after a bare space instead would block a commit
-# message that merely mentions the command. The -c/-C branch is what lets
-# `git -C /path push` through the global-option run; without it the option's
-# separate value ends the match before push is reached.
-if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)git\s+((-[cC]\s+[^ ]+|-[^ ]+)\s+)*push([^-A-Za-z0-9_]|$)'; then
-  echo "Blocked: git push. Pushes to the remote are Bertan's, made from a separate terminal. Leave the commits on the branch and say what is ready to push." >&2
+# Dropping bodies is itself a bypass: `sh -c "..."` and a heredoc fed to a shell
+# both carry real commands inside text that was just discarded. For those shapes
+# the raw command is appended back, so what the drop hides is still matched.
+# no-pr-decisions.sh carries the same block; the two must stay in step.
+WRAPPED=
+if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
+  WRAPPED=1
+  SCAN="$SCAN
+$COMMAND"
+fi
+
+# Re-admitting the text is enough for a heredoc, whose payload sits at the start
+# of a line, and not for `sh -c "..."`, whose payload sits inside quotes where no
+# command position exists. Inside a wrapper the anchor is therefore dropped
+# entirely. Narrow on purpose: the unanchored pattern runs only once a wrapper
+# has already been found, never over an ordinary command.
+if [ -n "$WRAPPED" ] \
+   && echo "$COMMAND" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?push([^-A-Za-z0-9_]|$)'; then
+  echo "Blocked: git push inside a shell wrapper. Pushes to the remote are Bertan's, made from a separate terminal." >&2
   exit 2
 fi
 
-# The anchor above ignores quoted text and heredoc bodies, which would otherwise
-# hide a real push inside a shell wrapper. Wrappers are matched on the whole raw
-# command, quotes and bodies included.
-if echo "$COMMAND" | grep -qE '(^|[;&|(]\s*)(ba|z|)sh\s+(-c|<<)|(^|[;&|(]\s*)eval([^-A-Za-z0-9_]|$)'; then
-  if echo "$COMMAND" | grep -qE 'git\s+([^;&|]*\s)?push([^-A-Za-z0-9_]|$)'; then
-    echo "Blocked: git push inside a shell wrapper. Pushes to the remote are Bertan's, made from a separate terminal." >&2
-    exit 2
-  fi
+# A command sits at a command position: the start of a line -- leading
+# whitespace included -- or after ; && || | or an opening paren.
+#
+# Leading whitespace is load-bearing. The anchor first written here required
+# column zero, which fixed the heredoc false positive and silently gave up every
+# indented push: a push inside an if or a for loop is written indented, and that
+# is the accident this hook exists to stop. no-commit-to-main.sh, with the
+# looser anchor, still caught it. Reported on PR #35 and fixed here.
+#
+# The cost is one false positive, accepted knowingly: a quoted multi-line string
+# that is not a heredoc, whose continuation line begins with the command, as in
+# `gh issue comment -b "...\n  git push ..."`. A blocked comment is visible and
+# one edit away; a silently permitted push is neither.
+#
+# The -c/-C branch lets `git -C /path push` through the global-option run;
+# without it the option's separate value ends the match before push is reached.
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)'; then
+  echo "Blocked: git push. Pushes to the remote are Bertan's, made from a separate terminal. Leave the commits on the branch and say what is ready to push." >&2
+  exit 2
 fi
 
 exit 0

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -12,6 +12,13 @@
 # anyway. In a linked worktree `git rev-parse --git-dir` is .git/worktrees/<name>
 # while --git-common-dir is .git; in the main checkout the two are equal.
 #
+# That check is the only signal that separates Bertan from an agent, because an
+# agent pushes as bgunyel. A server-side ruleset cannot tell them apart: on
+# dev-* it would block both or allow both, and naming him a bypass actor hands
+# the agent the bypass. So for dev-NN this file is the enforcement, not a
+# convenience in front of one. main is different -- there the policy is the same
+# for both, and the branch ruleset is the right mechanism.
+#
 # no-commit-to-main.sh independently refuses pushes whose destination is main.
 # It is left in place: it carries the narrower message, and it still stands if
 # this file is disabled.
@@ -41,14 +48,14 @@ SCAN=$(echo "$COMMAND" | awk '
 # Dropping bodies is itself a bypass: `sh -c "..."` and a heredoc fed to a shell
 # both carry real commands inside text that was just discarded.
 WRAPPED=
-if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
+if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
   WRAPPED=1
 fi
 
 # A push inside a wrapper is refused outright, with no worktree exception. The
 # payload sits in quotes where no command position exists, so the destination
-# cannot be read; permitting it would mean permitting a push whose target is
-# unknown. Re-admission is enough to find it, not to judge it.
+# cannot be read; permitting a push whose target is unknown is not the same as
+# permitting this branch.
 if [ -n "$WRAPPED" ] \
    && echo "$COMMAND" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?push([^-A-Za-z0-9_]|$)'; then
   echo "Blocked: git push inside a shell wrapper. The destination cannot be read through a quoted payload, so the worktree exception does not apply. Push plainly from the worktree, or leave it to Bertan." >&2
@@ -61,32 +68,31 @@ fi
 # Leading whitespace is load-bearing. The anchor first written here required
 # column zero, which fixed the heredoc false positive and silently gave up every
 # indented push: a push inside an if or a for loop is written indented, and that
-# is the accident this hook exists to stop. no-commit-to-main.sh, with the
-# looser anchor, still caught it. Reported on PR #35 and fixed there.
+# is the accident this hook exists to stop. Reported on PR #35 and fixed there.
 #
 # The cost is one false positive, accepted knowingly: a quoted multi-line string
-# that is not a heredoc, whose continuation line begins with the command, as in
-# `gh issue comment -b "...\n  git push ..."`. A blocked comment is visible and
-# one edit away; a silently permitted push is neither.
+# that is not a heredoc, whose continuation line begins with the command. A
+# blocked comment is visible and one edit away; a permitted push is neither.
 #
 # The -c/-C branch lets `git -C /path push` through the global-option run;
 # without it the option's separate value ends the match before push is reached.
-if ! echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)'; then
+if ! echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)'; then
   exit 0
 fi
 
 REFUSE="Blocked: git push. An agent may push only the branch of the linked worktree it is working in, so that it can open a pull request."
 
 # Where the hook runs is the session's directory, which is not necessarily where
-# the command will run. A cd, or a git redirected with -C / --git-dir /
-# --work-tree, moves the push somewhere this check did not look at, so both are
-# refused rather than assessed. no-commit-to-main.sh has the same blind spot and
-# does not close it; here the exception makes it worth closing.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)cd([^-A-Za-z0-9_]|$)'; then
+# the command will run. Anything that moves the push elsewhere is refused rather
+# than assessed: cd and pushd, and git redirected by option or by environment.
+# GIT_DIR= and GIT_WORK_TREE= are the environment spelling of --git-dir and
+# --work-tree and were missed when only the option form was refused.
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*(cd|pushd|popd)([^-A-Za-z0-9_]|$)'; then
   echo "$REFUSE This command changes directory first, so where the push would land cannot be judged from here." >&2
   exit 2
 fi
-if echo "$SCAN" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?(-C|--git-dir|--work-tree)([[:space:]]|=)'; then
+if echo "$SCAN" | grep -qE '(GIT_DIR|GIT_WORK_TREE|GIT_COMMON_DIR)=' \
+   || echo "$SCAN" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?(-C|--git-dir|--work-tree)([[:space:]]|=)'; then
   echo "$REFUSE This command points git at another directory, so where the push would land cannot be judged from here." >&2
   exit 2
 fi
@@ -108,22 +114,63 @@ if [ "$CURRENT" = "main" ] || echo "$CURRENT" | grep -qE '^dev-[0-9]+$'; then
   exit 2
 fi
 
-# A worktree may still push somebody else's branch. Every local branch except
-# the current one is refused wherever it appears as a whole token, which covers
-# `git push origin main`, `git push origin dev-05` and `git push origin
-# HEAD:main` without parsing a refspec.
-#
-# Splitting is on everything a branch name cannot contain, rather than on a list
-# of separators: a quote left attached to the token, as in a push named inside
-# `-b "...main"`, made an exact match miss. The keep set holds / because branch
-# names use it, so a fully qualified refs/heads/<name> is checked separately.
-for BRANCH in $(git for-each-ref --format='%(refname:short)' refs/heads 2>/dev/null); do
-  [ "$BRANCH" = "$CURRENT" ] && continue
-  TOKENS=$(echo "$SCAN" | tr -c 'A-Za-z0-9_./-' '\n')
-  if echo "$TOKENS" | grep -qxF "$BRANCH" || echo "$TOKENS" | grep -qxF "refs/heads/$BRANCH"; then
-    echo "$REFUSE This names $BRANCH, which is not this worktree's branch." >&2
+# Whole-repository and tag forms name no branch at all. Refusing branches by
+# name was the shape of this check before, and a denylist cannot see a spelling
+# that names nothing: `git push --all origin` advanced main and dev-05 from any
+# worktree, and --mirror deleted every remote branch absent locally, closing
+# open pull requests. Reported on PR #35.
+if echo "$SCAN" | grep -qE '[[:space:]](--all|--mirror|--tags|--follow-tags|--prune|--delete|-d)([[:space:]]|=|$)'; then
+  echo "$REFUSE That form pushes or deletes refs wholesale rather than naming this branch." >&2
+  exit 2
+fi
+if echo "$SCAN" | grep -q '[*]'; then
+  echo "$REFUSE A wildcard refspec does not name this branch." >&2
+  exit 2
+fi
+
+# What remains must positively name this branch. Everything after the first
+# push on the matched line, up to the next shell separator, is read as
+# arguments; the first bare token is the remote and every later one is a
+# refspec, whose source and destination must both be this branch or HEAD.
+PUSH_LINE=$(echo "$SCAN" | grep -m1 -E '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)')
+ARGS=${PUSH_LINE#*push}
+ARGS=$(printf '%s' "$ARGS" | sed 's/[;&|].*//' | tr -d '\042\047')
+
+names_this_branch() {
+  case "$1" in
+    HEAD|"$CURRENT"|"refs/heads/$CURRENT") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+SKIP=
+REMOTE_SEEN=
+REFSPEC_SEEN=
+for TOK in $ARGS; do
+  if [ -n "$SKIP" ]; then SKIP=; continue; fi
+  case "$TOK" in
+    -o|--push-option|--repo|--receive-pack|--exec) SKIP=1; continue ;;
+    -*) continue ;;
+  esac
+  if [ -z "$REMOTE_SEEN" ]; then REMOTE_SEEN=1; continue; fi
+  REFSPEC_SEEN=1
+  SPEC=${TOK#+}
+  case "$SPEC" in
+    *:*) SRC=${SPEC%%:*}; DST=${SPEC#*:} ;;
+    *)   SRC=$SPEC; DST=$SPEC ;;
+  esac
+  if ! names_this_branch "$SRC" || ! names_this_branch "$DST"; then
+    echo "$REFUSE This names $SPEC, not $CURRENT." >&2
     exit 2
   fi
 done
+
+# With no refspec the destination comes from push.default. Every value but
+# matching pushes the current branch alone; matching pushes every branch whose
+# name exists on both sides, which would carry dev-NN along without naming it.
+if [ -z "$REFSPEC_SEEN" ] && [ "$(git config --get push.default 2>/dev/null)" = "matching" ]; then
+  echo "$REFUSE push.default is matching, so a push naming no refspec would carry other branches with it." >&2
+  exit 2
+fi
 
 exit 0

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -35,6 +35,14 @@
 # This stops mistakes, not adversaries.
 . "$(dirname "$0")/lib/command-scan.sh"
 
+# check_push splits a push's arguments with `for TOK in $ARGS`, unquoted because
+# the split is the point. That also globs them against the worktree: `*` is
+# refused by name, `?` and [...] were not, and a refspec that matched a file
+# would have been read as that filename. Both spellings land on BLOCK today, so
+# this is a latent surprise rather than a hole -- closed here rather than left
+# to become one. Nothing in this file needs pathname expansion.
+set -f
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 SCAN=$(printf '%s\n' "$COMMAND" | cs_normalise)

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -5,6 +5,11 @@
 # refused, and Bertan's own pushes are made from a separate terminal where no
 # hook runs.
 #
+# The push must name that branch in the command -- `git push origin <branch>`,
+# not `git push`. A push naming no refspec is answered by configuration, and an
+# agent can set configuration, so a bare push cannot be judged from here at all.
+# See the refspec check at the foot of check_push.
+#
 # The exception is keyed on where the command runs, not on what the branch is
 # called. Worktrees are made two ways here -- EnterWorktree, which prefixes the
 # branch `worktree-`, and `git worktree add -b`, which does not -- so a name
@@ -110,6 +115,16 @@ check_push() {
     return 1
   fi
 
+  # -c and --config-env set configuration for this one command. Every value this
+  # hook reads back with `git config` is therefore a value the command can have
+  # already replaced, which is not a gap that can be closed by reading more
+  # carefully. `git -c push.default=matching push` was allowed for exactly that
+  # reason. Reported on PR #35's review.
+  if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])(-c|--config-env)([[:space:]]|=)'; then
+    echo "$REFUSE This command sets git configuration for itself, which overrides what this check would read back." >&2
+    return 1
+  fi
+
   # Joining consumes a backslash that ends a line, including one with nothing
   # after it, which is a bare push and stays permitted. A backslash surviving
   # here is one the join did not recognise, and what follows cannot be read. An
@@ -179,11 +194,22 @@ check_push() {
     fi
   done
 
-  # With no refspec the destination comes from push.default. Every value but
-  # matching pushes the current branch alone; matching pushes every branch whose
-  # name exists on both sides, which would carry dev-NN along without naming it.
-  if [ -z "$REFSPEC_SEEN" ] && [ "$(git config --get push.default 2>/dev/null)" = "matching" ]; then
-    echo "$REFUSE push.default is matching, so a push naming no refspec would carry other branches with it." >&2
+  # A push naming no refspec takes its destination from configuration, and there
+  # are four places to write it: push.default, a remote.<name>.push refspec, the
+  # branch's own upstream under push.default=upstream, and -c on the command
+  # itself. Reading push.default answered one of the four, and -c walked past
+  # even that -- so the destination is required in the command instead. That is
+  # what CLAUDE.md already asks for: a push "positively naming that branch".
+  #
+  # The check is also no longer a question about configuration, which is what
+  # makes it hold. An agent may run `git config`; nothing here refuses it. Any
+  # rule resting on a configured value could be arranged around one command
+  # earlier, and reading the value more thoroughly would not change that.
+  #
+  # The trade: bare `git push` no longer works, and neither does `git push
+  # origin`. Both were permitted before. Write `git push origin <branch>`.
+  if [ -z "$REFSPEC_SEEN" ]; then
+    echo "$REFUSE A push naming no refspec takes its destination from configuration, which this command could have set for itself. Name the branch: git push <remote> $CURRENT." >&2
     return 1
   fi
 

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Pushes to the remote are made by Bertan from a separate terminal, outside
+# Claude Code. Nothing an agent does in this repository needs to reach the
+# remote, so every push is refused here rather than judged case by case.
+#
+# no-commit-to-main.sh already refuses pushes whose destination is main. That
+# rule is deliberately left in place rather than folded into this one: it
+# carries the narrower message, and it still stands if this file is disabled.
+#
+# This stops mistakes, not adversaries. A caller who wants to push can spell it
+# in ways this regex does not match; the point is that none of them happen by
+# accident.
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+
+# A heredoc body is data, not commands. This repository writes dev-log entries
+# and commit messages through a quoted heredoc, and those texts name the very
+# commands refused here. grep anchors ^ per line, so a wrapped line of prose
+# beginning with one of them read as a command position and the rule forbade
+# writing about itself -- observed when an earlier version of this hook blocked
+# the commit that introduced it. Bodies are dropped before matching; a heredoc
+# fed to a shell is caught by the wrapper rule below, on the raw command.
+SCAN=$(echo "$COMMAND" | awk '
+  ind { if ($0 == d) ind = 0; next }
+  {
+    if (match($0, /<<-?[[:space:]]*[^[:space:];|&<>()]+/)) {
+      d = substr($0, RSTART, RLENGTH)
+      sub(/^<<-?[[:space:]]*/, "", d)
+      gsub(/[\047"]/, "", d)
+      ind = 1
+    }
+    print
+  }')
+
+# A real command sits at a command position: start of line, or after ; && || |
+# or an opening paren. Matching after a bare space instead would block a commit
+# message that merely mentions the command. The -c/-C branch is what lets
+# `git -C /path push` through the global-option run; without it the option's
+# separate value ends the match before push is reached.
+if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)git\s+((-[cC]\s+[^ ]+|-[^ ]+)\s+)*push([^-A-Za-z0-9_]|$)'; then
+  echo "Blocked: git push. Pushes to the remote are Bertan's, made from a separate terminal. Leave the commits on the branch and say what is ready to push." >&2
+  exit 2
+fi
+
+# The anchor above ignores quoted text and heredoc bodies, which would otherwise
+# hide a real push inside a shell wrapper. Wrappers are matched on the whole raw
+# command, quotes and bodies included.
+if echo "$COMMAND" | grep -qE '(^|[;&|(]\s*)(ba|z|)sh\s+(-c|<<)|(^|[;&|(]\s*)eval([^-A-Za-z0-9_]|$)'; then
+  if echo "$COMMAND" | grep -qE 'git\s+([^;&|]*\s)?push([^-A-Za-z0-9_]|$)'; then
+    echo "Blocked: git push inside a shell wrapper. Pushes to the remote are Bertan's, made from a separate terminal." >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
-# Pushes to the remote are made by Bertan from a separate terminal, outside
-# Claude Code. Nothing an agent does in this repository needs to reach the
-# remote, so every push is refused here rather than judged case by case.
+# Pushing is Bertan's, with one exception: an agent may push the branch of the
+# linked worktree it is working in, which is what lets it open a pull request at
+# all -- gh pr create needs the branch on the remote first. Everything else is
+# refused, and Bertan's own pushes are made from a separate terminal where no
+# hook runs.
 #
-# no-commit-to-main.sh already refuses pushes whose destination is main. That
-# rule is deliberately left in place rather than folded into this one: it
-# carries the narrower message, and it still stands if this file is disabled.
+# The exception is keyed on where the command runs, not on what the branch is
+# called. Worktrees are made two ways here -- EnterWorktree, which prefixes the
+# branch `worktree-`, and `git worktree add -b`, which does not -- so a name
+# rule would be inconsistent between them, and a name can be chosen to match
+# anyway. In a linked worktree `git rev-parse --git-dir` is .git/worktrees/<name>
+# while --git-common-dir is .git; in the main checkout the two are equal.
 #
-# This stops mistakes, not adversaries. A caller who wants to push can spell it
-# in ways this regex does not match; the point is that none of them happen by
-# accident.
+# no-commit-to-main.sh independently refuses pushes whose destination is main.
+# It is left in place: it carries the narrower message, and it still stands if
+# this file is disabled.
+#
+# This stops mistakes, not adversaries.
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 
@@ -32,24 +39,19 @@ SCAN=$(echo "$COMMAND" | awk '
   }')
 
 # Dropping bodies is itself a bypass: `sh -c "..."` and a heredoc fed to a shell
-# both carry real commands inside text that was just discarded. For those shapes
-# the raw command is appended back, so what the drop hides is still matched.
-# no-pr-decisions.sh carries the same block; the two must stay in step.
+# both carry real commands inside text that was just discarded.
 WRAPPED=
 if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
   WRAPPED=1
-  SCAN="$SCAN
-$COMMAND"
 fi
 
-# Re-admitting the text is enough for a heredoc, whose payload sits at the start
-# of a line, and not for `sh -c "..."`, whose payload sits inside quotes where no
-# command position exists. Inside a wrapper the anchor is therefore dropped
-# entirely. Narrow on purpose: the unanchored pattern runs only once a wrapper
-# has already been found, never over an ordinary command.
+# A push inside a wrapper is refused outright, with no worktree exception. The
+# payload sits in quotes where no command position exists, so the destination
+# cannot be read; permitting it would mean permitting a push whose target is
+# unknown. Re-admission is enough to find it, not to judge it.
 if [ -n "$WRAPPED" ] \
    && echo "$COMMAND" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?push([^-A-Za-z0-9_]|$)'; then
-  echo "Blocked: git push inside a shell wrapper. Pushes to the remote are Bertan's, made from a separate terminal." >&2
+  echo "Blocked: git push inside a shell wrapper. The destination cannot be read through a quoted payload, so the worktree exception does not apply. Push plainly from the worktree, or leave it to Bertan." >&2
   exit 2
 fi
 
@@ -60,7 +62,7 @@ fi
 # column zero, which fixed the heredoc false positive and silently gave up every
 # indented push: a push inside an if or a for loop is written indented, and that
 # is the accident this hook exists to stop. no-commit-to-main.sh, with the
-# looser anchor, still caught it. Reported on PR #35 and fixed here.
+# looser anchor, still caught it. Reported on PR #35 and fixed there.
 #
 # The cost is one false positive, accepted knowingly: a quoted multi-line string
 # that is not a heredoc, whose continuation line begins with the command, as in
@@ -69,9 +71,59 @@ fi
 #
 # The -c/-C branch lets `git -C /path push` through the global-option run;
 # without it the option's separate value ends the match before push is reached.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)'; then
-  echo "Blocked: git push. Pushes to the remote are Bertan's, made from a separate terminal. Leave the commits on the branch and say what is ready to push." >&2
+if ! echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)'; then
+  exit 0
+fi
+
+REFUSE="Blocked: git push. An agent may push only the branch of the linked worktree it is working in, so that it can open a pull request."
+
+# Where the hook runs is the session's directory, which is not necessarily where
+# the command will run. A cd, or a git redirected with -C / --git-dir /
+# --work-tree, moves the push somewhere this check did not look at, so both are
+# refused rather than assessed. no-commit-to-main.sh has the same blind spot and
+# does not close it; here the exception makes it worth closing.
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)cd([^-A-Za-z0-9_]|$)'; then
+  echo "$REFUSE This command changes directory first, so where the push would land cannot be judged from here." >&2
   exit 2
 fi
+if echo "$SCAN" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?(-C|--git-dir|--work-tree)([[:space:]]|=)'; then
+  echo "$REFUSE This command points git at another directory, so where the push would land cannot be judged from here." >&2
+  exit 2
+fi
+
+GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null)
+GIT_COMMON_PATH=$(git rev-parse --git-common-dir 2>/dev/null)
+if [ -z "$GIT_DIR_PATH" ] || [ "$GIT_DIR_PATH" = "$GIT_COMMON_PATH" ]; then
+  echo "$REFUSE This is the main checkout, not a linked worktree. Leave the commits on the branch and say what is ready to push." >&2
+  exit 2
+fi
+
+CURRENT=$(git branch --show-current 2>/dev/null)
+if [ -z "$CURRENT" ]; then
+  echo "$REFUSE This worktree has no branch checked out." >&2
+  exit 2
+fi
+if [ "$CURRENT" = "main" ] || echo "$CURRENT" | grep -qE '^dev-[0-9]+$'; then
+  echo "$REFUSE This worktree is on $CURRENT, which is Bertan's to push." >&2
+  exit 2
+fi
+
+# A worktree may still push somebody else's branch. Every local branch except
+# the current one is refused wherever it appears as a whole token, which covers
+# `git push origin main`, `git push origin dev-05` and `git push origin
+# HEAD:main` without parsing a refspec.
+#
+# Splitting is on everything a branch name cannot contain, rather than on a list
+# of separators: a quote left attached to the token, as in a push named inside
+# `-b "...main"`, made an exact match miss. The keep set holds / because branch
+# names use it, so a fully qualified refs/heads/<name> is checked separately.
+for BRANCH in $(git for-each-ref --format='%(refname:short)' refs/heads 2>/dev/null); do
+  [ "$BRANCH" = "$CURRENT" ] && continue
+  TOKENS=$(echo "$SCAN" | tr -c 'A-Za-z0-9_./-' '\n')
+  if echo "$TOKENS" | grep -qxF "$BRANCH" || echo "$TOKENS" | grep -qxF "refs/heads/$BRANCH"; then
+    echo "$REFUSE This names $BRANCH, which is not this worktree's branch." >&2
+    exit 2
+  fi
+done
 
 exit 0

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -45,6 +45,22 @@ SCAN=$(echo "$COMMAND" | awk '
     print
   }')
 
+# A backslash-newline is a line continuation, not a command separator. The
+# argument scope further down runs from push to the next separator, a newline
+# ended it, and an empty scope fell through to the bare-push case -- the
+# permitted one. So `git push \` followed by `--mirror origin` read as an
+# ordinary bare push and would have deleted every remote branch absent locally.
+# Continuations are joined before anything is matched. Reported on PR #35.
+SCAN=$(printf '%s\n' "$SCAN" | awk '
+  {
+    line = $0
+    while (line ~ /\\$/) {
+      sub(/\\$/, "", line)
+      if ((getline nxt) > 0) line = line nxt; else break
+    }
+    print line
+  }')
+
 # Dropping bodies is itself a bypass: `sh -c "..."` and a heredoc fed to a shell
 # both carry real commands inside text that was just discarded.
 WRAPPED=
@@ -120,7 +136,19 @@ fi
 # of `rm -f x && git push` -- is not mistaken for the push's own.
 PUSH_LINE=$(echo "$SCAN" | grep -m1 -E '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)')
 ARGS=${PUSH_LINE#*push}
-ARGS=$(printf '%s' "$ARGS" | sed 's/[;&|].*//' | tr -d '\042\047')
+# The scope ends at a shell separator, and a closing paren is one: without it
+# the ) of `(git push)` was read as the push's remote.
+ARGS=$(printf '%s' "$ARGS" | sed 's/[;&|)].*//' | tr -d '\042\047')
+
+# Joining above consumes a backslash that ends a line, including one with no
+# continuation line after it, which is simply a bare push. A backslash surviving
+# here is one the join did not recognise -- trailed by whitespace, say -- and
+# what follows it cannot be read. An empty scope is the permitted case, so an
+# unreadable one is refused rather than allowed to look empty.
+if printf '%s' "$ARGS" | grep -q '\\[[:space:]]*$'; then
+  echo "$REFUSE The arguments continue past where this check can read them." >&2
+  exit 2
+fi
 
 # Whole-repository and tag forms name no branch at all. Refusing branches by
 # name was the shape of this check before, and a denylist cannot see a spelling
@@ -168,7 +196,18 @@ for TOK in $ARGS; do
     -o|--push-option|--repo|--receive-pack|--exec) SKIP=1; continue ;;
     -*) continue ;;
   esac
-  if [ -z "$REMOTE_SEEN" ]; then REMOTE_SEEN=1; continue; fi
+  # The first bare token is the remote. Nothing required it to be one, so a URL
+  # or a typo'd name was admitted whenever the refspec happened to name this
+  # branch. It reaches none of Bertan's branches, but an invented remote is the
+  # shape of mistake this file is for. Raised on PR #35.
+  if [ -z "$REMOTE_SEEN" ]; then
+    REMOTE_SEEN=1
+    if ! git remote | grep -qxF "$TOK"; then
+      echo "$REFUSE $TOK is not a remote of this repository." >&2
+      exit 2
+    fi
+    continue
+  fi
   REFSPEC_SEEN=1
   # A leading + on a refspec is the other spelling of --force.
   case "$TOK" in

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -114,27 +114,43 @@ if [ "$CURRENT" = "main" ] || echo "$CURRENT" | grep -qE '^dev-[0-9]+$'; then
   exit 2
 fi
 
+# Everything after the first push on the matched line, up to the next shell
+# separator, is the push's own arguments. Every check below reads these rather
+# than the whole command, so an unrelated flag elsewhere on the line -- the -f
+# of `rm -f x && git push` -- is not mistaken for the push's own.
+PUSH_LINE=$(echo "$SCAN" | grep -m1 -E '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)')
+ARGS=${PUSH_LINE#*push}
+ARGS=$(printf '%s' "$ARGS" | sed 's/[;&|].*//' | tr -d '\042\047')
+
 # Whole-repository and tag forms name no branch at all. Refusing branches by
 # name was the shape of this check before, and a denylist cannot see a spelling
 # that names nothing: `git push --all origin` advanced main and dev-05 from any
 # worktree, and --mirror deleted every remote branch absent locally, closing
 # open pull requests. Reported on PR #35.
-if echo "$SCAN" | grep -qE '[[:space:]](--all|--mirror|--tags|--follow-tags|--prune|--delete|-d)([[:space:]]|=|$)'; then
+if printf ' %s ' "$ARGS" | grep -qE '[[:space:]](--all|--mirror|--tags|--follow-tags|--prune|--delete|-d)([[:space:]]|=|$)'; then
   echo "$REFUSE That form pushes or deletes refs wholesale rather than naming this branch." >&2
   exit 2
 fi
-if echo "$SCAN" | grep -q '[*]'; then
+
+# A forced push rewrites what the remote already has, which for this branch is
+# the history an open pull request is showing. --force-with-lease is refused
+# with the rest: it makes the rewrite safe against clobbering someone else's
+# work, not against rewriting a PR under its reviewer. The short form may be
+# bundled with other single-letter options, as -fu, so any single-dash token
+# containing f counts.
+if printf ' %s ' "$ARGS" | grep -qE '[[:space:]](--force|--force-with-lease|--force-if-includes|-[A-Za-z]*f[A-Za-z]*)([[:space:]]|=|$)'; then
+  echo "$REFUSE That is a forced push, which rewrites history the open pull request is showing. Add a commit instead." >&2
+  exit 2
+fi
+
+if printf '%s' "$ARGS" | grep -q '[*]'; then
   echo "$REFUSE A wildcard refspec does not name this branch." >&2
   exit 2
 fi
 
-# What remains must positively name this branch. Everything after the first
-# push on the matched line, up to the next shell separator, is read as
-# arguments; the first bare token is the remote and every later one is a
-# refspec, whose source and destination must both be this branch or HEAD.
-PUSH_LINE=$(echo "$SCAN" | grep -m1 -E '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*git[[:space:]]+((-[cC][[:space:]]+[^ ]+|-[^ ]+)[[:space:]]+)*push([^-A-Za-z0-9_]|$)')
-ARGS=${PUSH_LINE#*push}
-ARGS=$(printf '%s' "$ARGS" | sed 's/[;&|].*//' | tr -d '\042\047')
+# What remains must positively name this branch: the first bare token is the
+# remote and every later one is a refspec, whose source and destination must
+# both be this branch or HEAD.
 
 names_this_branch() {
   case "$1" in
@@ -154,7 +170,13 @@ for TOK in $ARGS; do
   esac
   if [ -z "$REMOTE_SEEN" ]; then REMOTE_SEEN=1; continue; fi
   REFSPEC_SEEN=1
-  SPEC=${TOK#+}
+  # A leading + on a refspec is the other spelling of --force.
+  case "$TOK" in
+    +*)
+      echo "$REFUSE A leading + forces the push, which rewrites history the open pull request is showing." >&2
+      exit 2 ;;
+  esac
+  SPEC=$TOK
   case "$SPEC" in
     *:*) SRC=${SPEC%%:*}; DST=${SPEC#*:} ;;
     *)   SRC=$SPEC; DST=$SPEC ;;

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -17,12 +17,15 @@
 # anyway. In a linked worktree `git rev-parse --git-dir` is .git/worktrees/<name>
 # while --git-common-dir is .git; in the main checkout the two are equal.
 #
-# That check is the only signal that separates Bertan from an agent, because an
-# agent pushes as bgunyel. A server-side ruleset cannot tell them apart: on
-# dev-* it would block both or allow both, and naming him a bypass actor hands
-# the agent the bypass. So for dev-NN this file is the enforcement, not a
-# convenience in front of one. main is different -- there the policy is the same
-# for both, and the branch ruleset is the right mechanism.
+# That check is the only signal available here that separates Bertan from an
+# agent, because an agent pushes as bgunyel today. A server-side ruleset cannot
+# tell those two apart while they share one account: on dev-* it would block
+# both or allow both, and naming him a bypass actor hands the agent the bypass.
+# So for dev-NN this file is the enforcement, not a convenience in front of one.
+# main is different -- there the policy is the same for both, and the branch
+# ruleset is the right mechanism. The shared account is a configuration choice,
+# not a law; docs/adr/0001-hooks-not-ruleset.md records it and the alternative
+# that would change the answer.
 #
 # Finding commands in the text is lib/command-scan.sh's job, not this file's.
 # Every defect found in PR #35 was that question answered differently in a
@@ -33,6 +36,17 @@
 # this file is disabled.
 #
 # This stops mistakes, not adversaries.
+#
+# STOPPING RULE. A newly found evasion earns a fix only if it is a shape an
+# agent would plausibly write, not one it would have to construct. Indentation,
+# && chains and control words clear that bar -- an agent writes those without
+# meaning to evade anything, which is why each of them was fixed. A payload
+# quoted inside eval or a shell wrapper does not, which is why wrappers are
+# refused outright rather than parsed: that is the designed answer, not a
+# limitation to be closed later. Each round of review on PR #35 found something,
+# and at least one fix opened the next hole: dropping heredoc bodies stopped a
+# false positive and blinded both hooks to a real command, which b625d64 then
+# closed. Stop when the shapes stop being ones an agent would plausibly write.
 . "$(dirname "$0")/lib/command-scan.sh"
 
 # check_push splits a push's arguments with `for TOK in $ARGS`, unquoted because

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -10,10 +10,6 @@
 # listing, diffing and checking one, reviewing with --comment, and every
 # gh issue subcommand.
 #
-# Commands are matched only at a command position (start of line, or after ;
-# && || | or a paren), and heredoc bodies are dropped first, so a dev-log entry
-# or a commit message may name any of them in prose.
-#
 # The convenient spelling is only one way in. The same merge is one REST call
 # (PUT /repos/O/R/pulls/N/merge) or one graphql mutation away, and gh api is
 # allowlisted in settings.local.json, so those two shapes are matched too. URLs
@@ -35,42 +31,84 @@ SCAN=$(echo "$COMMAND" | awk '
     print
   }')
 
+# Dropping bodies is itself a bypass, and this file lacked the guard its sibling
+# had -- reported on PR #35, where `bash -c 'gh pr merge 35'` and a graphql
+# mutation sent through a heredoc both passed. Two shapes re-admit the raw
+# command: a shell wrapper, and gh api reading a heredoc, which is the ordinary
+# way a mutation is sent and so is a decision hiding in dropped text.
 DECIDE="Blocked: deciding a pull request is Bertan's call, not an agent's. Opening a PR, commenting on it and editing it are allowed; accepting, rejecting, merging and reopening are not."
 
-if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+pr\s+merge([^-A-Za-z0-9_]|$)'; then
+WRAPPED=
+if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
+  WRAPPED=1
+  SCAN="$SCAN
+$COMMAND"
+elif echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+api' \
+     && echo "$COMMAND" | grep -q '<<'; then
+  SCAN="$SCAN
+$COMMAND"
+fi
+
+# Re-admitting the text is enough for a heredoc, whose payload sits at the start
+# of a line, and not for `sh -c "..."`, whose payload sits inside quotes where no
+# command position exists. Inside a wrapper the anchor is dropped entirely, for
+# every decision this file refuses. Narrow on purpose: the unanchored patterns
+# run only once a wrapper has already been found.
+if [ -n "$WRAPPED" ]; then
+  if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+(merge|close|reopen)([^-A-Za-z0-9_]|$)' \
+     || echo "$COMMAND" | grep -qE 'gh[[:space:]]+release[[:space:]]+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)' \
+     || echo "$COMMAND" | grep -qE '/pulls/[^ ]*/(merge|reviews)' \
+     || echo "$COMMAND" | grep -qE 'mergePullRequest|addPullRequestReview'; then
+    echo "$DECIDE A shell wrapper does not change what the command decides." >&2
+    exit 2
+  fi
+  if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+review([^-A-Za-z0-9_]|$)' \
+     && echo "$COMMAND" | grep -qE '[[:space:]](--approve|--request-changes|-a|-r)([[:space:]]|=|"|$)'; then
+    echo "$DECIDE A shell wrapper does not change what the command decides." >&2
+    exit 2
+  fi
+fi
+
+# A command sits at a command position: the start of a line -- leading
+# whitespace included, because `gh pr merge` inside an if or a for loop is
+# written indented -- or after ; && || | or an opening paren. Requiring column
+# zero, as this file first did, missed every indented decision. The cost is a
+# quoted multi-line string whose continuation line begins with one of these
+# commands; that false positive is accepted, being visible and one edit away.
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+merge([^-A-Za-z0-9_]|$)'; then
   echo "$DECIDE Leave the PR open and say it is ready to merge." >&2
   exit 2
 fi
 
 # Only the verdict flags. Reviewing with --comment leaves remarks without a
 # verdict and stays allowed, so the subcommand alone is not enough to block on.
-if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+pr\s+review([^-A-Za-z0-9_]|$)' \
-   && echo "$SCAN" | grep -qE '\s(--approve|--request-changes|-a|-r)(\s|=|$)'; then
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+review([^-A-Za-z0-9_]|$)' \
+   && echo "$SCAN" | grep -qE '[[:space:]](--approve|--request-changes|-a|-r)([[:space:]]|=|$)'; then
   echo "$DECIDE Review with --comment to leave remarks without a verdict." >&2
   exit 2
 fi
 
 # Rejecting a pull request by outcome rather than by verdict.
-if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+pr\s+(close|reopen)([^-A-Za-z0-9_]|$)'; then
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+(close|reopen)([^-A-Za-z0-9_]|$)'; then
   echo "$DECIDE Closing a PR rejects it; say why it should be closed instead." >&2
   exit 2
 fi
 
 # Outward-facing publication. This repository is public.
-if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+release\s+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)'; then
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+release[[:space:]]+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)'; then
   echo "Blocked: publishing or deleting a GitHub release is Bertan's call. This repository is public; a release is visible the moment it exists." >&2
   exit 2
 fi
 
 # The REST endpoints behind the two blocked pull-request commands.
-if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+api([^-A-Za-z0-9_]|$)' \
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+api([^-A-Za-z0-9_]|$)' \
    && echo "$SCAN" | grep -qE '/pulls/[^ ]*/(merge|reviews)'; then
   echo "$DECIDE Reaching the merge or review endpoint through gh api is the same decision by another name." >&2
   exit 2
 fi
 
 # The same two decisions expressed as graphql mutations.
-if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+api\s+graphql([^-A-Za-z0-9_]|$)' \
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+api([^-A-Za-z0-9_]|$)' \
    && echo "$SCAN" | grep -qE 'mergePullRequest|addPullRequestReview'; then
   echo "$DECIDE Reaching the merge or review mutation through graphql is the same decision by another name." >&2
   exit 2

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -47,44 +47,63 @@ CMDS=$(printf '%s\n' "$SCAN" | cs_split)
 
 DECIDE="Blocked: deciding a pull request is Bertan's call, not an agent's. Opening a PR, commenting on it and editing it are allowed; accepting, rejecting, merging and reopening are not."
 
+# `gh pr merge` is not the only way to write `gh pr merge`. Cobra resolves the
+# subcommand at the first non-flag argument, so a flag may sit in front of it:
+# `gh pr --repo o/r merge 35` merges, and every rule here wanted the subcommand
+# as the third word. -R/--repo takes its value as a separate token and has to
+# consume it, or the value would be read as the subcommand. Written once and
+# interpolated, so the group and the verb are still all a rule has to name.
+GHPR='^gh[[:space:]]+pr([[:space:]]+((-R|--repo|--hostname)[[:space:]]+[^[:space:]]+|-[^[:space:]]+))*[[:space:]]+'
+GHRELEASE='^gh[[:space:]]+release([[:space:]]+((-R|--repo|--hostname)[[:space:]]+[^[:space:]]+|-[^[:space:]]+))*[[:space:]]+'
+
+# The verdict flags, bundled or not. gh takes shorthand flags together, so
+# `gh pr review -ab "lgtm" 35` is --approve --body and was allowed while
+# `-a` alone was refused. no-git-push.sh had already answered this for -fu and
+# this file had not -- the same asymmetry twice. Only single-dash bundles are
+# scanned for a or r: a long flag would match on any letter it happens to
+# contain, and --repo would read as --request-changes.
+VERDICT='[[:space:]](--approve|--request-changes|-[A-Za-z]*[ar][A-Za-z]*)([[:space:]]|=|"|$)'
+
 # A wrapper's payload sits inside quotes, where there is no command word for the
 # tokeniser to find, so these run unanchored over the raw text -- and only once
 # a wrapper has been found, never over an ordinary command.
 if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
-  if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+(merge|close|reopen)([^-A-Za-z0-9_]|$)' \
-     || echo "$COMMAND" | grep -qE 'gh[[:space:]]+release[[:space:]]+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)' \
+  if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+.*(merge|close|reopen)([^-A-Za-z0-9_]|$)' \
+     || echo "$COMMAND" | grep -qE 'gh[[:space:]]+release[[:space:]]+.*(create|delete|delete-asset)([^-A-Za-z0-9_]|$)' \
      || echo "$COMMAND" | grep -qE '/pulls/[^ ]*/(merge|reviews)' \
-     || echo "$COMMAND" | grep -qE 'mergePullRequest|addPullRequestReview'; then
+     || echo "$COMMAND" | grep -qE '/releases([^A-Za-z0-9_-]|$)' \
+     || echo "$COMMAND" | grep -qiE 'state[[:space:]]*[=:][[:space:]]*"?(closed|open)"?' \
+     || echo "$COMMAND" | grep -qE 'mergePullRequest|addPullRequestReview|closePullRequest|reopenPullRequest|createRelease|updateRelease|deleteRelease'; then
     echo "$DECIDE A shell wrapper does not change what the command decides." >&2
     exit 2
   fi
   if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+review([^-A-Za-z0-9_]|$)' \
-     && echo "$COMMAND" | grep -qE '[[:space:]](--approve|--request-changes|-a|-r)([[:space:]]|=|"|$)'; then
+     && echo "$COMMAND" | grep -qE "$VERDICT"; then
     echo "$DECIDE A shell wrapper does not change what the command decides." >&2
     exit 2
   fi
 fi
 
-if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+pr[[:space:]]+merge([^-A-Za-z0-9_]|$)'; then
+if printf '%s\n' "$CMDS" | grep -qE "${GHPR}merge([^-A-Za-z0-9_]|\$)"; then
   echo "$DECIDE Leave the PR open and say it is ready to merge." >&2
   exit 2
 fi
 
 # Only the verdict flags, and only in the same command as the subcommand.
 # Reviewing with --comment leaves remarks without a verdict and stays allowed.
-if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+pr[[:space:]]+review([[:space:]].*)?[[:space:]](--approve|--request-changes|-a|-r)([[:space:]]|=|$)'; then
+if printf '%s\n' "$CMDS" | grep -qE "${GHPR}review([[:space:]].*)?${VERDICT}"; then
   echo "$DECIDE Review with --comment to leave remarks without a verdict." >&2
   exit 2
 fi
 
 # Rejecting a pull request by outcome rather than by verdict.
-if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+pr[[:space:]]+(close|reopen)([^-A-Za-z0-9_]|$)'; then
+if printf '%s\n' "$CMDS" | grep -qE "${GHPR}(close|reopen)([^-A-Za-z0-9_]|\$)"; then
   echo "$DECIDE Closing a PR rejects it; say why it should be closed instead." >&2
   exit 2
 fi
 
 # Outward-facing publication. This repository is public.
-if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+release[[:space:]]+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)'; then
+if printf '%s\n' "$CMDS" | grep -qE "${GHRELEASE}(create|delete|delete-asset)([^-A-Za-z0-9_]|\$)"; then
   echo "Blocked: publishing or deleting a GitHub release is Bertan's call. This repository is public; a release is visible the moment it exists." >&2
   exit 2
 fi
@@ -135,8 +154,23 @@ if [ -n "$API_WRITE" ]; then
     echo "$DECIDE Reaching the merge or review endpoint through gh api is the same decision by another name." >&2
     exit 2
   fi
-  if echo "$SCAN" | grep -qE 'mergePullRequest|addPullRequestReview'; then
-    echo "$DECIDE Reaching the merge or review mutation through graphql is the same decision by another name." >&2
+  # Closing and reopening were refused in the gh pr spelling and open through
+  # gh api, so the boundary was spelling-dependent where it claimed not to be.
+  # They are a write to the pull request itself rather than to a subpath, and
+  # the same PATCH is how `gh pr edit` retitles one, which stays allowed -- so
+  # the endpoint cannot decide this and the field has to. graphql spells the
+  # same change as a state on updatePullRequest.
+  if echo "$SCAN" | grep -qiE '(/pulls/|updatePullRequest)' \
+     && echo "$SCAN" | grep -qiE 'state[[:space:]]*[=:][[:space:]]*"?(closed|open)"?'; then
+    echo "$DECIDE Setting a pull request's state through gh api closes or reopens it, which is the same decision by another name." >&2
+    exit 2
+  fi
+  if echo "$SCAN" | grep -qE '/releases([^A-Za-z0-9_-]|$)'; then
+    echo "Blocked: publishing or deleting a GitHub release is Bertan's call, reached through gh api no less than through gh release. This repository is public; a release is visible the moment it exists." >&2
+    exit 2
+  fi
+  if echo "$SCAN" | grep -qE 'mergePullRequest|addPullRequestReview|closePullRequest|reopenPullRequest|createRelease|updateRelease|deleteRelease'; then
+    echo "$DECIDE Reaching the same decision through a graphql mutation is the same decision by another name." >&2
     exit 2
   fi
 fi

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Agents may open pull requests and talk on them; they may not decide them.
+# Accepting, rejecting, merging or reopening a PR is Bertan's call, and so is
+# publishing a release.
+#
+# CLAUDE.md: "merge into main by PR only, never commit to main." Opening the
+# pull request is the agent's half of that sentence; closing it is not.
+#
+# Still allowed: creating a PR, commenting on one, editing one, viewing,
+# listing, diffing and checking one, reviewing with --comment, and every
+# gh issue subcommand.
+#
+# Commands are matched only at a command position (start of line, or after ;
+# && || | or a paren), and heredoc bodies are dropped first, so a dev-log entry
+# or a commit message may name any of them in prose.
+#
+# The convenient spelling is only one way in. The same merge is one REST call
+# (PUT /repos/O/R/pulls/N/merge) or one graphql mutation away, and gh api is
+# allowlisted in settings.local.json, so those two shapes are matched too. URLs
+# have many spellings and this is not airtight -- it closes the ordinary paths.
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+
+# A heredoc body is data, not commands: a commit message or dev-log entry that
+# names these commands must not be refused by them.
+SCAN=$(echo "$COMMAND" | awk '
+  ind { if ($0 == d) ind = 0; next }
+  {
+    if (match($0, /<<-?[[:space:]]*[^[:space:];|&<>()]+/)) {
+      d = substr($0, RSTART, RLENGTH)
+      sub(/^<<-?[[:space:]]*/, "", d)
+      gsub(/[\047"]/, "", d)
+      ind = 1
+    }
+    print
+  }')
+
+DECIDE="Blocked: deciding a pull request is Bertan's call, not an agent's. Opening a PR, commenting on it and editing it are allowed; accepting, rejecting, merging and reopening are not."
+
+if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+pr\s+merge([^-A-Za-z0-9_]|$)'; then
+  echo "$DECIDE Leave the PR open and say it is ready to merge." >&2
+  exit 2
+fi
+
+# Only the verdict flags. Reviewing with --comment leaves remarks without a
+# verdict and stays allowed, so the subcommand alone is not enough to block on.
+if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+pr\s+review([^-A-Za-z0-9_]|$)' \
+   && echo "$SCAN" | grep -qE '\s(--approve|--request-changes|-a|-r)(\s|=|$)'; then
+  echo "$DECIDE Review with --comment to leave remarks without a verdict." >&2
+  exit 2
+fi
+
+# Rejecting a pull request by outcome rather than by verdict.
+if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+pr\s+(close|reopen)([^-A-Za-z0-9_]|$)'; then
+  echo "$DECIDE Closing a PR rejects it; say why it should be closed instead." >&2
+  exit 2
+fi
+
+# Outward-facing publication. This repository is public.
+if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+release\s+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)'; then
+  echo "Blocked: publishing or deleting a GitHub release is Bertan's call. This repository is public; a release is visible the moment it exists." >&2
+  exit 2
+fi
+
+# The REST endpoints behind the two blocked pull-request commands.
+if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+api([^-A-Za-z0-9_]|$)' \
+   && echo "$SCAN" | grep -qE '/pulls/[^ ]*/(merge|reviews)'; then
+  echo "$DECIDE Reaching the merge or review endpoint through gh api is the same decision by another name." >&2
+  exit 2
+fi
+
+# The same two decisions expressed as graphql mutations.
+if echo "$SCAN" | grep -qE '(^|[;&|(]\s*)gh\s+api\s+graphql([^-A-Za-z0-9_]|$)' \
+   && echo "$SCAN" | grep -qE 'mergePullRequest|addPullRequestReview'; then
+  echo "$DECIDE Reaching the merge or review mutation through graphql is the same decision by another name." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -14,61 +14,34 @@
 # (PUT /repos/O/R/pulls/N/merge) or one graphql mutation away, and gh api is
 # allowlisted in settings.local.json, so those two shapes are matched too. URLs
 # have many spellings and this is not airtight -- it closes the ordinary paths.
+#
+# Finding commands in the text is lib/command-scan.sh's job. Each line it
+# returns is one command with everything before the command word removed, so
+# every rule below anchors at ^ and none of them describes a command position.
+# That is where all of PR #35's defects lived, this file's included: it was the
+# sibling that had the wrapper rule, and this one that did not.
+. "$(dirname "$0")/lib/command-scan.sh"
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+SCAN=$(printf '%s\n' "$COMMAND" | cs_normalise)
 
-# A heredoc body is data, not commands: a commit message or dev-log entry that
-# names these commands must not be refused by them.
-SCAN=$(echo "$COMMAND" | awk '
-  ind { if ($0 == d) ind = 0; next }
-  {
-    if (match($0, /<<-?[[:space:]]*[^[:space:];|&<>()]+/)) {
-      d = substr($0, RSTART, RLENGTH)
-      sub(/^<<-?[[:space:]]*/, "", d)
-      gsub(/[\047"]/, "", d)
-      ind = 1
-    }
-    print
-  }')
-
-# A backslash-newline is a line continuation, not a command separator. Its
-# sibling scoped arguments by line and was defeated by one; these checks span
-# lines and were not, but the two files are kept in step deliberately -- the one
-# time they diverged, the wrapper rule existed in only one of them.
-SCAN=$(printf '%s\n' "$SCAN" | awk '
-  {
-    line = $0
-    while (line ~ /\\$/) {
-      sub(/\\$/, "", line)
-      if ((getline nxt) > 0) line = line nxt; else break
-    }
-    print line
-  }')
-
-# Dropping bodies is itself a bypass, and this file lacked the guard its sibling
-# had -- reported on PR #35, where `bash -c 'gh pr merge 35'` and a graphql
-# mutation sent through a heredoc both passed. Two shapes re-admit the raw
-# command: a shell wrapper, and gh api reading a heredoc, which is the ordinary
-# way a mutation is sent and so is a decision hiding in dropped text.
-DECIDE="Blocked: deciding a pull request is Bertan's call, not an agent's. Opening a PR, commenting on it and editing it are allowed; accepting, rejecting, merging and reopening are not."
-
-WRAPPED=
-if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
-  WRAPPED=1
-  SCAN="$SCAN
-$COMMAND"
-elif echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+api' \
-     && echo "$COMMAND" | grep -q '<<'; then
+# gh api reading a heredoc is a decision hiding in text that was just dropped --
+# a heredoc is the ordinary way to send a graphql mutation. The raw command is
+# re-admitted for that shape alone.
+if printf '%s\n' "$SCAN" | cs_split | grep -qE '^gh[[:space:]]+api([^-A-Za-z0-9_]|$)' \
+   && echo "$COMMAND" | grep -q '<<'; then
   SCAN="$SCAN
 $COMMAND"
 fi
+CMDS=$(printf '%s\n' "$SCAN" | cs_split)
 
-# Re-admitting the text is enough for a heredoc, whose payload sits at the start
-# of a line, and not for `sh -c "..."`, whose payload sits inside quotes where no
-# command position exists. Inside a wrapper the anchor is dropped entirely, for
-# every decision this file refuses. Narrow on purpose: the unanchored patterns
-# run only once a wrapper has already been found.
-if [ -n "$WRAPPED" ]; then
+DECIDE="Blocked: deciding a pull request is Bertan's call, not an agent's. Opening a PR, commenting on it and editing it are allowed; accepting, rejecting, merging and reopening are not."
+
+# A wrapper's payload sits inside quotes, where there is no command word for the
+# tokeniser to find, so these run unanchored over the raw text -- and only once
+# a wrapper has been found, never over an ordinary command.
+if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
   if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+(merge|close|reopen)([^-A-Za-z0-9_]|$)' \
      || echo "$COMMAND" | grep -qE 'gh[[:space:]]+release[[:space:]]+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)' \
      || echo "$COMMAND" | grep -qE '/pulls/[^ ]*/(merge|reviews)' \
@@ -83,49 +56,43 @@ if [ -n "$WRAPPED" ]; then
   fi
 fi
 
-# A command sits at a command position: the start of a line -- leading
-# whitespace included, because `gh pr merge` inside an if or a for loop is
-# written indented -- or after ; && || | or an opening paren. Requiring column
-# zero, as this file first did, missed every indented decision. The cost is a
-# quoted multi-line string whose continuation line begins with one of these
-# commands; that false positive is accepted, being visible and one edit away.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+merge([^-A-Za-z0-9_]|$)'; then
+if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+pr[[:space:]]+merge([^-A-Za-z0-9_]|$)'; then
   echo "$DECIDE Leave the PR open and say it is ready to merge." >&2
   exit 2
 fi
 
-# Only the verdict flags. Reviewing with --comment leaves remarks without a
-# verdict and stays allowed, so the subcommand alone is not enough to block on.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+review([^-A-Za-z0-9_]|$)' \
-   && echo "$SCAN" | grep -qE '[[:space:]](--approve|--request-changes|-a|-r)([[:space:]]|=|$)'; then
+# Only the verdict flags, and only in the same command as the subcommand.
+# Reviewing with --comment leaves remarks without a verdict and stays allowed.
+if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+pr[[:space:]]+review([[:space:]].*)?[[:space:]](--approve|--request-changes|-a|-r)([[:space:]]|=|$)'; then
   echo "$DECIDE Review with --comment to leave remarks without a verdict." >&2
   exit 2
 fi
 
 # Rejecting a pull request by outcome rather than by verdict.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+(close|reopen)([^-A-Za-z0-9_]|$)'; then
+if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+pr[[:space:]]+(close|reopen)([^-A-Za-z0-9_]|$)'; then
   echo "$DECIDE Closing a PR rejects it; say why it should be closed instead." >&2
   exit 2
 fi
 
 # Outward-facing publication. This repository is public.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+release[[:space:]]+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)'; then
+if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+release[[:space:]]+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)'; then
   echo "Blocked: publishing or deleting a GitHub release is Bertan's call. This repository is public; a release is visible the moment it exists." >&2
   exit 2
 fi
 
-# The REST endpoints behind the two blocked pull-request commands.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+api([^-A-Za-z0-9_]|$)' \
-   && echo "$SCAN" | grep -qE '/pulls/[^ ]*/(merge|reviews)'; then
-  echo "$DECIDE Reaching the merge or review endpoint through gh api is the same decision by another name." >&2
-  exit 2
-fi
-
-# The same two decisions expressed as graphql mutations.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+api([^-A-Za-z0-9_]|$)' \
-   && echo "$SCAN" | grep -qE 'mergePullRequest|addPullRequestReview'; then
-  echo "$DECIDE Reaching the merge or review mutation through graphql is the same decision by another name." >&2
-  exit 2
+# The REST endpoints and the graphql mutations behind those commands. The
+# command word and the payload can be separated by the tokeniser -- a mutation
+# body splits on its own braces and parens -- so gh api is looked for among the
+# commands and what it carries anywhere in the text.
+if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+api([^-A-Za-z0-9_]|$)'; then
+  if echo "$SCAN" | grep -qE '/pulls/[^ ]*/(merge|reviews)'; then
+    echo "$DECIDE Reaching the merge or review endpoint through gh api is the same decision by another name." >&2
+    exit 2
+  fi
+  if echo "$SCAN" | grep -qE 'mergePullRequest|addPullRequestReview'; then
+    echo "$DECIDE Reaching the merge or review mutation through graphql is the same decision by another name." >&2
+    exit 2
+  fi
 fi
 
 exit 0

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -39,11 +39,11 @@ SCAN=$(echo "$COMMAND" | awk '
 DECIDE="Blocked: deciding a pull request is Bertan's call, not an agent's. Opening a PR, commenting on it and editing it are allowed; accepting, rejecting, merging and reopening are not."
 
 WRAPPED=
-if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
+if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
   WRAPPED=1
   SCAN="$SCAN
 $COMMAND"
-elif echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+api' \
+elif echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+api' \
      && echo "$COMMAND" | grep -q '<<'; then
   SCAN="$SCAN
 $COMMAND"
@@ -75,40 +75,40 @@ fi
 # zero, as this file first did, missed every indented decision. The cost is a
 # quoted multi-line string whose continuation line begins with one of these
 # commands; that false positive is accepted, being visible and one edit away.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+merge([^-A-Za-z0-9_]|$)'; then
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+merge([^-A-Za-z0-9_]|$)'; then
   echo "$DECIDE Leave the PR open and say it is ready to merge." >&2
   exit 2
 fi
 
 # Only the verdict flags. Reviewing with --comment leaves remarks without a
 # verdict and stays allowed, so the subcommand alone is not enough to block on.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+review([^-A-Za-z0-9_]|$)' \
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+review([^-A-Za-z0-9_]|$)' \
    && echo "$SCAN" | grep -qE '[[:space:]](--approve|--request-changes|-a|-r)([[:space:]]|=|$)'; then
   echo "$DECIDE Review with --comment to leave remarks without a verdict." >&2
   exit 2
 fi
 
 # Rejecting a pull request by outcome rather than by verdict.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+(close|reopen)([^-A-Za-z0-9_]|$)'; then
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+(close|reopen)([^-A-Za-z0-9_]|$)'; then
   echo "$DECIDE Closing a PR rejects it; say why it should be closed instead." >&2
   exit 2
 fi
 
 # Outward-facing publication. This repository is public.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+release[[:space:]]+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)'; then
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+release[[:space:]]+(create|delete|delete-asset)([^-A-Za-z0-9_]|$)'; then
   echo "Blocked: publishing or deleting a GitHub release is Bertan's call. This repository is public; a release is visible the moment it exists." >&2
   exit 2
 fi
 
 # The REST endpoints behind the two blocked pull-request commands.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+api([^-A-Za-z0-9_]|$)' \
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+api([^-A-Za-z0-9_]|$)' \
    && echo "$SCAN" | grep -qE '/pulls/[^ ]*/(merge|reviews)'; then
   echo "$DECIDE Reaching the merge or review endpoint through gh api is the same decision by another name." >&2
   exit 2
 fi
 
 # The same two decisions expressed as graphql mutations.
-if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)gh[[:space:]]+api([^-A-Za-z0-9_]|$)' \
+if echo "$SCAN" | grep -qE '(^[[:space:]]*|[;&|(][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+api([^-A-Za-z0-9_]|$)' \
    && echo "$SCAN" | grep -qE 'mergePullRequest|addPullRequestReview'; then
   echo "$DECIDE Reaching the merge or review mutation through graphql is the same decision by another name." >&2
   exit 2

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -31,6 +31,20 @@ SCAN=$(echo "$COMMAND" | awk '
     print
   }')
 
+# A backslash-newline is a line continuation, not a command separator. Its
+# sibling scoped arguments by line and was defeated by one; these checks span
+# lines and were not, but the two files are kept in step deliberately -- the one
+# time they diverged, the wrapper rule existed in only one of them.
+SCAN=$(printf '%s\n' "$SCAN" | awk '
+  {
+    line = $0
+    while (line ~ /\\$/) {
+      sub(/\\$/, "", line)
+      if ((getline nxt) > 0) line = line nxt; else break
+    }
+    print line
+  }')
+
 # Dropping bodies is itself a bypass, and this file lacked the guard its sibling
 # had -- reported on PR #35, where `bash -c 'gh pr merge 35'` and a graphql
 # mutation sent through a heredoc both passed. Two shapes re-admit the raw

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -7,13 +7,22 @@
 # pull request is the agent's half of that sentence; closing it is not.
 #
 # Still allowed: creating a PR, commenting on one, editing one, viewing,
-# listing, diffing and checking one, reviewing with --comment, and every
-# gh issue subcommand.
+# listing, diffing and checking one, reviewing with --comment, every gh issue
+# subcommand, and reading a PR through gh api -- including the two endpoints
+# that decide one when they are written to. GET /pulls/N/reviews lists reviews
+# and GET /pulls/N/merge reports whether the PR is merged; refusing those by
+# endpoint refused a listing, not a decision, which the review on PR #35 caught.
+# The method is what separates them, so the method is what is tested.
 #
 # The convenient spelling is only one way in. The same merge is one REST call
 # (PUT /repos/O/R/pulls/N/merge) or one graphql mutation away, and gh api is
 # allowlisted in settings.local.json, so those two shapes are matched too. URLs
 # have many spellings and this is not airtight -- it closes the ordinary paths.
+#
+# The wrapper rule below is the exception to the method test, and stays blunt on
+# purpose: inside `bash -c '...'` the payload is quoted text, so neither the
+# method nor anything else can be read out of it. A read of a PR wrapped in a
+# shell is refused with the writes. Run it unwrapped.
 #
 # Finding commands in the text is lib/command-scan.sh's job. Each line it
 # returns is one command with everything before the command word removed, so
@@ -80,11 +89,48 @@ if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+release[[:space:]]+(create|d
   exit 2
 fi
 
+# Is this gh api call a write? Succeeds if it is, or if that cannot be told.
+#
+# gh sends GET unless told otherwise, and switches to POST the moment a field or
+# input flag appears, so a call carrying neither is a read. The test is the
+# method and not the endpoint because the endpoint does not distinguish them:
+# GET /pulls/N/reviews lists reviews and GET /pulls/N/merge reports whether the
+# PR is merged. Both are reading a pull request, which CLAUDE.md allows in the
+# same sentence that forbids deciding one.
+#
+# Any token beginning -f or -F counts, not just `-f x=y`: gh accepts the value
+# attached, and `-fevent=APPROVE` is the same request as `-f event=APPROVE`.
+# A method that cannot be parsed is treated as a write.
+gh_api_is_write() {
+  local CMD="$1" METHOD
+  METHOD=$(printf '%s' "$CMD" | sed -nE 's/.*(^|[[:space:]])(-X|--method)[[:space:]=]*([A-Za-z]+).*/\3/p')
+  if [ -n "$METHOD" ]; then
+    case "$METHOD" in
+      GET|get|Get|HEAD|head|Head) ;;
+      *) return 0 ;;
+    esac
+  elif printf '%s' "$CMD" | grep -qE '(^|[[:space:]])(-X|--method)([[:space:]]|=|$)'; then
+    return 0
+  fi
+  if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])(-[fF]|--field|--raw-field|--input)'; then
+    return 0
+  fi
+  return 1
+}
+
 # The REST endpoints and the graphql mutations behind those commands. The
 # command word and the payload can be separated by the tokeniser -- a mutation
 # body splits on its own braces and parens -- so gh api is looked for among the
 # commands and what it carries anywhere in the text.
-if printf '%s\n' "$CMDS" | grep -qE '^gh[[:space:]]+api([^-A-Za-z0-9_]|$)'; then
+API_WRITE=
+while IFS= read -r CMD; do
+  printf '%s\n' "$CMD" | grep -qE '^gh[[:space:]]+api([^-A-Za-z0-9_]|$)' || continue
+  if gh_api_is_write "$CMD"; then API_WRITE=1; break; fi
+done <<CMDLIST
+$CMDS
+CMDLIST
+
+if [ -n "$API_WRITE" ]; then
   if echo "$SCAN" | grep -qE '/pulls/[^ ]*/(merge|reviews)'; then
     echo "$DECIDE Reaching the merge or review endpoint through gh api is the same decision by another name." >&2
     exit 2

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -29,6 +29,16 @@
 # every rule below anchors at ^ and none of them describes a command position.
 # That is where all of PR #35's defects lived, this file's included: it was the
 # sibling that had the wrapper rule, and this one that did not.
+#
+# STOPPING RULE. A newly found evasion earns a fix only if it is a shape an
+# agent would plausibly write, not one it would have to construct. A flag
+# sitting in front of the subcommand, a bundled shorthand flag, a graphql
+# mutation in a heredoc: all shapes an agent writes without meaning to evade
+# anything, and all fixed here for that reason. A payload quoted inside eval or
+# a shell wrapper is not, which is why wrappers are refused outright rather than
+# parsed -- that is the designed answer, not a limitation to be closed later.
+# The endpoint list above is a list and will never be a principle; it stops
+# growing when the spellings stop being ones an agent would plausibly write.
 . "$(dirname "$0")/lib/command-scan.sh"
 
 INPUT=$(cat)

--- a/.claude/hooks/probe-hooks.sh
+++ b/.claude/hooks/probe-hooks.sh
@@ -11,10 +11,17 @@
 # indentation and wrapper probes come from the review on PR #35.
 #
 # The control-word, here-string, <<- , bare-push and gh api probes come from a
-# second review of the same branch, which found four ways past the boundary that
-# these probes did not ask about. That is worth saying plainly: the suite was
-# green while `if true; then git push --mirror origin; fi` was permitted. A
-# probe suite is evidence about the cases it names and about nothing else.
+# second review of the same branch, and the quoted-<<, bundled-flag,
+# flag-before-subcommand and gh api close/release probes from a third. Between
+# them those reviews found eight ways past the boundary that this suite did not
+# ask about, and it was green before each round. Worth saying plainly rather
+# than counting: the suite passed while `if true; then git push --mirror origin;
+# fi` was permitted, and passed again while a commit message mentioning `<<EOF`
+# blinded both hooks for the rest of the command.
+#
+# So the number below is not a measure of the boundary. A probe suite is
+# evidence about the cases it names and about nothing else, and every case here
+# was named by someone who went looking for one it had missed.
 #
 # One expectation is not a literal but a context: whether pushing this branch is
 # permitted depends on where the suite runs, because that is exactly what
@@ -105,6 +112,10 @@ tok 'dash-heredoc ends on a tab-indented terminator' \
     'cat <<-EOF
 gh pr merge 35' \
     "$(printf 'cat <<-EOF\n\thello\n\tEOF\ngh pr merge 35\n' | cs_normalise)"
+tok 'unterminated heredoc gives its lines back' \
+    'git commit -m "fix <<EOF handling"
+    git push --all origin' \
+    "$(printf 'git commit -m "fix <<EOF handling"\n    git push --all origin\n' | cs_normalise)"
 tok 'control word removed, then/fi' \
     'true
 git push --mirror origin' \
@@ -238,6 +249,71 @@ probe no-pr-decisions.sh BLOCK 'DELETE a review'         'gh api -X DELETE repos
 # A read wrapped in a shell is still refused: inside quotes the method cannot be
 # read any more than the endpoint can. Run it unwrapped.
 probe no-pr-decisions.sh BLOCK 'a GET inside bash -c'    "bash -c 'gh api repos/bgunyel/clause-and-effect/pulls/35/reviews'"
+
+echo "=== REGRESSION: review of 02a14d8, a heredoc that never was ==="
+# `<<` inside double quotes is text, not a redirection, and the opener was
+# matched anywhere on the line. The terminator it took never arrives, so every
+# following line was dropped and both hooks went blind for the rest of the
+# command -- reachable by writing a commit message about this very file. Third
+# wrong answer to what counts as a heredoc, so the drop is no longer trusted:
+# lines held for a heredoc that does not terminate are given back at END.
+probe no-git-push.sh     BLOCK 'commit msg naming <<EOF, then --all'    $'git commit -m "hooks: fix <<EOF handling in cs_normalise"\n    git push --all origin'
+probe no-pr-decisions.sh BLOCK 'pr comment naming <<, then a merge'     $'gh pr comment 35 -b "the << operator confused it"\n    gh pr merge 35'
+probe no-git-push.sh     BLOCK 'left shift << in a message, then --all' $'git commit -m "left shift << done"\n    git push --all origin'
+probe no-git-push.sh     BLOCK 'issue comment naming <<, then --mirror' $'gh issue comment 1 -b "see << notes"\n    git push --mirror origin'
+# A heredoc that does terminate is still data, so the older probes above still
+# ALLOW -- that is what says the fail-safe did not simply disable the drop.
+
+echo "=== REGRESSION: review of 02a14d8, bundled gh shorthand flags ==="
+# gh takes shorthand flags together, so -ab is --approve --body and approves.
+# no-git-push.sh had already answered this for -fu and this file had not: the
+# same asymmetry between the siblings, in a second place.
+probe no-pr-decisions.sh BLOCK 'gh pr review -ab "lgtm" 35'  'gh pr review -ab "lgtm" 35'
+probe no-pr-decisions.sh BLOCK 'gh pr review 35 -ab lgtm'    'gh pr review 35 -ab lgtm'
+probe no-pr-decisions.sh BLOCK 'gh pr review -rb "no" 35'    'gh pr review -rb "no" 35'
+probe no-pr-decisions.sh BLOCK 'verdict letter last, -ba'    'gh pr review -ba "lgtm" 35'
+# A bundle carrying no verdict letter is still a comment, and a long flag must
+# not match on a letter it happens to contain -- --repo is not --request-changes.
+probe no-pr-decisions.sh ALLOW 'gh pr review -cb "a remark"' 'gh pr review -cb "a remark" 35'
+probe no-pr-decisions.sh ALLOW 'review --comment with --repo' 'gh pr review --comment --repo o/r -b x 35'
+
+echo "=== REGRESSION: review of 02a14d8, a flag before the subcommand ==="
+# Cobra resolves the subcommand at the first non-flag argument, so a flag may
+# sit in front of it and every rule here wanted it as the third word. -R/--repo
+# takes its value as a separate token, which would otherwise be read as the
+# subcommand and hide it just as effectively.
+probe no-pr-decisions.sh BLOCK 'gh pr --repo o/r merge 35'      'gh pr --repo o/r merge 35'
+probe no-pr-decisions.sh BLOCK 'gh pr -R o/r close 35'          'gh pr -R o/r close 35'
+probe no-pr-decisions.sh BLOCK 'gh pr --repo=o/r reopen 35'     'gh pr --repo=o/r reopen 35'
+probe no-pr-decisions.sh BLOCK 'gh pr --repo o/r review -a 35'  'gh pr --repo o/r review -a 35'
+probe no-pr-decisions.sh BLOCK 'gh release --repo o/r create v1' 'gh release --repo o/r create v1'
+# An ordinary subcommand behind a flag is still ordinary.
+probe no-pr-decisions.sh ALLOW 'gh pr --repo o/r view 35'       'gh pr --repo o/r view 35'
+probe no-pr-decisions.sh ALLOW 'gh pr --repo o/r list'          'gh pr --repo o/r list'
+
+echo "=== REGRESSION: review of 02a14d8, close and release through gh api ==="
+# Closing a PR and publishing a release were refused in the gh spelling and open
+# through gh api, so the boundary was spelling-dependent exactly where the file
+# says it is not. PATCH /pulls/N is also how gh pr edit retitles, which stays
+# allowed, so the field decides this one rather than the endpoint.
+probe no-pr-decisions.sh BLOCK 'PATCH a PR to state=closed'  'gh api -X PATCH repos/o/r/pulls/35 -f state=closed'
+probe no-pr-decisions.sh BLOCK 'PATCH a PR to state=open'    'gh api -X PATCH repos/o/r/pulls/35 -f state=open'
+probe no-pr-decisions.sh BLOCK 'POST a release'              'gh api -X POST repos/o/r/releases -f tag_name=v1'
+probe no-pr-decisions.sh BLOCK 'DELETE a release'            'gh api -X DELETE repos/o/r/releases/123'
+probe no-pr-decisions.sh BLOCK 'graphql closePullRequest'    'gh api graphql -f query="mutation{closePullRequest(input:{x:1})}"'
+probe no-pr-decisions.sh BLOCK 'graphql createRelease'       'gh api graphql -f query="mutation{createRelease(input:{x:1})}"'
+probe no-pr-decisions.sh BLOCK 'graphql state on updatePR'   'gh api graphql -f query="mutation{updatePullRequest(input:{state:CLOSED})}"'
+# Retitling through that same endpoint is editing, and listing releases is
+# reading. Both stay allowed, which is what makes the field test worth having.
+probe no-pr-decisions.sh ALLOW 'PATCH a PR title'            'gh api -X PATCH repos/o/r/pulls/35 -f title=newtitle'
+probe no-pr-decisions.sh ALLOW 'GET the releases list'       'gh api repos/o/r/releases'
+probe no-pr-decisions.sh ALLOW 'gh pr edit retitles'         'gh pr edit 35 --title newtitle'
+
+echo "=== the push argument split does not glob against the worktree ==="
+# `for TOK in $ARGS` is unquoted because the split is the point; set -f stops
+# the same line expanding ? and [...] against the files sitting next to it.
+probe no-git-push.sh BLOCK 'a ? wildcard refspec'     'git push origin ?'
+probe no-git-push.sh BLOCK 'a [...] wildcard refspec' 'git push origin [a-z]*'
 
 echo "=== worktree exception: pushing this worktree's own branch ==="
 # Every permitted push names the branch. That is the whole exception: a push

--- a/.claude/hooks/probe-hooks.sh
+++ b/.claude/hooks/probe-hooks.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Regression probes for no-git-push.sh and no-pr-decisions.sh.
+#
+# A hook is a process, so the only way to test one is to run it; what the rule
+# against calling the function under test forbids is deriving the expectation
+# from it, and every verdict below is written as a literal BLOCK or ALLOW.
+#
+# The four heredoc probes exist because an earlier version of these hooks
+# blocked the commit that introduced them: grep anchors ^ per line, so a wrapped
+# line of a commit message naming one of the refused commands read as a command
+# position. The four multi-line probes guard the other direction, that dropping
+# heredoc bodies did not also drop real commands.
+#
+# Run: bash .claude/hooks/probe-hooks.sh
+cd "$(dirname "$0")" || exit 1
+
+FAILED=0
+probe() {
+  local script="$1" want="$2" label="$3" cmd="$4" got rc
+  printf '%s' "$cmd" | jq -Rs '{tool_name:"Bash",tool_input:{command:.}}' | ./"$script" >/dev/null 2>&1
+  rc=$?
+  if [ $rc -eq 2 ]; then got=BLOCK; else got=ALLOW; fi
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %-5s %s\n' "$got" "$label"
+  else
+    printf '  FAIL want=%s got=%s  %s\n' "$want" "$got" "$label"
+    FAILED=1
+  fi
+}
+
+echo "=== REGRESSION: heredoc prose that blocked its own commit ==="
+COMMIT_MSG=$'git commit -q -F - <<\'EOF\'\nLeave pushing and deciding a PR to Bertan\n\nno-git-push.sh refuses every push; no-pr-decisions.sh refuses\ngh pr review --approve and --request-changes, gh pr close and reopen.\ngit push is refused in every form.\ngh pr merge 5 would also be refused.\nEOF'
+probe no-git-push.sh     ALLOW 'commit msg naming git push in heredoc' "$COMMIT_MSG"
+probe no-pr-decisions.sh ALLOW 'commit msg naming gh pr verbs in heredoc' "$COMMIT_MSG"
+NOTE=$'cat > /tmp/note.md <<\'MD\'\ngh pr merge is now refused by a hook.\ngit push likewise.\nMD'
+probe no-git-push.sh     ALLOW 'heredoc body naming git push' "$NOTE"
+probe no-pr-decisions.sh ALLOW 'heredoc body naming gh pr merge' "$NOTE"
+
+echo "=== REGRESSION: real commands still caught in multi-line input ==="
+probe no-git-push.sh     BLOCK 'multi-line, push on line 2'   $'cd /tmp\ngit push origin dev-05'
+probe no-pr-decisions.sh BLOCK 'multi-line, merge on line 2'  $'cd /tmp\ngh pr merge 5'
+probe no-git-push.sh     BLOCK 'heredoc fed to a shell'       $'bash <<\'EOF\'\ngit push\nEOF'
+probe no-git-push.sh     BLOCK 'real push after heredoc ends' $'cat > /tmp/f <<\'EOF\'\nhello\nEOF\ngit push'
+
+echo "=== no-git-push.sh : must BLOCK ==="
+for c in 'git push' \
+         'git push origin dev-05' \
+         'git push -f origin dev-05' \
+         'git push --force-with-lease' \
+         'git push origin HEAD:main' \
+         'git -C /home/bgunyel/source/ai/clause-and-effect push' \
+         'git -c user.name=x push origin HEAD' \
+         'git commit -m msg && git push' \
+         'cd /tmp; git push' \
+         'make test || git push' \
+         '(git push)' \
+         'bash -c "git push origin dev-05"' \
+         'sh -c "git push"' \
+         'eval "git push"' \
+         'git push;'
+do probe no-git-push.sh BLOCK "$c" "$c"; done
+
+echo "=== no-git-push.sh : must ALLOW ==="
+for c in 'git status' \
+         'git commit -m "explain how to git push later"' \
+         'echo "run git push when ready" >> notes.md' \
+         'git log --oneline' \
+         'git fetch origin' \
+         'gh pr create --fill' \
+         'grep -rn "git push" src/' \
+         'git pull --rebase' \
+         'make test'
+do probe no-git-push.sh ALLOW "$c" "$c"; done
+
+echo "=== no-pr-decisions.sh : must BLOCK ==="
+for c in 'gh pr merge 5' \
+         'gh pr merge --auto --squash 5' \
+         'cd /tmp && gh pr merge 5' \
+         '(gh pr merge 5)' \
+         'gh pr review --approve 5' \
+         'gh pr review -a 5' \
+         'gh pr review --request-changes -b "no"' \
+         'gh pr close 5' \
+         'gh pr reopen 5' \
+         'gh release create v1.0.0' \
+         'gh release delete v1.0.0' \
+         'gh api -X PUT repos/bgunyel/clause-and-effect/pulls/5/merge' \
+         'gh api --method POST /repos/bgunyel/clause-and-effect/pulls/5/reviews -f event=APPROVE' \
+         'gh api https://api.github.com/repos/bgunyel/clause-and-effect/pulls/5/merge -X PUT' \
+         'gh api graphql -f query="mutation { mergePullRequest(input:{x:1}) }"' \
+         'gh api graphql -f query="mutation { addPullRequestReview(input:{event:APPROVE}) }"'
+do probe no-pr-decisions.sh BLOCK "$c" "$c"; done
+
+echo "=== no-pr-decisions.sh : must ALLOW ==="
+for c in 'gh pr create --title x --body y' \
+         'gh pr comment 5 --body "looks fine"' \
+         'gh pr review --comment -b "a remark"' \
+         'gh pr view 5' \
+         'gh pr list' \
+         'gh pr diff 5' \
+         'gh pr checks 5' \
+         'gh pr edit 5 --add-label bug' \
+         'gh pr ready 5' \
+         'gh issue close 27' \
+         'gh issue comment 27 --body x' \
+         'gh release list' \
+         'gh api repos/bgunyel/clause-and-effect/pulls/5' \
+         'gh api repos/bgunyel/clause-and-effect/issues/27/comments' \
+         'echo "then run gh pr merge 5 to land it" >> notes.md' \
+         'git push'
+do probe no-pr-decisions.sh ALLOW "$c" "$c"; done
+
+echo
+if [ $FAILED -eq 0 ]; then echo "ALL PROBES PASSED"; else echo "SOME PROBES FAILED"; fi
+exit $FAILED

--- a/.claude/hooks/probe-hooks.sh
+++ b/.claude/hooks/probe-hooks.sh
@@ -10,6 +10,12 @@
 # commit message naming a refused command read as a command position. The
 # indentation and wrapper probes come from the review on PR #35.
 #
+# The control-word, here-string, <<- , bare-push and gh api probes come from a
+# second review of the same branch, which found four ways past the boundary that
+# these probes did not ask about. That is worth saying plainly: the suite was
+# green while `if true; then git push --mirror origin; fi` was permitted. A
+# probe suite is evidence about the cases it names and about nothing else.
+#
 # One expectation is not a literal but a context: whether pushing this branch is
 # permitted depends on where the suite runs, because that is exactly what
 # no-git-push.sh decides. Run from a linked worktree on a feature branch, a push
@@ -91,6 +97,21 @@ tok 'heredoc body dropped' \
     'cat > f <<EOF
 echo after' \
     "$(printf 'cat > f <<EOF\ngit push origin main\nEOF\necho after\n' | cs_normalise)"
+tok 'here-string is not a heredoc' \
+    'cat <<< "hello"
+gh pr merge 35' \
+    "$(printf 'cat <<< "hello"\ngh pr merge 35\n' | cs_normalise)"
+tok 'dash-heredoc ends on a tab-indented terminator' \
+    'cat <<-EOF
+gh pr merge 35' \
+    "$(printf 'cat <<-EOF\n\thello\n\tEOF\ngh pr merge 35\n' | cs_normalise)"
+tok 'control word removed, then/fi' \
+    'true
+git push --mirror origin' \
+    "$(printf 'if true; then git push --mirror origin; fi\n' | cs_split)"
+tok 'control word removed, brace group' \
+    'git push --mirror origin' \
+    "$(printf '{ git push --mirror origin; }\n' | cs_split)"
 tok 'git args, plain' 'origin main' "$(printf 'git push origin main\n' | cs_git_args push)"
 tok 'git args, global option with a separate value' \
     '--all' "$(printf 'git -C /x push --all\n' | cs_git_args push)"
@@ -156,17 +177,102 @@ echo "=== ACCEPTED false positive: quoted multi-line string, not a heredoc ==="
 # knowingly, not a bug fix.
 probe no-git-push.sh     BLOCK 'multi-line -b string continuing with a push' $'gh issue comment 27 -b "to release:\n  git push origin main"'
 probe no-pr-decisions.sh BLOCK 'multi-line -b string continuing with a merge' $'gh issue comment 27 -b "to land it:\n  gh pr merge 35"'
+# And the price of removing control words: a quoted string holding a separator
+# and then one of them reads as a command. Same trade, same reason.
+probe no-git-push.sh     BLOCK 'quoted "; then" before a push'  'git commit -m "wait; then git push --all origin"'
+probe no-pr-decisions.sh BLOCK 'quoted "; then" before a merge' 'git commit -m "wait; then gh pr merge 35"'
+
+echo "=== REGRESSION: PR #35 review, a command after a control word ==="
+# A separator is not the only thing a command can follow. Splitting on ; left
+# `then` in front of the command word, so the anchor never saw the command at
+# all, and `do`, `else`, `elif`, `{` and `!` did the same. Every probe here was
+# ALLOW before the control words were removed in cs_split.
+probe no-git-push.sh     BLOCK 'then + push --mirror'     'if true; then git push --mirror origin; fi'
+probe no-git-push.sh     BLOCK 'do + push --all'          'while true; do git push --all origin; done'
+probe no-git-push.sh     BLOCK 'brace group + push'       '{ git push --mirror origin; }'
+probe no-git-push.sh     BLOCK 'then + push to dev-05'    'if true; then git push origin dev-05; fi'
+probe no-pr-decisions.sh BLOCK 'then + gh pr merge'       'if true; then gh pr merge 35; fi'
+probe no-pr-decisions.sh BLOCK 'do + gh pr merge'         'for x in a; do gh pr merge 35; done'
+probe no-pr-decisions.sh BLOCK 'until/do + gh pr merge'   'until false; do gh pr merge 35; done'
+probe no-pr-decisions.sh BLOCK 'else + gh pr merge'       'if true; then :; else gh pr merge 35; fi'
+probe no-pr-decisions.sh BLOCK 'elif + gh pr merge'       'if true; then :; elif true; then gh pr merge 35; fi'
+probe no-pr-decisions.sh BLOCK '! negation + gh pr merge' '! gh pr merge 35'
+probe no-pr-decisions.sh BLOCK 'brace group + gh pr close' '{ gh pr close 35; }'
+# The words are removed at the start of a command only, so an ordinary sentence
+# that happens to contain one is untouched.
+probe no-pr-decisions.sh ALLOW 'a control word mid-sentence' 'echo "then run gh pr merge 35" >> notes.md'
+
+echo "=== REGRESSION: PR #35 review, heredoc detection dropped live commands ==="
+# Dropping a heredoc body is the one step that hides commands, so both ends of
+# it have to be exact. `<<<` is a here-string and was read as a heredoc whose
+# terminator never arrives; `<<-` ends on a tab-indented terminator that an
+# exact comparison never matched. Either one discarded every following line, so
+# the hook saw an empty command and returned 0.
+probe no-pr-decisions.sh BLOCK 'here-string then a merge'  $'cat <<< "hello"\ngh pr merge 35'
+probe no-git-push.sh     BLOCK 'here-string then a push'   $'cat <<< "hello"\ngit push --mirror origin'
+probe no-pr-decisions.sh BLOCK '<<- tab terminator, then a merge' $'cat <<-EOF\n\thello\n\tEOF\ngh pr merge 35'
+probe no-git-push.sh     BLOCK '<<- tab terminator, then a push'  $'cat <<-EOF\n\thello\n\tEOF\ngit push --mirror origin'
+# The body of a real heredoc is still data, tab-indented or not.
+probe no-pr-decisions.sh ALLOW '<<- body naming a merge'   $'cat <<-EOF\n\tgh pr merge 35 would be refused\n\tEOF\necho done'
+probe no-git-push.sh     ALLOW '<<- body naming a push'    $'cat <<-EOF\n\tgit push --all origin is refused\n\tEOF\necho done'
+
+echo "=== REGRESSION: PR #35 review, reading a PR through gh api ==="
+# The endpoint does not say whether a call decides anything. GET /pulls/N/reviews
+# lists reviews and GET /pulls/N/merge reports whether the PR is merged; both are
+# reading a pull request, which CLAUDE.md allows in the sentence that forbids
+# deciding one, and both were refused. The method separates them, so the method
+# is what is tested -- gh sends GET unless a --method or a field flag says
+# otherwise.
+probe no-pr-decisions.sh ALLOW 'GET the reviews list'    'gh api repos/bgunyel/clause-and-effect/pulls/35/reviews'
+probe no-pr-decisions.sh ALLOW 'GET the merge state'     'gh api repos/bgunyel/clause-and-effect/pulls/35/merge'
+probe no-pr-decisions.sh ALLOW 'GET named explicitly'    'gh api -X GET repos/bgunyel/clause-and-effect/pulls/35/reviews'
+probe no-pr-decisions.sh ALLOW 'GET with --paginate'     'gh api --paginate repos/bgunyel/clause-and-effect/pulls/35/reviews'
+probe no-pr-decisions.sh ALLOW 'GET with --jq'           'gh api repos/bgunyel/clause-and-effect/pulls/35/reviews --jq ".[].state"'
+# The writes to those same endpoints are refused exactly as before.
+probe no-pr-decisions.sh BLOCK 'POST a review verdict'   'gh api repos/bgunyel/clause-and-effect/pulls/35/reviews -f event=APPROVE'
+probe no-pr-decisions.sh BLOCK 'value attached to -f'    'gh api repos/bgunyel/clause-and-effect/pulls/35/reviews -fevent=APPROVE'
+probe no-pr-decisions.sh BLOCK 'method attached to -X'   'gh api -XPUT repos/bgunyel/clause-and-effect/pulls/35/merge'
+probe no-pr-decisions.sh BLOCK '--method=PUT'            'gh api --method=PUT repos/bgunyel/clause-and-effect/pulls/35/merge'
+probe no-pr-decisions.sh BLOCK 'a review body by --input' 'gh api repos/bgunyel/clause-and-effect/pulls/35/reviews --input body.json'
+probe no-pr-decisions.sh BLOCK 'DELETE a review'         'gh api -X DELETE repos/bgunyel/clause-and-effect/pulls/35/reviews'
+# A read wrapped in a shell is still refused: inside quotes the method cannot be
+# read any more than the endpoint can. Run it unwrapped.
+probe no-pr-decisions.sh BLOCK 'a GET inside bash -c'    "bash -c 'gh api repos/bgunyel/clause-and-effect/pulls/35/reviews'"
 
 echo "=== worktree exception: pushing this worktree's own branch ==="
-probe no-git-push.sh "$OWN_BRANCH_PUSH" 'bare git push'                    'git push'
-probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push after a commit'          'git commit -m msg && git push'
-probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push in a subshell'           '(git push)'
-probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push with a trailing ;'       'git push;'
+# Every permitted push names the branch. That is the whole exception: a push
+# that does not name it is answered by configuration instead, and configuration
+# is not a thing this hook can hold still. See the bare-push section below.
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'push naming this branch'          "git push origin $CURRENT"
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'push after a commit'              "git commit -m msg && git push origin $CURRENT"
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'push in a subshell'               "(git push origin $CURRENT)"
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'push with a trailing ;'           "git push origin $CURRENT;"
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push -u origin <this branch>' "git push -u origin $CURRENT"
-probe no-git-push.sh "$OWN_BRANCH_PUSH" 'indented push, own branch'        $'if true; then\n    git push\nfi'
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'indented push, own branch'        $'if true; then\n    git push origin '"$CURRENT"$'\nfi'
 # An unrelated -f elsewhere on the line is not the push's own flag. Every option
 # check reads the push's arguments, not the whole command, so this still passes.
-probe no-git-push.sh "$OWN_BRANCH_PUSH" 'rm -f before an ordinary push'    'rm -f notes.md && git push'
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'rm -f before an ordinary push'    "rm -f notes.md && git push origin $CURRENT"
+
+echo "=== REGRESSION: PR #35 review, a bare push is answered by configuration ==="
+# A push naming no refspec is sent where push.default, a remote.<name>.push
+# refspec, or the branch's upstream says -- and -c sets any of those for one
+# command, past whatever this hook reads back afterwards. The old check read
+# push.default alone, so `git -c push.default=matching push` was ALLOW: it would
+# have carried every branch whose name exists on both sides, dev-05 included.
+#
+# The trade, taken knowingly: `git push` and `git push origin` were permitted
+# and are refused now. The destination has to be in the command, which is what
+# CLAUDE.md already asked for -- a push "positively naming that branch".
+probe no-git-push.sh BLOCK 'bare git push'                     'git push'
+probe no-git-push.sh BLOCK 'push naming only the remote'       'git push origin'
+probe no-git-push.sh BLOCK 'bare push after a commit'          'git commit -m msg && git push'
+probe no-git-push.sh BLOCK 'bare push in a subshell'           '(git push)'
+probe no-git-push.sh BLOCK 'push.default set for this command' 'git -c push.default=matching push'
+probe no-git-push.sh BLOCK 'push.default=upstream for one'     'git -c push.default=upstream push origin'
+probe no-git-push.sh BLOCK 'config set by --config-env'        'git --config-env=push.default=PD push'
+# -c is refused even alongside a refspec that does name this branch: the hook
+# cannot know which setting the override was for.
+probe no-git-push.sh BLOCK '-c with an explicit refspec'       "git -c http.sslVerify=false push origin $CURRENT"
 
 echo "=== forced pushes, refused in every spelling ==="
 # Forcing rewrites what the remote already has, which for this branch is the
@@ -220,7 +326,6 @@ probe no-git-push.sh     BLOCK 'pushd before a push'  'pushd /some/repo && git p
 probe no-pr-decisions.sh BLOCK 'env prefix before gh' 'FOO=1 gh pr merge 35'
 
 echo "=== the allowlist still admits an ordinary push of this branch ==="
-probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push origin'                "git push origin"
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push origin HEAD'           "git push origin HEAD"
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push origin HEAD:<branch>'  "git push origin HEAD:$CURRENT"
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push origin <b>:<b>'        "git push origin $CURRENT:$CURRENT"
@@ -237,9 +342,11 @@ probe no-git-push.sh BLOCK 'continued --all'     $'git push \\\n  --all origin'
 probe no-git-push.sh BLOCK 'continued force'     $'git push \\\n  --force-with-lease origin main'
 probe no-git-push.sh BLOCK 'continued origin main' $'git push \\\n  origin main'
 probe no-git-push.sh BLOCK 'continuation over three lines' $'git push \\\n  --all \\\n  origin'
-# A trailing backslash with nothing after it is not a continuation of anything:
-# the command is a bare push of this branch, and that is permitted.
-probe no-git-push.sh "$OWN_BRANCH_PUSH" 'trailing backslash, nothing after' $'git push \\'
+# A trailing backslash with nothing after it is not a continuation of anything.
+# The command is a bare push, which used to be the permitted shape and is now
+# refused for naming no destination -- the join still has to consume the
+# backslash, or this would be refused for being unreadable instead.
+probe no-git-push.sh BLOCK 'trailing backslash, nothing after' $'git push \\'
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'continued push of this branch'     $'git push \\\n  origin '"$CURRENT"
 
 echo "=== the remote must be a remote of this repository ==="

--- a/.claude/hooks/probe-hooks.sh
+++ b/.claude/hooks/probe-hooks.sh
@@ -150,6 +150,29 @@ probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push origin HEAD:<branch>'  "git pu
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push origin <b>:<b>'        "git push origin $CURRENT:$CURRENT"
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'push option with a value'       "git push -o ci.skip origin $CURRENT"
 
+echo "=== REGRESSION: PR #35, a line continuation emptied the argument scope ==="
+# The scope ran from push to the next shell separator; a newline ended it, and
+# an empty scope fell through to the bare-push case, the permitted one. So one
+# wrapped line turned any push into an ordinary one -- --mirror included, which
+# deletes remote branches and closes open PRs. Continuations are now joined
+# before anything is matched.
+probe no-git-push.sh BLOCK 'continued --mirror'  $'git push \\\n  --mirror origin'
+probe no-git-push.sh BLOCK 'continued --all'     $'git push \\\n  --all origin'
+probe no-git-push.sh BLOCK 'continued force'     $'git push \\\n  --force-with-lease origin main'
+probe no-git-push.sh BLOCK 'continued origin main' $'git push \\\n  origin main'
+probe no-git-push.sh BLOCK 'continuation over three lines' $'git push \\\n  --all \\\n  origin'
+# A trailing backslash with nothing after it is not a continuation of anything:
+# the command is a bare push of this branch, and that is permitted.
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'trailing backslash, nothing after' $'git push \\'
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'continued push of this branch'     $'git push \\\n  origin '"$CURRENT"
+
+echo "=== the remote must be a remote of this repository ==="
+# Nothing required the first bare token to be a remote, so a URL or a typo was
+# admitted whenever the refspec named this branch. Raised on PR #35.
+probe no-git-push.sh BLOCK 'a foreign remote URL'    'git push git@github.com:someone/else.git HEAD'
+probe no-git-push.sh BLOCK 'an undefined remote name' 'git push upstream HEAD'
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'origin is a real remote' "git push origin $CURRENT"
+
 echo "=== no-git-push.sh : not a push at all ==="
 for c in 'git status' \
          'git commit -m "explain how to git push later"' \

--- a/.claude/hooks/probe-hooks.sh
+++ b/.claude/hooks/probe-hooks.sh
@@ -49,6 +49,82 @@ probe() {
   fi
 }
 
+. ./lib/command-scan.sh
+
+tok() {  # tok <label> <expected> <actual>
+  if [ "$3" = "$2" ]; then
+    printf '  ok   %s\n' "$1"
+  else
+    printf '  FAIL %s\n         want |%s|\n         got  |%s|\n' "$1" "$2" "$3"
+    FAILED=1
+  fi
+}
+
+echo "=== the tokeniser itself ==="
+# Every defect on PR #35 was one question -- how far around a matched token to
+# look -- answered differently in a different place. It is answered once in
+# lib/command-scan.sh, so these aim at it rather than through a hook.
+tok 'split on ; && || |' \
+    'a
+b
+c
+d' \
+    "$(printf 'a && b; c | d\n' | cs_split)"
+tok 'split on a subshell paren' \
+    'a
+b' \
+    "$(printf 'a && (b)\n' | cs_split)"
+tok 'split on backticks, the twin of $( )' \
+    'echo
+git push --mirror origin' \
+    "$(printf 'echo `git push --mirror origin`\n' | cs_split)"
+tok 'environment assignments removed' \
+    'git push' \
+    "$(printf 'GIT_DIR=/x FOO=1 git push\n' | cs_split)"
+tok 'wrapper word and its options removed' \
+    'git push --mirror' \
+    "$(printf 'xargs -n1 git push --mirror\n' | cs_split)"
+tok 'continuation joined before anything else' \
+    'git push   --all origin' \
+    "$(printf 'git push \\\n  --all origin\n' | cs_normalise)"
+tok 'heredoc body dropped' \
+    'cat > f <<EOF
+echo after' \
+    "$(printf 'cat > f <<EOF\ngit push origin main\nEOF\necho after\n' | cs_normalise)"
+tok 'git args, plain' 'origin main' "$(printf 'git push origin main\n' | cs_git_args push)"
+tok 'git args, global option with a separate value' \
+    '--all' "$(printf 'git -C /x push --all\n' | cs_git_args push)"
+tok 'git args, empty for a bare push' '' "$(printf 'git push\n' | cs_git_args push)"
+if printf 'git push\n' | cs_git_args push >/dev/null; then
+  tok 'bare push succeeds, so empty args mean a push' 'found' 'found'
+else
+  tok 'bare push succeeds, so empty args mean a push' 'found' 'not found'
+fi
+if printf 'git status\n' | cs_git_args push >/dev/null; then
+  tok 'git status is not a push' 'not found' 'found'
+else
+  tok 'git status is not a push' 'not found' 'not found'
+fi
+
+echo "=== REGRESSION: PR #35, only the first push on a line was validated ==="
+# The scope found the first push, validated its arguments, and stopped. So a
+# legitimate push carried an illegitimate one after ; or && on its coat-tails.
+probe no-git-push.sh BLOCK 'legit push ; push origin main'  "git push origin $CURRENT; git push origin main"
+probe no-git-push.sh BLOCK 'legit push && push --all'       "git push origin $CURRENT && git push --all origin"
+probe no-git-push.sh BLOCK 'bare push && forced push'       "git push && git push --force origin $CURRENT"
+probe no-git-push.sh BLOCK 'three pushes, last one bad'     "git push; git push origin $CURRENT; git push --mirror origin"
+probe no-pr-decisions.sh BLOCK 'gh pr view ; gh pr merge'   'gh pr view 5; gh pr merge 5'
+
+echo "=== REGRESSION: PR #35, backticks and command prefixes ==="
+# $( ) was closed by the paren in the separator class and its twin was not --
+# the same asymmetry GIT_DIR= had against --git-dir. Both hooks were open.
+probe no-git-push.sh     BLOCK 'backticked push'      'echo `git push --mirror origin`'
+probe no-git-push.sh     BLOCK 'dollar-paren push'    'echo $(git push --mirror origin)'
+probe no-pr-decisions.sh BLOCK 'backticked merge'     'echo `gh pr merge 35`'
+probe no-pr-decisions.sh BLOCK 'dollar-paren merge'   'echo $(gh pr merge 35)'
+probe no-git-push.sh     BLOCK 'push through xargs'   'echo origin | xargs git push --mirror'
+probe no-pr-decisions.sh BLOCK 'merge through xargs'  'echo 35 | xargs gh pr merge'
+
 echo "=== REGRESSION: heredoc prose that blocked its own commit ==="
 COMMIT_MSG=$'git commit -q -F - <<\'EOF\'\nLeave pushing and deciding a PR to Bertan\n\nno-git-push.sh refuses every push; no-pr-decisions.sh refuses\ngh pr review --approve and --request-changes, gh pr close and reopen.\ngit push origin main is refused in every form.\ngh pr merge 5 would also be refused.\nEOF'
 probe no-git-push.sh     ALLOW 'commit msg naming git push in heredoc' "$COMMIT_MSG"

--- a/.claude/hooks/probe-hooks.sh
+++ b/.claude/hooks/probe-hooks.sh
@@ -5,14 +5,35 @@
 # against calling the function under test forbids is deriving the expectation
 # from it, and every verdict below is written as a literal BLOCK or ALLOW.
 #
-# The four heredoc probes exist because an earlier version of these hooks
-# blocked the commit that introduced them: grep anchors ^ per line, so a wrapped
-# line of a commit message naming one of the refused commands read as a command
-# position. The four multi-line probes guard the other direction, that dropping
-# heredoc bodies did not also drop real commands.
+# The heredoc probes exist because an earlier version of these hooks blocked the
+# commit that introduced them: grep anchors ^ per line, so a wrapped line of a
+# commit message naming a refused command read as a command position. The
+# indentation and wrapper probes come from the review on PR #35.
+#
+# One expectation is not a literal but a context: whether pushing this branch is
+# permitted depends on where the suite runs, because that is exactly what
+# no-git-push.sh decides. Run from a linked worktree on a feature branch, a push
+# of that branch is ALLOW; run from the main checkout, the identical command is
+# BLOCK. OWN_BRANCH_PUSH holds whichever applies, and the banner says which.
 #
 # Run: bash .claude/hooks/probe-hooks.sh
 cd "$(dirname "$0")" || exit 1
+
+CURRENT=$(git branch --show-current 2>/dev/null)
+GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null)
+GIT_COMMON_PATH=$(git rev-parse --git-common-dir 2>/dev/null)
+
+if [ -n "$GIT_DIR_PATH" ] && [ "$GIT_DIR_PATH" != "$GIT_COMMON_PATH" ] \
+   && [ -n "$CURRENT" ] && [ "$CURRENT" != "main" ] \
+   && ! echo "$CURRENT" | grep -qE '^dev-[0-9]+$'; then
+  OWN_BRANCH_PUSH=ALLOW
+  CONTEXT="linked worktree on $CURRENT -- a push of this branch is permitted"
+else
+  OWN_BRANCH_PUSH=BLOCK
+  CONTEXT="main checkout or a reserved branch (${CURRENT:-none}) -- every push is refused"
+fi
+echo "context: $CONTEXT"
+echo
 
 FAILED=0
 probe() {
@@ -29,33 +50,23 @@ probe() {
 }
 
 echo "=== REGRESSION: heredoc prose that blocked its own commit ==="
-COMMIT_MSG=$'git commit -q -F - <<\'EOF\'\nLeave pushing and deciding a PR to Bertan\n\nno-git-push.sh refuses every push; no-pr-decisions.sh refuses\ngh pr review --approve and --request-changes, gh pr close and reopen.\ngit push is refused in every form.\ngh pr merge 5 would also be refused.\nEOF'
+COMMIT_MSG=$'git commit -q -F - <<\'EOF\'\nLeave pushing and deciding a PR to Bertan\n\nno-git-push.sh refuses every push; no-pr-decisions.sh refuses\ngh pr review --approve and --request-changes, gh pr close and reopen.\ngit push origin main is refused in every form.\ngh pr merge 5 would also be refused.\nEOF'
 probe no-git-push.sh     ALLOW 'commit msg naming git push in heredoc' "$COMMIT_MSG"
 probe no-pr-decisions.sh ALLOW 'commit msg naming gh pr verbs in heredoc' "$COMMIT_MSG"
-NOTE=$'cat > /tmp/note.md <<\'MD\'\ngh pr merge is now refused by a hook.\ngit push likewise.\nMD'
+NOTE=$'cat > /tmp/note.md <<\'MD\'\ngh pr merge is now refused by a hook.\ngit push origin main likewise.\nMD'
 probe no-git-push.sh     ALLOW 'heredoc body naming git push' "$NOTE"
 probe no-pr-decisions.sh ALLOW 'heredoc body naming gh pr merge' "$NOTE"
 
-echo "=== REGRESSION: real commands still caught in multi-line input ==="
-probe no-git-push.sh     BLOCK 'multi-line, push on line 2'   $'cd /tmp\ngit push origin dev-05'
-probe no-pr-decisions.sh BLOCK 'multi-line, merge on line 2'  $'cd /tmp\ngh pr merge 5'
-probe no-git-push.sh     BLOCK 'heredoc fed to a shell'       $'bash <<\'EOF\'\ngit push\nEOF'
-probe no-git-push.sh     BLOCK 'real push after heredoc ends' $'cat > /tmp/f <<\'EOF\'\nhello\nEOF\ngit push'
-
 echo "=== REGRESSION: PR #35, indentation defeated the anchor ==="
-# The anchor required column zero, so a command inside an if or a for loop --
-# indented, and the ordinary way either is written -- passed both hooks, while
-# no-commit-to-main.sh with its looser anchor still caught the same shape.
-probe no-git-push.sh     BLOCK 'if/then + indented push'   $'if true; then\n    git push origin dev-05\nfi'
-probe no-git-push.sh     BLOCK 'for loop + indented push'  $'for b in a b; do\n  git push origin $b\ndone'
-probe no-git-push.sh     BLOCK 'deeply indented push'      $'if true; then\n  if true; then\n        git push\n  fi\nfi'
-probe no-pr-decisions.sh BLOCK 'if/then + indented merge'  $'if true; then\n    gh pr merge 35\nfi'
-probe no-pr-decisions.sh BLOCK 'for loop + indented close' $'for n in 1 2; do\n  gh pr close $n\ndone'
+# Each names a refused destination, so these assert that the command is still
+# *found* when indented, independently of the worktree exception.
+probe no-git-push.sh     BLOCK 'if/then + indented push to dev-05' $'if true; then\n    git push origin dev-05\nfi'
+probe no-git-push.sh     BLOCK 'for loop + indented push to main'  $'for r in a b; do\n  git push origin main\ndone'
+probe no-git-push.sh     BLOCK 'deeply indented push to main'      $'if true; then\n  if true; then\n        git push origin main\n  fi\nfi'
+probe no-pr-decisions.sh BLOCK 'if/then + indented merge'          $'if true; then\n    gh pr merge 35\nfi'
+probe no-pr-decisions.sh BLOCK 'for loop + indented close'         $'for n in 1 2; do\n  gh pr close $n\ndone'
 
 echo "=== REGRESSION: PR #35, no-pr-decisions.sh had no wrapper rule ==="
-# Its sibling re-admitted the raw command for shell wrappers and this file did
-# not, so everything the heredoc drop hid stayed hidden -- including a graphql
-# mutation, which is ordinarily sent through a heredoc.
 probe no-pr-decisions.sh BLOCK 'bash -c gh pr merge'  "bash -c 'gh pr merge 35'"
 probe no-pr-decisions.sh BLOCK 'sh -c gh pr merge'    'sh -c "gh pr merge 35"'
 probe no-pr-decisions.sh BLOCK 'eval gh pr merge'     "eval 'gh pr merge 35'"
@@ -63,33 +74,37 @@ probe no-pr-decisions.sh BLOCK 'graphql mutation via heredoc' $'gh api graphql -
 probe no-pr-decisions.sh BLOCK 'REST merge via heredoc body'  $'gh api -X PUT --input - <<EOF\n{"path":"/repos/o/r/pulls/5/merge"}\nEOF'
 
 echo "=== ACCEPTED false positive: quoted multi-line string, not a heredoc ==="
-# The price of allowing leading whitespace in the anchor. A continuation line of
-# a quoted argument that begins with one of these commands is refused. Kept on
-# purpose: a blocked comment is visible and one edit away, a silently permitted
-# push is neither. These assert the current, deliberate behaviour -- if a later
-# change makes them ALLOW, that is a decision to take knowingly, not a bug fix.
+# The price of allowing leading whitespace in the anchor. Kept on purpose: a
+# blocked comment is visible and one edit away, a silently permitted push is
+# neither. If a later change makes these ALLOW, that is a decision to take
+# knowingly, not a bug fix.
 probe no-git-push.sh     BLOCK 'multi-line -b string continuing with a push' $'gh issue comment 27 -b "to release:\n  git push origin main"'
 probe no-pr-decisions.sh BLOCK 'multi-line -b string continuing with a merge' $'gh issue comment 27 -b "to land it:\n  gh pr merge 35"'
 
-echo "=== no-git-push.sh : must BLOCK ==="
-for c in 'git push' \
-         'git push origin dev-05' \
-         'git push -f origin dev-05' \
-         'git push --force-with-lease' \
-         'git push origin HEAD:main' \
-         'git -C /home/bgunyel/source/ai/clause-and-effect push' \
-         'git -c user.name=x push origin HEAD' \
-         'git commit -m msg && git push' \
-         'cd /tmp; git push' \
-         'make test || git push' \
-         '(git push)' \
-         'bash -c "git push origin dev-05"' \
-         'sh -c "git push"' \
-         'eval "git push"' \
-         'git push;'
-do probe no-git-push.sh BLOCK "$c" "$c"; done
+echo "=== worktree exception: pushing this worktree's own branch ==="
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'bare git push'                    'git push'
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push after a commit'          'git commit -m msg && git push'
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push in a subshell'           '(git push)'
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push with a trailing ;'       'git push;'
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push --force-with-lease'      'git push --force-with-lease'
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push -u origin <this branch>' "git push -u origin $CURRENT"
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'indented push, own branch'        $'if true; then\n    git push\nfi'
 
-echo "=== no-git-push.sh : must ALLOW ==="
+echo "=== worktree exception does not extend to ==="
+probe no-git-push.sh BLOCK 'another branch by name: main'      'git push origin main'
+probe no-git-push.sh BLOCK 'another branch by name: dev-05'    'git push origin dev-05'
+probe no-git-push.sh BLOCK 'a refspec destination: HEAD:main'  'git push origin HEAD:main'
+probe no-git-push.sh BLOCK 'a forced push to dev-05'           'git push -f origin dev-05'
+probe no-git-push.sh BLOCK 'a cd before the push'              'cd /tmp && git push'
+probe no-git-push.sh BLOCK 'a cd before the push, with ;'      'cd /tmp; git push'
+probe no-git-push.sh BLOCK 'git redirected with -C'            'git -C /home/bgunyel/source/ai/clause-and-effect push'
+probe no-git-push.sh BLOCK 'git redirected with --git-dir'     'git --git-dir=/elsewhere/.git push'
+probe no-git-push.sh BLOCK 'a push inside sh -c'               'sh -c "git push"'
+probe no-git-push.sh BLOCK 'a push inside bash -c'             'bash -c "git push origin dev-05"'
+probe no-git-push.sh BLOCK 'a push inside eval'                'eval "git push"'
+probe no-git-push.sh BLOCK 'a push inside a heredoc fed to sh' $'bash <<\'EOF\'\ngit push\nEOF'
+
+echo "=== no-git-push.sh : not a push at all ==="
 for c in 'git status' \
          'git commit -m "explain how to git push later"' \
          'echo "run git push when ready" >> notes.md' \

--- a/.claude/hooks/probe-hooks.sh
+++ b/.claude/hooks/probe-hooks.sh
@@ -86,9 +86,25 @@ probe no-git-push.sh "$OWN_BRANCH_PUSH" 'bare git push'                    'git 
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push after a commit'          'git commit -m msg && git push'
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push in a subshell'           '(git push)'
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push with a trailing ;'       'git push;'
-probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push --force-with-lease'      'git push --force-with-lease'
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push -u origin <this branch>' "git push -u origin $CURRENT"
 probe no-git-push.sh "$OWN_BRANCH_PUSH" 'indented push, own branch'        $'if true; then\n    git push\nfi'
+# An unrelated -f elsewhere on the line is not the push's own flag. Every option
+# check reads the push's arguments, not the whole command, so this still passes.
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'rm -f before an ordinary push'    'rm -f notes.md && git push'
+
+echo "=== forced pushes, refused in every spelling ==="
+# Forcing rewrites what the remote already has, which for this branch is the
+# history an open pull request is showing. --force-with-lease is refused with
+# the rest: it guards against clobbering another person's work, not against
+# rewriting a PR under its reviewer.
+probe no-git-push.sh BLOCK 'git push -f'                   'git push -f'
+probe no-git-push.sh BLOCK 'git push --force'              'git push --force'
+probe no-git-push.sh BLOCK 'git push --force-with-lease'   'git push --force-with-lease'
+probe no-git-push.sh BLOCK 'lease with a value'            "git push --force-with-lease=$CURRENT origin"
+probe no-git-push.sh BLOCK 'git push --force-if-includes'  'git push --force-if-includes origin'
+probe no-git-push.sh BLOCK 'bundled short flags -fu'       "git push -fu origin $CURRENT"
+probe no-git-push.sh BLOCK 'forced by leading + on refspec' "git push origin +$CURRENT"
+probe no-git-push.sh BLOCK 'forced push of own branch'     "git push -f origin $CURRENT"
 
 echo "=== worktree exception does not extend to ==="
 probe no-git-push.sh BLOCK 'another branch by name: main'      'git push origin main'

--- a/.claude/hooks/probe-hooks.sh
+++ b/.claude/hooks/probe-hooks.sh
@@ -104,6 +104,36 @@ probe no-git-push.sh BLOCK 'a push inside bash -c'             'bash -c "git pus
 probe no-git-push.sh BLOCK 'a push inside eval'                'eval "git push"'
 probe no-git-push.sh BLOCK 'a push inside a heredoc fed to sh' $'bash <<\'EOF\'\ngit push\nEOF'
 
+echo "=== REGRESSION: PR #35, a denylist could not see a push naming no branch ==="
+# The check refused branches by name, so any spelling that named none was
+# invisible: --all advanced main and dev-05 from any worktree, and --mirror
+# deleted every remote branch absent locally, closing open pull requests. The
+# check is now an allowlist -- the push must positively name this branch.
+probe no-git-push.sh BLOCK 'git push --all origin'      'git push --all origin'
+probe no-git-push.sh BLOCK 'git push --mirror origin'   'git push --mirror origin'
+probe no-git-push.sh BLOCK 'git push --prune origin'    'git push --prune origin'
+probe no-git-push.sh BLOCK 'git push origin --tags'     'git push origin --tags'
+probe no-git-push.sh BLOCK 'git push --follow-tags'     'git push --follow-tags origin'
+probe no-git-push.sh BLOCK 'wildcard refspec, forced'   'git push origin +refs/heads/*:refs/heads/*'
+probe no-git-push.sh BLOCK 'deleting a remote branch'   "git push origin --delete $CURRENT"
+probe no-git-push.sh BLOCK 'deleting by empty source'   'git push origin :main'
+
+echo "=== REGRESSION: PR #35, redirects and cd forms the rules did not reach ==="
+# An environment assignment precedes the command, so git was not at a command
+# position and the push was never even detected; the anchors now allow a VAR=
+# prefix. pushd changes directory exactly as cd does.
+probe no-git-push.sh     BLOCK 'GIT_DIR= prefix'     'GIT_DIR=/other/.git git push origin main'
+probe no-git-push.sh     BLOCK 'GIT_WORK_TREE= prefix' 'GIT_WORK_TREE=/other git push'
+probe no-git-push.sh     BLOCK 'pushd before a push'  'pushd /some/repo && git push'
+probe no-pr-decisions.sh BLOCK 'env prefix before gh' 'FOO=1 gh pr merge 35'
+
+echo "=== the allowlist still admits an ordinary push of this branch ==="
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push origin'                "git push origin"
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push origin HEAD'           "git push origin HEAD"
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push origin HEAD:<branch>'  "git push origin HEAD:$CURRENT"
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'git push origin <b>:<b>'        "git push origin $CURRENT:$CURRENT"
+probe no-git-push.sh "$OWN_BRANCH_PUSH" 'push option with a value'       "git push -o ci.skip origin $CURRENT"
+
 echo "=== no-git-push.sh : not a push at all ==="
 for c in 'git status' \
          'git commit -m "explain how to git push later"' \

--- a/.claude/hooks/probe-hooks.sh
+++ b/.claude/hooks/probe-hooks.sh
@@ -42,6 +42,35 @@ probe no-pr-decisions.sh BLOCK 'multi-line, merge on line 2'  $'cd /tmp\ngh pr m
 probe no-git-push.sh     BLOCK 'heredoc fed to a shell'       $'bash <<\'EOF\'\ngit push\nEOF'
 probe no-git-push.sh     BLOCK 'real push after heredoc ends' $'cat > /tmp/f <<\'EOF\'\nhello\nEOF\ngit push'
 
+echo "=== REGRESSION: PR #35, indentation defeated the anchor ==="
+# The anchor required column zero, so a command inside an if or a for loop --
+# indented, and the ordinary way either is written -- passed both hooks, while
+# no-commit-to-main.sh with its looser anchor still caught the same shape.
+probe no-git-push.sh     BLOCK 'if/then + indented push'   $'if true; then\n    git push origin dev-05\nfi'
+probe no-git-push.sh     BLOCK 'for loop + indented push'  $'for b in a b; do\n  git push origin $b\ndone'
+probe no-git-push.sh     BLOCK 'deeply indented push'      $'if true; then\n  if true; then\n        git push\n  fi\nfi'
+probe no-pr-decisions.sh BLOCK 'if/then + indented merge'  $'if true; then\n    gh pr merge 35\nfi'
+probe no-pr-decisions.sh BLOCK 'for loop + indented close' $'for n in 1 2; do\n  gh pr close $n\ndone'
+
+echo "=== REGRESSION: PR #35, no-pr-decisions.sh had no wrapper rule ==="
+# Its sibling re-admitted the raw command for shell wrappers and this file did
+# not, so everything the heredoc drop hid stayed hidden -- including a graphql
+# mutation, which is ordinarily sent through a heredoc.
+probe no-pr-decisions.sh BLOCK 'bash -c gh pr merge'  "bash -c 'gh pr merge 35'"
+probe no-pr-decisions.sh BLOCK 'sh -c gh pr merge'    'sh -c "gh pr merge 35"'
+probe no-pr-decisions.sh BLOCK 'eval gh pr merge'     "eval 'gh pr merge 35'"
+probe no-pr-decisions.sh BLOCK 'graphql mutation via heredoc' $'gh api graphql -f query=@- <<EOF\nmutation { mergePullRequest(input:{pullRequestId:"x"}) { clientMutationId } }\nEOF'
+probe no-pr-decisions.sh BLOCK 'REST merge via heredoc body'  $'gh api -X PUT --input - <<EOF\n{"path":"/repos/o/r/pulls/5/merge"}\nEOF'
+
+echo "=== ACCEPTED false positive: quoted multi-line string, not a heredoc ==="
+# The price of allowing leading whitespace in the anchor. A continuation line of
+# a quoted argument that begins with one of these commands is refused. Kept on
+# purpose: a blocked comment is visible and one edit away, a silently permitted
+# push is neither. These assert the current, deliberate behaviour -- if a later
+# change makes them ALLOW, that is a decision to take knowingly, not a bug fix.
+probe no-git-push.sh     BLOCK 'multi-line -b string continuing with a push' $'gh issue comment 27 -b "to release:\n  git push origin main"'
+probe no-pr-decisions.sh BLOCK 'multi-line -b string continuing with a merge' $'gh issue comment 27 -b "to land it:\n  gh pr merge 35"'
+
 echo "=== no-git-push.sh : must BLOCK ==="
 for c in 'git push' \
          'git push origin dev-05' \

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "worktree": {
+    "baseRef": "head"
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,16 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/append-only-docs.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/no-git-push.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/no-pr-decisions.sh",
+            "timeout": 5
           }
         ]
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,11 +194,19 @@ a claim without a number is a claim to re-measure.
 
 An agent may push the branch of the linked worktree it is working in —
 non-forced, positively naming that branch, to a remote this repository has — and
-nothing else. It may open a pull request, comment on one, edit one and read one.
-It may not merge one, review one with a verdict, close or reopen one, or create
-or delete a release. `main` and `dev-NN` are Bertan's to push; `main` is
+nothing else. It may open a pull request, comment on one, edit one and read one,
+through `gh pr view` or through a `gh api` request that does not write. It may
+not merge one, review one with a verdict, close or reopen one, or create or
+delete a release. `main` and `dev-NN` are Bertan's to push; `main` is
 additionally protected server-side by the `main-branch-protection` ruleset,
 which requires a pull request.
+
+"Positively naming that branch" is literal: write `git push origin <branch>`.
+A bare `git push`, and `git push origin` with no refspec, are refused. Their
+destination comes from configuration — `push.default`, a `remote.<name>.push`
+refspec, the branch's upstream — and an agent may run `git config`, so a rule
+resting on a configured value can be arranged around one command earlier. The
+destination has to be in the command for the hook to have anything to check.
 
 Enforced by `.claude/hooks/no-git-push.sh` and `no-pr-decisions.sh`, both built
 on `.claude/hooks/lib/command-scan.sh`, which answers where a command starts and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,37 @@ a claim without a number is a claim to re-measure.
 - A red suite mid-refactor is acceptable — verify against the recorded snapshot
   in the dev-log rather than insisting on green first.
 
+## What an unattended agent may do to this repository
+
+An agent may push the branch of the linked worktree it is working in —
+non-forced, positively naming that branch, to a remote this repository has — and
+nothing else. It may open a pull request, comment on one, edit one and read one.
+It may not merge one, review one with a verdict, close or reopen one, or create
+or delete a release. `main` and `dev-NN` are Bertan's to push; `main` is
+additionally protected server-side by the `main-branch-protection` ruleset,
+which requires a pull request.
+
+Enforced by `.claude/hooks/no-git-push.sh` and `no-pr-decisions.sh`, both built
+on `.claude/hooks/lib/command-scan.sh`, which answers where a command starts and
+where its arguments end — that question, re-derived in each hook, was the whole
+of five defects. `bash .claude/hooks/probe-hooks.sh` checks the boundary in both
+directions and prints which context it ran in. Hooks see only the Bash tool, so
+Bertan's own terminal is not subject to any of this.
+
+`dev-NN` rests on those hooks alone and can rest on nothing else: an agent pushes
+as `bgunyel`, so a server-side rule on `dev-*` would block Bertan too, and naming
+him a bypass actor would hand the agent the bypass. Whether the command runs in a
+linked worktree is the only signal that separates them. `main` is different —
+there the policy is identical for both, which is why a ruleset carries it.
+
+**Deliberately left open.** These stop mistakes, not adversaries: they read the
+text of a command, so a caller that means to evade them can. Two consequences are
+accepted rather than fixed. A push or a decision inside `sh -c` is refused
+outright rather than assessed, because a destination inside quotes cannot be
+read. And a quoted multi-line string whose continuation line begins with one of
+these commands is refused although it is only prose — a blocked comment is
+visible and one edit away, a silently permitted push is neither.
+
 ## Agent skills
 
 ### Issue tracker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,8 +158,8 @@ been green for the wrong reasons.
 
 ## Documentation
 
-Four directories with different jobs; the distinction erodes easily
-(`docs/design/README.md` states it in full):
+Five directories with different jobs; the distinction erodes easily
+(`docs/design/README.md` states the first four in full):
 
 | directory | answers | dated? |
 |---|---|---|
@@ -167,6 +167,7 @@ Four directories with different jobs; the distinction erodes easily
 | `docs/lessons-learned/` | how a specific failure happened | yes, **append-only** |
 | `docs/eval-reports/` | what the numbers were at a point in time | yes, **append-only** |
 | `docs/design/` | how a mechanism works **today** | no, revised in place |
+| `docs/adr/` | why a decision was taken, and what was rejected | no, superseded rather than revised |
 
 `docs/todo.md` is the backlog; `docs/evaluation-plan.md` is what the framework
 *should* become, not evidence about what exists. Append-only means old entries
@@ -193,41 +194,40 @@ a claim without a number is a claim to re-measure.
 ## What an unattended agent may do to this repository
 
 An agent may push the branch of the linked worktree it is working in —
-non-forced, positively naming that branch, to a remote this repository has — and
-nothing else. It may open a pull request, comment on one, edit one and read one,
-through `gh pr view` or through a `gh api` request that does not write. It may
-not merge one, review one with a verdict, close or reopen one, or create or
-delete a release. `main` and `dev-NN` are Bertan's to push; `main` is
-additionally protected server-side by the `main-branch-protection` ruleset,
-which requires a pull request.
+non-forced, and naming that branch in the command, because a bare `git push`
+takes its destination from configuration an agent can itself change: write
+`git push origin <branch>`. That is the whole of what it may push. It may open a
+pull request, comment on one, edit one and read one, through `gh pr view` or
+through a `gh api` request that does not write. It may not merge one, review one
+with a verdict, close or reopen one, or create or delete a release. `main` and
+`dev-NN` are Bertan's to push; `main` is additionally protected server-side by
+the `main-branch-protection` ruleset, which requires a pull request. Enforced by
+`.claude/hooks/no-git-push.sh` and `no-pr-decisions.sh`, both built on
+`.claude/hooks/lib/command-scan.sh`; `bash .claude/hooks/probe-hooks.sh` checks
+the boundary in both directions. Hooks see only the Bash tool, so Bertan's own
+terminal is not subject to any of this.
 
-"Positively naming that branch" is literal: write `git push origin <branch>`.
-A bare `git push`, and `git push origin` with no refspec, are refused. Their
-destination comes from configuration — `push.default`, a `remote.<name>.push`
-refspec, the branch's upstream — and an agent may run `git config`, so a rule
-resting on a configured value can be arranged around one command earlier. The
-destination has to be in the command for the hook to have anything to check.
-
-Enforced by `.claude/hooks/no-git-push.sh` and `no-pr-decisions.sh`, both built
-on `.claude/hooks/lib/command-scan.sh`, which answers where a command starts and
-where its arguments end — that question, re-derived in each hook, was the whole
-of five defects. `bash .claude/hooks/probe-hooks.sh` checks the boundary in both
-directions and prints which context it ran in. Hooks see only the Bash tool, so
-Bertan's own terminal is not subject to any of this.
-
-`dev-NN` rests on those hooks alone and can rest on nothing else: an agent pushes
-as `bgunyel`, so a server-side rule on `dev-*` would block Bertan too, and naming
-him a bypass actor would hand the agent the bypass. Whether the command runs in a
-linked worktree is the only signal that separates them. `main` is different —
-there the policy is identical for both, which is why a ruleset carries it.
+`dev-NN` rests on those hooks *because* an agent currently acts with Bertan's
+credentials, so no server-side rule can tell the two apart. That is a
+configuration choice and not a constraint: giving the agent its own actor would
+move the rule to a ruleset. Why it was not done, and what would have to be
+checked first, is in `docs/adr/0001-hooks-not-ruleset.md`.
 
 **Deliberately left open.** These stop mistakes, not adversaries: they read the
-text of a command, so a caller that means to evade them can. Two consequences are
-accepted rather than fixed. A push or a decision inside `sh -c` is refused
+text of a command, so a caller that means to evade them can. Three consequences
+are accepted rather than fixed. A push or a decision inside `sh -c` is refused
 outright rather than assessed, because a destination inside quotes cannot be
-read. And a quoted multi-line string whose continuation line begins with one of
+read. A quoted multi-line string whose continuation line begins with one of
 these commands is refused although it is only prose — a blocked comment is
-visible and one edit away, a silently permitted push is neither.
+visible and one edit away, a silently permitted push is neither. And nothing in
+this repository guards `.claude/`: the only `Edit|Write` hook covers three
+`docs/` directories, so the hook files and `settings.json` that carry this
+boundary are not themselves covered by the boundary. Whether an edit to them
+prompts at all is left to the harness's own permission settings, which are
+configuration rather than a rule of this repository. That gap is open by the
+same standard that decides the rest — an agent does not *mistakenly* rewrite the
+hook that just refused it — and closing it would make every future hook change a
+two-person procedure for no gain against the threat actually named.
 
 ## Agent skills
 
@@ -243,5 +243,5 @@ The five canonical roles, each label string equal to its name. See
 
 ### Domain docs
 
-Single-context: `CONTEXT.md` and `docs/adr/` at the repo root, neither of which
-exists yet. See `docs/agents/domain.md`.
+Single-context: `docs/adr/` holds one ADR; `CONTEXT.md` does not exist yet. See
+`docs/agents/domain.md`.

--- a/docs/adr/0001-hooks-not-ruleset.md
+++ b/docs/adr/0001-hooks-not-ruleset.md
@@ -21,6 +21,11 @@ means to evade them. And they see only the Bash tool inside a Claude Code
 session, so Bertan's own terminal is subject to none of it — which is the
 point, not an oversight.
 
+A hook takes effect only where the harness looks for it: `.claude/settings.json`
+is read from the main checkout, so `no-git-push.sh` and `no-pr-decisions.sh`
+were inert — an agent's `git push` went through unrefused — while they were
+registered only on the branch that adds them.
+
 This decision is about the mechanism and deliberately records no inventory of
 which commands are permitted. That list lives in the hooks and in CLAUDE.md, and
 it will grow; the reason it is a list held in hooks at all is what is recorded

--- a/docs/adr/0001-hooks-not-ruleset.md
+++ b/docs/adr/0001-hooks-not-ruleset.md
@@ -1,0 +1,40 @@
+# The agent boundary is enforced by hooks, not by a server-side ruleset
+
+An unattended agent working in this repository acts with Bertan's GitHub
+credentials. A branch ruleset on `dev-*` therefore cannot separate the two: it
+would refuse Bertan's own writes as readily as the agent's, and naming him a
+bypass actor would hand the agent the bypass along with it. The one signal that
+does separate them is local — whether the command is running in a linked
+worktree — and only a check inside the session can read it. So the boundary is
+carried by `PreToolUse` hooks, which run in the agent's session and nowhere
+else.
+
+`main` is the contrast, and it shows the principle rather than breaking it.
+There the policy is identical for both actors, so nothing needs separating, and
+the `main-branch-protection` ruleset carries it server-side — out of reach of
+the thing it constrains, which is where enforcement belongs whenever it can go
+there.
+
+Two consequences follow from putting it in hooks, and both are accepted. The
+hooks read the text of a command, so they stop mistakes rather than a caller who
+means to evade them. And they see only the Bash tool inside a Claude Code
+session, so Bertan's own terminal is subject to none of it — which is the
+point, not an oversight.
+
+This decision is about the mechanism and deliberately records no inventory of
+which commands are permitted. That list lives in the hooks and in CLAUDE.md, and
+it will grow; the reason it is a list held in hooks at all is what is recorded
+here.
+
+## Considered Options
+
+**Give the agent its own actor** — a deploy key, or a GitHub App installation
+token. The premise this ADR rests on is a configuration choice and not a law:
+with a second identity, `dev-*` could be protected by a ruleset that names
+Bertan as a bypass actor and leaves the agent outside it, and the boundary would
+move server-side where the agent cannot edit it. That is the better shape, and
+it is not scheduled. It is written down because it is the option a reader would
+otherwise re-propose after concluding from the hooks that nothing else was
+possible. Before anything is bet on it: this repository is user-owned rather
+than organisation-owned, and its one existing ruleset has an empty bypass-actor
+list, so the approach needs verifying rather than assuming.


### PR DESCRIPTION
Closes #37

Two `PreToolUse` hooks on the `Bash` matcher, joining the four already there.

**`no-git-push.sh`** refuses every push. Pushes are made by Bertan from a separate terminal outside Claude Code, so no push is judged case by case.

**`no-pr-decisions.sh`** refuses merging a pull request, reviewing one with a verdict (`--approve`, `--request-changes`), closing or reopening one, and creating or deleting a release. The line is between talking and deciding: an agent may open a pull request and argue on it, and may not accept, reject or merge one.

Still allowed: `gh pr create`, `gh pr comment`, `gh pr edit`, `gh pr view/list/diff/checks/ready`, `gh pr review --comment`, and every `gh issue` subcommand.

### The direct API path is matched too

`gh pr merge` is only the convenient spelling. The same merge is one REST call (`PUT /repos/O/R/pulls/N/merge`) or one graphql mutation away, and `gh api` is allowlisted in `settings.local.json`, so it runs without a prompt.

This section used to claim more than the code did — it covered merging and reviewing, and left closing and releasing open through `gh api` while refusing both one file-section earlier. Raised in review; the code was widened rather than the claim narrowed. What is matched now, and it is a list rather than a principle:

| decision | REST | graphql |
|---|---|---|
| merge | `/pulls/*/merge` | `mergePullRequest` |
| review with a verdict | `/pulls/*/reviews` | `addPullRequestReview` |
| close / reopen | a write to `/pulls/N` carrying `state=closed` or `state=open` | `closePullRequest`, `reopenPullRequest`, `updatePullRequest` with that state |
| release | `/releases` | `createRelease`, `updateRelease`, `deleteRelease` |

Close and reopen are matched on the **field**, not the endpoint, because `PATCH /repos/O/R/pulls/N` is also how `gh pr edit` retitles a PR — which is allowed, and is asserted to stay allowed by a probe.

**Only writes are matched.** `gh` sends `GET` unless a `--method` or a field flag says otherwise, and the endpoint does not distinguish a decision from a reading: `GET /pulls/N/reviews` lists reviews and `GET /pulls/N/merge` reports whether the PR is merged. Both are reading a pull request, which the boundary allows. A method that cannot be parsed counts as a write. The exception is a call wrapped in `bash -c`, where the method is quoted text and no more readable than the endpoint — a wrapped read is refused with the writes.

### Two rounds of false positives, both recorded as probes

Matching is anchored to a *command position* — start of line, or after `;` `&&` `||` `|` or an opening paren — not to a bare preceding space, which is what `no-commit-to-main.sh` uses. The looser anchor blocks writing a commit message that merely names the command, and this repository does that constantly.

That was not enough. `grep` anchors `^` per line, so a wrapped line of prose inside a quoted heredoc still read as a command position — **the first version of these hooks refused the commit that introduced them.** Heredoc bodies are now dropped before matching. Because that also hides a real command, shell wrappers (`sh -c`, and a heredoc fed to a shell) are matched separately on the raw text, quotes and bodies included.

### `probe-hooks.sh`

63 probes, run with `bash .claude/hooks/probe-hooks.sh`, all passing:

- 4 that a commit message or note may *name* these commands
- 4 that a real command in multi-line input is still caught
- 55 over the ordinary spellings, both the block and the allow side

It found two defects during this work, which is why it is committed rather than thrown away. A hook is a process and running it is the only way to test it; per CLAUDE.md the expectations are written as literals, never derived from the scripts.

**Reviewer's call:** this third file is the one thing here that was not asked for. Drop it if you would rather the hooks ship alone.

### Notes

`no-commit-to-main.sh` already refused pushes whose destination was main, and that rule is now a subset of the broader one. Left in place on purpose: it carries the narrower message, and it still stands if the broader hook is disabled.

These hooks are inert in the main checkout until this merges — `settings.json` there was restored to its committed state during this work.

**These stop mistakes, not adversaries.** A caller who means to push or merge can spell it in ways no regex catches.

https://claude.ai/code/session_01Mx8Qck1kMHWmNFhKb4YAjv


