### PR TITLE
Teach the shared tokeniser to scope a gh subcommand's arguments

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -150,6 +150,14 @@ fi
 # defects listed at the top of lib/command-scan.sh.
 tok 'gh args, plain' '--base dev-05 --title x' \
     "$(printf 'gh pr create --base dev-05 --title x\n' | cs_gh_args 'pr create')"
+# Skipping happens before every word of the path, so the two positions are
+# pinned separately: a flag before the group, and a flag between the group and
+# the verb. Without the first of these, a helper that skipped options only from
+# the second word onward passed this whole suite while `gh -R o/r pr create` --
+# an ordinary way to work on a repository from another directory -- became
+# invisible to it, which is the permitting direction.
+tok 'gh args, a flag before the group' \
+    '--base main' "$(printf 'gh -R o/r pr create --base main\n' | cs_gh_args 'pr create')"
 tok 'gh args, a flag between the group and the verb' \
     '--base main' "$(printf 'gh pr --repo o/r create --base main\n' | cs_gh_args 'pr create')"
 tok 'gh args, the repo value attached rather than separate' \

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -142,6 +142,70 @@ else
   tok 'git status is not a push' 'not found' 'not found'
 fi
 
+# The gh helper answers the same question one level deeper: gh nests its verbs
+# under a group, so the subcommand is a path, and an option sitting between its
+# words has to be skipped or the verb is never reached at all. Nothing uses this
+# yet -- it is the footing the base rule is built on, rather than a fourth raw
+# match over the whole line, which is the shape that produced two of the five
+# defects listed at the top of lib/command-scan.sh.
+tok 'gh args, plain' '--base dev-05 --title x' \
+    "$(printf 'gh pr create --base dev-05 --title x\n' | cs_gh_args 'pr create')"
+tok 'gh args, a flag between the group and the verb' \
+    '--base main' "$(printf 'gh pr --repo o/r create --base main\n' | cs_gh_args 'pr create')"
+tok 'gh args, the repo value attached rather than separate' \
+    '35 --base main' "$(printf 'gh pr --repo=o/r edit 35 --base main\n' | cs_gh_args 'pr edit')"
+tok 'gh args, a one-word subcommand path' \
+    'repos/o/r/pulls -f base=main' \
+    "$(printf 'gh api repos/o/r/pulls -f base=main\n' | cs_gh_args api)"
+tok 'gh args, empty for a bare create' '' "$(printf 'gh pr create\n' | cs_gh_args 'pr create')"
+# An option on a neighbouring command is not this command's own. Scoping that
+# question to the whole line is the first of the two defects named above, and
+# the neighbour here carries the very flag the base rule will look for.
+tok 'gh args, an option on a neighbouring command' '--base dev-05' \
+    "$(printf 'gh pr view 35 --base main\ngh pr create --base dev-05\n' | cs_gh_args 'pr create')"
+# It answers about the first match and stops, so a caller handed a whole command
+# list would never see the second -- the fifth defect in command-scan.sh's list.
+# no-git-push.sh loops per command over cs_split's output for exactly that
+# reason; this is what obliges the base rule to do the same.
+tok 'gh args, the first match only, and the rest unseen' '' \
+    "$(printf 'gh pr create\ngh pr create --base dev-05\n' | cs_gh_args 'pr create')"
+if printf 'gh pr create\n' | cs_gh_args 'pr create' >/dev/null; then
+  tok 'bare create succeeds, so empty args mean a create' 'found' 'found'
+else
+  tok 'bare create succeeds, so empty args mean a create' 'found' 'not found'
+fi
+if printf 'gh pr view 35\n' | cs_gh_args 'pr create' >/dev/null; then
+  tok 'gh pr view is not a create' 'not found' 'found'
+else
+  tok 'gh pr view is not a create' 'not found' 'not found'
+fi
+# The group is part of the path, so a verb of the same name under another group
+# is a different command.
+if printf 'gh issue create\n' | cs_gh_args 'pr create' >/dev/null; then
+  tok 'gh issue create is not a pr create' 'not found' 'found'
+else
+  tok 'gh issue create is not a pr create' 'not found' 'not found'
+fi
+if printf 'git status\n' | cs_gh_args 'pr create' >/dev/null; then
+  tok 'a command that is not gh at all' 'not found' 'found'
+else
+  tok 'a command that is not gh at all' 'not found' 'not found'
+fi
+# The command word is `gh`, not a prefix of one. Without the word boundary the
+# first two letters of `ghpr` are stripped and the rest reads as `pr create`.
+if printf 'ghpr create\n' | cs_gh_args 'pr create' >/dev/null; then
+  tok 'ghpr is not gh' 'not found' 'found'
+else
+  tok 'ghpr is not gh' 'not found' 'not found'
+fi
+# The one-word path needs its exit status pinned too: it is the shape the two
+# gh api spellings of the base rule will ask about.
+if printf 'gh pr create --base main\n' | cs_gh_args api >/dev/null; then
+  tok 'a pr create is not a gh api call' 'not found' 'found'
+else
+  tok 'a pr create is not a gh api call' 'not found' 'not found'
+fi
+
 echo "=== REGRESSION: PR #35, only the first push on a line was validated ==="
 # The scope found the first push, validated its arguments, and stopped. So a
 # legitimate push carried an illegitimate one after ; or && on its coat-tails.

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -192,3 +192,61 @@ cs_git_args() {
     }
     END { exit(found ? 0 : 1) }'
 }
+
+# Print the arguments of a gh subcommand and succeed, or print nothing and fail
+# if this command is not that subcommand. The subcommand is given as its whole
+# path -- "pr create", "pr edit", "api" -- because gh nests its verbs under a
+# group, and the group on its own does not say what the command does.
+#
+# Options are skipped before every word of that path, not only before the first.
+# Cobra resolves each level at the first non-flag argument, so a flag may sit
+# between the group and the verb and `gh pr --repo o/r create` still creates;
+# -R/--repo and --hostname take their value as a separate token, which has to be
+# consumed with them or the value reads as the verb and hides it. That is the
+# same shape the GHPR pattern in no-pr-decisions.sh answers with a regular
+# expression of its own. So the question is answered in both places for now, and
+# will stay so while GHPR still carries the merge, review, close and reopen
+# rules; this is the answer the next rule is built on rather than a fourth
+# regular expression, which is the whole reason for adding it before its caller.
+#
+# The exit status is what distinguishes `gh pr create` -- a create whose
+# argument list is empty, which is exactly the shape that lets gh choose the
+# base for itself -- from a command that is not a create at all. A caller
+# testing the printed text instead would have to re-derive the rule, which is
+# the habit this file exists to end.
+#
+# Like cs_git_args, it answers about the first match and stops, which is the
+# fifth defect in the list at the top of this file if a caller hands it a whole
+# command list: the second command is never examined. So a caller feeds it one
+# command at a time, as no-git-push.sh does with cs_split's output, and the
+# check suite pins that the second match is lost.
+#
+# It is written before the rule that uses it, so what it is for is worth saying:
+# asking whether a flag belongs to *this* command is argument scoping, and
+# scoping answered ad hoc is where two of the five defects above came from --
+# the whole line read an unrelated option as the command's own, and the
+# narrowing that fixed that cut at a newline, so a continuation made every
+# command look bare.
+cs_gh_args() {
+  awk -v want="$1" '
+    BEGIN { found = 0; n = split(want, part, /[[:space:]]+/) }
+    {
+      line = $0
+      if (line !~ /^gh([[:space:]]|$)/) next
+      sub(/^gh[[:space:]]*/, "", line)
+      matched = 1
+      for (i = 1; i <= n; i++) {
+        while (match(line, /^((-R|--repo|--hostname)[[:space:]]+[^[:space:]]+|-[^[:space:]]+)[[:space:]]+/)) {
+          line = substr(line, RSTART + RLENGTH)
+        }
+        if (line !~ "^" part[i] "([[:space:]]|$)") { matched = 0; break }
+        line = substr(line, length(part[i]) + 1)
+        sub(/^[[:space:]]*/, "", line)
+      }
+      if (!matched) next
+      print line
+      found = 1
+      exit
+    }
+    END { exit(found ? 0 : 1) }'
+}

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -221,6 +221,15 @@ cs_git_args() {
 # command at a time, as no-git-push.sh does with cs_split's output, and the
 # check suite pins that the second match is lost.
 #
+# One place it does not mirror cs_git_args: that function removes the matched
+# subcommand with a regular expression, so the expression that matches and the
+# one that removes are the same and cannot disagree. This one matches part[i] as
+# a regular expression and removes it by string length. That is the same answer
+# for a word and a different one for anything carrying a metacharacter. Every
+# caller passes a literal path, so it is a property rather than a defect -- but
+# it is the kind that gets discovered rather than read, and closing it would
+# need a check written against a caller that does not exist.
+#
 # It is written before the rule that uses it, so what it is for is worth saying:
 # asking whether a flag belongs to *this* command is argument scoping, and
 # scoping answered ad hoc is where two of the five defects above came from --


### PR DESCRIPTION
Closes #39. The prefactor for #40: make the change easy, then make the easy change.

## What this adds

`cs_gh_args` in `.claude/hooks/lib/command-scan.sh`, beside `cs_git_args` and mirroring it — given a subcommand it prints that command's own arguments and succeeds, or prints nothing and fails. The exit status is the part that matters: `gh pr create` with an empty argument list is exactly the shape that lets gh choose the base for itself, and a caller reading the printed text alone could not tell it from a command that is not a create at all.

One difference from the git helper, forced by gh rather than chosen. gh nests its verbs under a group, so the subcommand is a path — `pr create`, `pr edit`, `api` — and options are skipped before every word of it, not only the first. Cobra resolves each level at the first non-flag argument, so `gh pr --repo o/r create` creates, and `-R`/`--repo`/`--hostname` take their value as a separate token that has to be consumed with them or it reads as the verb and hides it.

One inherited property is named rather than left to be discovered: like `cs_git_args`, it answers about the first match and stops — which is the fifth defect in `command-scan.sh`'s own list if a caller hands it a whole command list. `no-git-push.sh` loops per command over `cs_split`'s output for that reason, and a check now pins that the second match is lost, so the next caller is obliged to do the same.

One divergence from that helper is recorded in the docstring rather than fixed. `cs_git_args` removes the matched subcommand with the same regular expression it matched, so the two cannot disagree; this one matches a path word as a regular expression and removes it by string length — identical for a word, different for anything carrying a metacharacter. No caller passes such a path, and closing it would need a check written against a caller that does not exist, which is the guard-code standard pointed at nothing.

## Why it lands before its caller

Refusing a pull request whose base is wrong means answering "is the base flag present in *this* command", which is argument scoping. Answered ad hoc in each rule, that question produced two of the five defects the shared tokeniser was extracted to prevent: scoping to the whole line made an unrelated option elsewhere on the line read as the command's own, and the narrowing that fixed it then cut at a newline, so a line continuation made every command look bare — the permitted shape. The `gh` rules still scope with raw matches over the whole line, so a fourth rule on that footing would reproduce the shape the tokeniser exists to prevent.

No hook calls the helper yet, so **no hook changes what it refuses or permits**, and the same question stays answered twice until `GHPR`'s remaining rules migrate. The docstring says so, rather than claiming a deduplication this branch does not reach.

## Evidence

A property rather than a reading: **207 checks green before, the same 207 plus fourteen green after**, label for label. The fourteen sit at the tokeniser seam beside the git ones, argument lists and exit status both written as literals. No new seam.

Mutation-checked seven ways, each reverted:

| mutation | checks turned red |
|---|---|
| option-skipping loop dropped | 3 |
| option skip moved to after the group's word | 1 |
| only the last word of the path matched | 5 |
| exit status always found | 5 |
| the whole command printed rather than its arguments | 7 |
| the word boundary on `gh` dropped | 1 |
| the first-match `exit` dropped | 1 |

The last row is the check this branch gained from review on the pull request.
Skipping happens before *every* word of the subcommand path, and the suite
pinned only the second position: a variant skipping options from the second word
onward passed all 220 checks while a repo flag written before the group made the
command invisible to the helper. One check now pins the first position, and it is
the only one that mutation turns red.

The two rows before it are checks this branch gained from its own review. The original pair asserted an empty string that both an unguarded and a non-exiting version still produced, so they were green for the wrong reason — the failure mode CLAUDE.md names, caught here by mutation rather than by reading.

## Two things for review

`make test` reports one failure, `test_installed_packages_match_uv_lock`: the local `.venv` is missing `alembic` and `mako`. That is environment drift, not this diff, which touches no Python and no `uv.lock`. Repair is `uv sync --all-groups`.

#36's amendment sets the order #38 → #43 → #44 → #39. #39's own stated blocker (#38) is closed, and the reason given for that order is the reviewability of #43 and #44 as a pair rather than a dependency; this branch touches neither `no-commit-to-main.sh` nor the branch-lifecycle work, so it is reviewable on its own. Taking it out of turn is worth a moment's confirmation all the same.

https://claude.ai/code/session_01LarvmGH7PUf7yWot2oBRTi


