### PR TITLE
Rebuild no-commit-to-main.sh on the shared tokeniser

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Regression checks for no-git-push.sh and no-pr-decisions.sh.
+# Regression checks for no-git-push.sh, no-pr-decisions.sh and
+# no-commit-to-main.sh.
 #
 # A hook is a process, so the only way to test one is to run it; what the rule
 # against calling the function under test forbids is deriving the expectation
@@ -33,8 +34,37 @@
 # of that branch is ALLOW; run from the main checkout, the identical command is
 # BLOCK. OWN_BRANCH_PUSH holds whichever applies, and the banner says which.
 #
+# no-commit-to-main.sh is checked in two classes, because issue #43 rebuilt it
+# on lib/command-scan.sh and did not preserve its behaviour -- that file's
+# behaviour included its defects. The invariant class is written in identical
+# literals on both sides of the migration and pins what was preserved, which is
+# the file's purpose. The defective class names what it got wrong before, and
+# each of those checks carries the verdict it used to return: `ok ALLOW (was
+# BLOCK)` is the migration's evidence, and reverting the file turns exactly
+# those red with `got` equal to the recorded `was`. An all-green run on both
+# sides would have been evidence that the migration changed nothing. Sixteen
+# invariants, eighteen flips, two that the file fails closed without its
+# library, and four that name which refusal fired.
+#
+# A review of the migration found eight more permitting verdicts of the same
+# kind, seven of them shapes an agent writes without meaning anything by them:
+# `git push -u origin HEAD` from main, `git checkout main && git commit`,
+# `sudo` and `timeout` in front of either, `git --git-dir <path>` in its
+# separated spelling, and the file permitting everything when its library was
+# not beside it. Four of those were fixed in lib/command-scan.sh rather than
+# here, and they were holes in no-git-push.sh too. That is the ninth review
+# round on these files to find something the suite did not ask about.
+#
+# Some of those checks depend on which branch is checked out where the hook
+# runs, and one on the difference between that and where the command would run.
+# They are run with the hook's working directory inside a throwaway repository
+# on main or on a dev branch rather than in this one, because this one is
+# neither. `git branch --show-current` reports an unborn branch, so the
+# fixtures need no commits.
+#
 # Run: bash .claude/hooks/check-hooks.sh
 cd "$(dirname "$0")" || exit 1
+HOOKS=$(pwd)
 
 CURRENT=$(git branch --show-current 2>/dev/null)
 GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null)
@@ -64,6 +94,70 @@ check() {
     printf '  FAIL want=%s got=%s  %s\n' "$want" "$got" "$label"
     FAILED=1
   fi
+}
+
+# Two throwaway repositories, one on main and one on a dev branch, so that a
+# hook reading `git branch --show-current` can be asked both questions from a
+# suite that runs on neither. They hold no commits and no remotes: an unborn
+# branch is still reported by name, and nothing here reaches a remote.
+FIXTURES=$(mktemp -d)
+trap 'rm -rf "$FIXTURES"' EXIT
+git init -q -b main "$FIXTURES/on-main"
+git init -q -b dev-99 "$FIXTURES/on-dev"
+ON_MAIN="$FIXTURES/on-main"
+ON_DEV="$FIXTURES/on-dev"
+# An unmade fixture would make ( cd "$dir" && hook ) return 1, which reads as
+# ALLOW -- so every ALLOW-expecting check below would pass without running the
+# hook at all. `git init -b` needs git 2.28.
+[ -d "$ON_MAIN/.git" ] && [ -d "$ON_DEV/.git" ] || {
+  echo "fixtures were not created; git init -b needs git 2.28 or newer" >&2
+  exit 1
+}
+# A copy of each hook with no lib/ beside it, to ask what one does when the
+# tokeniser it now depends on is not there.
+mkdir -p "$FIXTURES/nolib"
+cp no-commit-to-main.sh "$FIXTURES/nolib/"
+
+# check, with the hook's working directory named rather than inherited. The
+# hook is invoked by absolute path because it sources lib/ relative to $0.
+check_in() {  # check_in <dir> <script|/absolute/hook> <want> <label> <cmd>
+  local dir="$1" script="$2" want="$3" label="$4" cmd="$5" got rc hook
+  case "$script" in /*) hook="$script" ;; *) hook="$HOOKS/$script" ;; esac
+  printf '%s' "$cmd" | jq -Rs '{tool_name:"Bash",tool_input:{command:.}}' \
+    | ( cd "$dir" && "$hook" ) >/dev/null 2>&1
+  rc=$?
+  if [ $rc -eq 2 ]; then got=BLOCK; else got=ALLOW; fi
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %-5s %s\n' "$got" "$label"
+  else
+    printf '  FAIL want=%s got=%s  %s\n' "$want" "$got" "$label"
+    FAILED=1
+  fi
+}
+
+# A check whose verdict the #43 migration changed. Both verdicts are literals:
+# `was` is what the file returned before it, `want` what it returns after, and
+# the run prints both so the flip is visible rather than inferred. Reverting
+# the migration fails exactly these, reporting got=<was>.
+flip() {  # flip <dir> <script> <was> <want> <label> <cmd>
+  check_in "$1" "$2" "$4" "$5 (was $3)" "$6"
+}
+
+# Which refusal fired, not just that one did. no-commit-to-main.sh is kept
+# beside a hook that would refuse most of the same commands only because its
+# message names main and says why main is closed; nothing above can tell the
+# three messages apart, so a change routing every path through one of them
+# would leave the suite green and the file pointless.
+says() {  # says <dir> <script> <fragment> <label> <cmd>
+  local dir="$1" script="$2" want="$3" label="$4" cmd="$5" err
+  err=$(printf '%s' "$cmd" | jq -Rs '{tool_name:"Bash",tool_input:{command:.}}' \
+        | ( cd "$dir" && "$HOOKS/$script" ) 2>&1 >/dev/null)
+  case "$err" in
+    *"$want"*) printf '  ok   says  %s\n' "$label" ;;
+    *) printf '  FAIL %s\n         wanted the refusal to say |%s|\n         it said |%s|\n' \
+         "$label" "$want" "$err"
+       FAILED=1 ;;
+  esac
 }
 
 . ./lib/command-scan.sh
@@ -485,6 +579,166 @@ for c in 'gh pr create --title x --body y' \
          'echo "then run gh pr merge 5 to land it" >> notes.md' \
          'git push'
 do check no-pr-decisions.sh ALLOW "$c" "$c"; done
+
+echo "=== REGRESSION: review of #43, prefixes and separated options hid commands ==="
+# Found by reviewing the #43 migration, fixed in lib/command-scan.sh, and
+# therefore not about no-commit-to-main.sh: every hook was blind to these.
+# cs_split stripped a wrapper word and its options but not an operand, so
+# `timeout 30` left a bare 30 where the command word had to be; sudo, doas,
+# setsid and chronic were not wrapper words at all; and cs_git_args skipped
+# --git-dir only in its = form, so the separated one hid the subcommand behind
+# its own value.
+check no-git-push.sh     BLOCK 'timeout before a wholesale push' 'timeout 5 git push --all origin'
+check no-git-push.sh     BLOCK 'sudo before a mirror push'       'sudo git push --mirror origin'
+check no-git-push.sh     BLOCK 'separated --git-dir before a push' 'git --git-dir /tmp/other/.git push --all origin'
+check no-pr-decisions.sh BLOCK 'setsid before a merge'           'setsid gh pr merge 5'
+check no-pr-decisions.sh BLOCK 'sudo before a merge'             'sudo gh pr merge 5'
+# The operand strip takes one token and only if it is not an option, so an
+# ordinary command that begins with one of these words is still itself.
+check no-git-push.sh     ALLOW 'timeout in front of something else' 'timeout 5 make test'
+check no-git-push.sh     ALLOW 'sudo in front of something else'    'sudo apt-get install jq'
+
+echo "=== no-commit-to-main.sh : invariants, identical literals across #43 ==="
+# What the migration preserved. These six were written before it, are green on
+# both sides of it, and are the whole of what this file is for: main is not
+# committed to, and main is not pushed to.
+check_in "$ON_MAIN" no-commit-to-main.sh BLOCK 'commit while standing on main' \
+  'git commit -m "wip"'
+check_in "$ON_DEV"  no-commit-to-main.sh ALLOW 'commit on a dev branch' \
+  'git commit -m "wip"'
+check_in "$ON_DEV"  no-commit-to-main.sh BLOCK 'push naming main' \
+  'git push origin main'
+check_in "$ON_DEV"  no-commit-to-main.sh BLOCK 'the HEAD:main refspec' \
+  'git push origin HEAD:main'
+check_in "$ON_DEV"  no-commit-to-main.sh ALLOW 'main on the source side only' \
+  'git push origin main:spike'
+check_in "$ON_MAIN" no-commit-to-main.sh BLOCK 'a bare push while on main' \
+  'git push'
+# The other side of the bare push, and the commands this file has no opinion
+# about at all. Also invariant: a commit message may name a push, and a push of
+# a dev branch is no business of this file's.
+check_in "$ON_DEV"  no-commit-to-main.sh ALLOW 'a bare push on a dev branch' \
+  'git push'
+check_in "$ON_DEV"  no-commit-to-main.sh ALLOW 'push of a dev branch' \
+  'git push origin dev-99'
+check_in "$ON_DEV"  no-commit-to-main.sh ALLOW 'commit message naming a push' \
+  'git commit -m "explain how to git push later"'
+check_in "$ON_MAIN" no-commit-to-main.sh ALLOW 'neither a commit nor a push' \
+  'git status'
+check_in "$ON_MAIN" no-commit-to-main.sh BLOCK 'commit after a control word' \
+  'if true; then git commit -m "wip"; fi'
+# A commit message is the one argument here that carries arbitrary prose, so
+# the directory options are matched only where git accepts them. Permitted
+# before the migration for a weaker reason -- they were not matched at all.
+check_in "$ON_DEV"  no-commit-to-main.sh ALLOW 'a commit message naming -C' \
+  'git commit -m "stop matching -C everywhere"'
+# A prefix word the old anchor did not care about, because it looked only for a
+# space in front of `git`. cs_split strips a known wrapper word and its
+# options, and these were not in its list -- so the migration first lost these
+# four, in the permitting direction, and lib/command-scan.sh was corrected
+# rather than the loss being recorded. Found reviewing the migration.
+check_in "$ON_MAIN" no-commit-to-main.sh BLOCK 'sudo in front of a commit on main' \
+  'sudo git commit -m "wip"'
+check_in "$ON_MAIN" no-commit-to-main.sh BLOCK 'timeout, whose operand is not an option' \
+  'timeout 30 git commit -m "wip"'
+check_in "$ON_DEV"  no-commit-to-main.sh BLOCK 'timeout in front of a push to main' \
+  'timeout 30 git push origin main'
+check_in "$ON_DEV"  no-commit-to-main.sh BLOCK 'sudo in front of a push to main' \
+  'sudo git push origin main'
+
+echo "=== no-commit-to-main.sh : what #43 changed, verdict by verdict ==="
+# Written before the migration against the file as it stood, so each `was` is
+# a measurement of the old file and not a guess about it. Reverting the
+# migration fails exactly this section.
+#
+# The first three are the same defect from three directions: the file answered
+# the command-position question itself, with a bare preceding space for an
+# anchor and no notion of a heredoc body. The heredoc case is the one that
+# blocked the writing of issue #36 -- a ticket cannot quote the command it is
+# about. The quoted-string cases are the same false positive the sibling hooks
+# were rebuilt to stop.
+flip "$ON_DEV"  no-commit-to-main.sh BLOCK ALLOW 'heredoc body quoting a push to main' \
+  $'cat >> notes.md <<EOF\ngit push origin main is refused here\nEOF\necho written'
+flip "$ON_MAIN" no-commit-to-main.sh BLOCK ALLOW 'a commit named inside a quoted string' \
+  'echo "never git commit while standing on main"'
+flip "$ON_DEV"  no-commit-to-main.sh BLOCK ALLOW 'a push named inside a quoted string' \
+  'echo "never git push origin main from here"'
+# The branch was read with `git branch --show-current` in the hook's own
+# working directory, which is the session's and not necessarily the command's,
+# while nothing refused a command that changed directory. #40 refused to
+# compute a merge base here for exactly this reason.
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'cd into a repository on main, then commit' \
+  "cd $ON_MAIN && git commit -m 'on main'"
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'GIT_DIR pointed at a repository on main' \
+  "GIT_DIR=$ON_MAIN/.git git commit -m 'on main'"
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'git -C into another repository' \
+  "git -C $ON_MAIN commit -m 'on main'"
+# A wrapper's payload sits in quotes, where the old anchor found no command at
+# all: a wrapped commit was permitted on main itself. Refused outright now,
+# as in both sibling hooks.
+flip "$ON_MAIN" no-commit-to-main.sh ALLOW BLOCK 'sh -c wrapping a commit, on main' \
+  "sh -c 'git commit -m \"wip\"'"
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'eval wrapping a push to main' \
+  'eval "git push origin main"'
+# Matching main by name could not see a spelling that named no branch, which is
+# the hole PR #35 closed in no-git-push.sh and left open here. Both of these
+# advance main from a dev branch.
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'push --all advances main too' \
+  'git push --all origin'
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'push --mirror advances main too' \
+  'git push --mirror origin'
+# The bare-push case rests on configuration, and -c replaces it for this one
+# command: push.default=matching advances main from a dev branch.
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'push with configuration set inline' \
+  'git -c push.default=matching push'
+# HEAD names whatever is checked out, so on main it names main -- and it also
+# counts as a refspec, which switched off the bare-push case that would have
+# caught the same push. `git push -u origin HEAD` is a shape written daily.
+# Found reviewing the migration; no-git-push.sh already resolves HEAD, and
+# this file did not.
+flip "$ON_MAIN" no-commit-to-main.sh ALLOW BLOCK 'push origin HEAD while on main' \
+  'git push origin HEAD'
+flip "$ON_MAIN" no-commit-to-main.sh ALLOW BLOCK 'push -u origin HEAD while on main' \
+  'git push -u origin HEAD'
+flip "$ON_MAIN" no-commit-to-main.sh ALLOW BLOCK 'the @ spelling of HEAD' \
+  'git push origin @'
+check_in "$ON_DEV" no-commit-to-main.sh ALLOW 'HEAD off main still names a dev branch' \
+  'git push origin HEAD'
+# Changing branch defeats the branch read exactly as changing directory does,
+# and is the likelier of the two. Refusing directory moves while permitting
+# this left the soundness claim half-made. Found reviewing the migration.
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'checkout main, then commit' \
+  'git checkout main && git commit -m "wip"'
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'switch to main, then commit' \
+  'git switch main && git commit -m "wip"'
+# git's directory options in their separated spelling. cs_git_args skipped
+# --git-dir only in its = form, so the separated one left the path at the head
+# of the line, the subcommand was never found, and this file left without an
+# opinion -- with `main` written in the command. Found reviewing the migration.
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'separated --git-dir before commit' \
+  "git --git-dir $ON_MAIN/.git commit -m 'on main'"
+flip "$ON_DEV"  no-commit-to-main.sh ALLOW BLOCK 'separated --namespace before a push to main' \
+  'git --namespace n push origin main'
+
+echo "=== the hooks fail closed when the tokeniser is not beside them ==="
+# All three hooks now rest on lib/command-scan.sh, and this one is kept in the
+# tree precisely because it still stands when the broader hook is disabled. An
+# unreadable library left cs_split undefined, the command list empty and every
+# commit on main permitted -- a single point of failure that failed open.
+check_in "$ON_MAIN" "$FIXTURES/nolib/no-commit-to-main.sh" BLOCK 'no lib/, commit on main' \
+  'git commit -m "wip"'
+check_in "$ON_DEV"  "$FIXTURES/nolib/no-commit-to-main.sh" BLOCK 'no lib/, anything at all' \
+  'ls'
+
+echo "=== the refusals still name main, which is why this file is kept ==="
+says "$ON_MAIN" no-commit-to-main.sh 'Blocked: committing to main.' \
+  'a commit on main is refused as a commit on main' 'git commit -m "wip"'
+says "$ON_DEV"  no-commit-to-main.sh 'Blocked: pushing to main.' \
+  'a push to main is refused as a push to main' 'git push origin main'
+says "$ON_MAIN" no-commit-to-main.sh "bare 'git push' while on main" \
+  'the bare push keeps its own wording' 'git push'
+says "$ON_DEV"  no-commit-to-main.sh 'whether it lands on main' \
+  'a directory move says what cannot be judged' "cd $ON_MAIN && git commit -m 'wip'"
 
 echo
 if [ $FAILED -eq 0 ]; then echo "ALL CHECKS PASSED"; else echo "SOME CHECKS FAILED"; fi

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -192,9 +192,30 @@ git push --mirror origin' \
 tok 'environment assignments removed' \
     'git push' \
     "$(printf 'GIT_DIR=/x FOO=1 git push\n' | cs_split)"
+# The wrapper word and its options go, and the tail follows as further
+# candidates -- see the note in cs_split. They cost nothing here: a line that
+# does not begin with a command word matches no rule.
 tok 'wrapper word and its options removed' \
-    'git push --mirror' \
+    'git push --mirror
+push --mirror
+--mirror' \
     "$(printf 'xargs -n1 git push --mirror\n' | cs_split)"
+# The value of a wrapper option that takes one is not an option, so the strip
+# stops in front of it and the command word is no longer at ^. The tail is what
+# finds it.
+tok 'a wrapper option value does not hide the command' \
+    'root git push --all origin
+git push --all origin
+push --all origin
+--all origin' \
+    "$(printf 'sudo -u root git push --all origin\n' | cs_split)"
+# The tail stops at a token opening a quote: what follows is the text of an
+# argument, and a commit message naming a push is not a push.
+tok 'the tail stops where a quoted argument starts' \
+    'git commit -m "git push --all origin"
+commit -m "git push --all origin"
+-m "git push --all origin"' \
+    "$(printf 'sudo git commit -m "git push --all origin"\n' | cs_split)"
 tok 'continuation joined before anything else' \
     'git push   --all origin' \
     "$(printf 'git push \\\n  --all origin\n' | cs_normalise)"
@@ -597,6 +618,27 @@ check no-pr-decisions.sh BLOCK 'sudo before a merge'             'sudo gh pr mer
 # ordinary command that begins with one of these words is still itself.
 check no-git-push.sh     ALLOW 'timeout in front of something else' 'timeout 5 make test'
 check no-git-push.sh     ALLOW 'sudo in front of something else'    'sudo apt-get install jq'
+
+# Found by reviewing PR #49, and the same defect one turn further on. Stripping
+# a wrapper word and its options leaves the value of any option that took one
+# where the command word has to be, so the operand rule above closes `timeout
+# 30` and not `timeout -s KILL 30`, and closes nothing at all for the wrapper
+# words that have no operand rule. cs_split offers the tail as further
+# candidates rather than keeping a third list of which options take a value.
+check no-git-push.sh BLOCK 'sudo with a separated option value'   'sudo -u root git push --all origin'
+check no-git-push.sh BLOCK 'nice with a separated niceness'       'nice -n 10 git push --all origin'
+check no-git-push.sh BLOCK 'ionice with a separated class'        'ionice -c 2 git push --all origin'
+check no-git-push.sh BLOCK 'timeout whose signal took the operand' 'timeout -s KILL 30 git push --all origin'
+check no-git-push.sh BLOCK 'xargs with a separated count'         'xargs -n 1 git push --all origin'
+check no-git-push.sh BLOCK 'env with a separated directory'       'env -C /tmp git push --all origin'
+check no-pr-decisions.sh BLOCK 'sudo with a separated option value, before a merge' \
+  'sudo -u root gh pr merge 5'
+# The tail only ever adds candidates, so an ordinary command that begins with a
+# wrapper word still yields itself and the additions refuse nothing.
+check no-git-push.sh ALLOW 'a wrapper option value in front of something else' \
+  'sudo -u root apt-get install jq'
+check no-git-push.sh ALLOW 'a commit whose message quotes a push, behind a wrapper' \
+  'sudo git commit -m "git push --all origin"'
 
 echo "=== no-commit-to-main.sh : invariants, identical literals across #43 ==="
 # What the migration preserved. These six were written before it, are green on

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -155,6 +155,7 @@ cs_split() {
     {
       line = $0
       sub(/^[[:space:]]+/, "", line)
+      wrapped = 0
       changed = 1
       while (changed) {
         changed = 0
@@ -171,6 +172,7 @@ cs_split() {
           while (match(line, /^-[^[:space:]]*[[:space:]]+/)) {
             line = substr(line, RSTART + RLENGTH)
           }
+          wrapped = 1
           changed = 1
         }
         # timeout and flock take an operand -- a duration, a lock file -- that
@@ -187,11 +189,42 @@ cs_split() {
           if (match(line, /^[^-[:space:]][^[:space:]]*[[:space:]]+/)) {
             line = substr(line, RSTART + RLENGTH)
           }
+          wrapped = 1
           changed = 1
         }
       }
       sub(/[[:space:]]+$/, "", line)
       if (line != "") print line
+      # A wrapper option taking its value as a separate token leaves that value
+      # where the command word has to be, and the command behind it is never at
+      # ^ again: `sudo -u root git push --all origin` left `root`, `nice -n 10`
+      # left `10`, and `timeout -s KILL 30` left `30` even after the operand
+      # strip above took KILL for the duration. Which options take a value is a
+      # list, and two are already kept here -- for the git globals and for the
+      # gh ones -- so a third would be the same answer written a third time,
+      # wrong wherever it is short.
+      #
+      # So the tail is offered as further candidates rather than the head being
+      # trimmed to find one. Offering cannot hide a command; trimming can.
+      # `sudo apt-get install jq` still yields itself, and `install jq` beside
+      # it refuses nothing. It is the rule at the top of this file -- splitting
+      # more eagerly than a shell only ever refuses more -- applied where the
+      # command word cannot be found by looking.
+      #
+      # Three is past the longest real leftover: `timeout -s KILL 30 cmd`
+      # leaves two. A token opening a quote ends it, because what follows is
+      # the text of an argument, and reading text as a command is the mistake
+      # cs_normalise has already made three times.
+      if (wrapped && line != "") {
+        rest = line
+        for (k = 0; k < 3; k++) {
+          if (rest ~ /^["]/ || rest ~ /^[\x27]/) break
+          if (!match(rest, /^[^[:space:]]+[[:space:]]+/)) break
+          rest = substr(rest, RSTART + RLENGTH)
+          if (rest ~ /^["]/ || rest ~ /^[\x27]/) break
+          print rest
+        }
+      }
     }'
 }
 

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Where a command starts, where its arguments end, and how many commands a
-# string holds. Sourced by no-git-push.sh and no-pr-decisions.sh.
+# string holds. Sourced by no-git-push.sh, no-pr-decisions.sh and, since issue
+# #43, no-commit-to-main.sh -- which is every hook that reads a command.
 #
 # This exists because of what the defects in PR #35 turned out to have in
 # common. Every one of them, found by Bertan or by the assistant, was the same
@@ -35,6 +36,19 @@
 # direction, is evidence about the question rather than about the answers: it
 # cannot be got exact by looking more carefully, because that is what the
 # previous two attempts were. The drop is a fail-safe now. See cs_normalise.
+#
+# A fourth review, of the #43 migration, found two more -- both the same shape
+# as the first three, and both here rather than in a hook. A wrapper word was
+# stripped along with its options but not its operand, so `timeout 30 git push
+# --all origin` left a bare `30` where the command word had to be; and sudo,
+# doas, setsid and chronic were not wrapper words at all. Separately,
+# cs_git_args skipped git's own --git-dir, --work-tree, --namespace and
+# --exec-path only in their = spelling, so the separated form hid the
+# subcommand behind its own value and `git --namespace n push origin main` was
+# not a push. Every one was silent, in the permitting direction, and invisible
+# to all three hooks at once. That is what this file is for and also what it
+# keeps costing: the question is answered once, so an answer that is wrong is
+# wrong everywhere.
 #
 # The answers are approximate on purpose. Splitting more eagerly than a shell
 # would yields extra command candidates, which can only refuse more; it never
@@ -152,9 +166,25 @@ cs_split() {
           line = substr(line, RSTART + RLENGTH)
           changed = 1
         }
-        if (match(line, /^(env|command|xargs|nohup|nice|time|stdbuf|ionice)[[:space:]]+/)) {
+        if (match(line, /^(env|command|xargs|nohup|nice|time|stdbuf|ionice|sudo|doas|setsid|chronic)[[:space:]]+/)) {
           line = substr(line, RSTART + RLENGTH)
           while (match(line, /^-[^[:space:]]*[[:space:]]+/)) {
+            line = substr(line, RSTART + RLENGTH)
+          }
+          changed = 1
+        }
+        # timeout and flock take an operand -- a duration, a lock file -- that
+        # is not an option, so stripping only options left it at the head of
+        # the line and the command word behind it was never at ^. That made
+        # `timeout 30 git push --all origin` invisible to every hook. The
+        # operand is stripped with the word, one token and only if it is not
+        # itself an option.
+        if (match(line, /^(timeout|flock)[[:space:]]+/)) {
+          line = substr(line, RSTART + RLENGTH)
+          while (match(line, /^-[^[:space:]]*[[:space:]]+/)) {
+            line = substr(line, RSTART + RLENGTH)
+          }
+          if (match(line, /^[^-[:space:]][^[:space:]]*[[:space:]]+/)) {
             line = substr(line, RSTART + RLENGTH)
           }
           changed = 1
@@ -181,7 +211,7 @@ cs_git_args() {
       line = $0
       if (line !~ /^git([[:space:]]|$)/) next
       sub(/^git[[:space:]]*/, "", line)
-      while (match(line, /^(-[cC][[:space:]]+[^[:space:]]+|--(git-dir|work-tree|namespace|exec-path)=[^[:space:]]*|-[^[:space:]]+)[[:space:]]+/)) {
+      while (match(line, /^(-[cC][[:space:]]+[^[:space:]]+|--(git-dir|work-tree|namespace|exec-path)([[:space:]]+|=)[^[:space:]]*|-[^[:space:]]+)[[:space:]]+/)) {
         line = substr(line, RSTART + RLENGTH)
       }
       if (line !~ "^" want "([[:space:]]|$)") next

--- a/.claude/hooks/no-commit-to-main.sh
+++ b/.claude/hooks/no-commit-to-main.sh
@@ -2,33 +2,258 @@
 # CLAUDE.md: "Sequential dev-NN branches; merge into main by PR only, never
 # commit to main."
 #
-# Two ways to violate that from a shell: commit while standing on main, or
-# push a refspec whose destination is main. Pushing a dev-NN branch from any
-# branch is fine and is not matched here.
+# Two ways to violate that from a shell: commit while standing on main, or push
+# a refspec whose destination is main. Pushing a dev-NN branch from any branch
+# is fine and is not matched here.
+#
+# no-git-push.sh refuses far more pushes than this file does, and would refuse
+# every one this file refuses. This file is kept anyway, for the two reasons it
+# was kept when its siblings were rebuilt on PR #35: the refusal names main and
+# says why main in particular is closed, and it still stands if the broader hook
+# is disabled. Neither reason licensed answering the command-position question
+# here, which is what this file did until issue #43, and what its four defects
+# were made of:
+#
+#   - the anchor was a bare preceding space, so `git commit` inside a quoted
+#     string was a command position -- the same false positive the siblings were
+#     rebuilt to stop
+#   - heredoc bodies were scanned, so a dev-log entry or a ticket quoting
+#     `git push origin main` read as that push. That is not hypothetical: it
+#     blocked the writing of issue #36, which is about these hooks
+#   - no shell wrapper and no directory change was refused, and yet the branch
+#     was read with `git branch --show-current` in the hook's own working
+#     directory rather than the command's
+#   - main was matched by name, so a spelling naming no branch was invisible:
+#     `git push --all origin` advances main from any branch and was permitted
+#
+# The third of those is why the migration was scheduled rather than left
+# unscheduled. #40 refused to compute a merge base in a hook for exactly that
+# reason -- the hook's directory is the session's and not necessarily the
+# command's. Refusing what moves the command elsewhere is what makes reading the
+# branch here sound at all, and it is what the two siblings already do.
+#
+# Behaviour is not preserved by that migration, because this file's behaviour
+# included those defects. What is preserved is its purpose, and the classes of
+# check in check-hooks.sh are the difference: sixteen invariants written in
+# identical literals on both sides, eighteen verdicts that flipped, two that
+# this file refuses rather than permits when its library is not beside it, and
+# four that name the refusal it has to give.
+#
+# Not covered, and deliberately: `git merge`, `git rebase`, `git cherry-pick`
+# and `git revert` put commits on main without a `git commit`, and none of them
+# is matched here or was before. `git merge --no-ff dev-NN` on main is the
+# nearest miss -- it is the thing the file is named after, and it is the
+# server-side ruleset on main, not this hook, that refuses it.
+#
+# This stops mistakes, not adversaries. The stopping rule in no-git-push.sh
+# governs here too: a shape an agent would plausibly write earns a fix, a
+# payload it would have to construct does not.
+#
+# Sourced, not assumed. All three hooks rest on this file now, and this one is
+# kept in the tree because it still stands when the broader hook is disabled --
+# which it would not if an unreadable library left cs_split undefined, the
+# command list empty and every commit on main permitted. A guard's own breakage
+# refuses; it does not wave things through.
+#
+# The file is tested for before it is sourced, and the functions after: a
+# missing file makes `.` end the shell where an `if` around it never runs, so
+# the guard would have been a comment.
+LIB="$(dirname "$0")/lib/command-scan.sh"
+[ -r "$LIB" ] && . "$LIB"
+if ! command -v cs_split >/dev/null 2>&1; then
+  echo "Blocked: no-commit-to-main.sh could not load lib/command-scan.sh, so it cannot tell whether this command touches main. Refusing rather than permitting." >&2
+  exit 2
+fi
+
+# The refspec loop below splits with `for TOK in $ARGS`, unquoted because the
+# split is the point; that would also glob the tokens against the worktree.
+# Nothing here needs pathname expansion.
+set -f
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+SCAN=$(printf '%s\n' "$COMMAND" | cs_normalise)
+CMDS=$(printf '%s\n' "$SCAN" | cs_split)
+
+COMMIT_REFUSE="Blocked: committing to main. CLAUDE.md requires sequential dev-NN branches, merged into main by PR only. Create or switch to a dev-NN branch first."
+PUSH_REFUSE="Blocked: pushing to main. CLAUDE.md requires that main is only ever updated by pull request. Push your dev-NN branch and open a PR instead."
+ELSEWHERE_REFUSE="Blocked: this command moves git somewhere else before committing or pushing, so whether it lands on main cannot be judged from here. CLAUDE.md closes main to everything but a pull request. Run it plainly, from the branch it belongs on."
+
+# A commit or a push inside a wrapper is refused outright, as in both siblings.
+# The payload sits in quotes where no command position exists, so neither a
+# push's destination nor the directory a commit would run in can be read, and
+# main cannot be ruled out. Matched on the raw command -- quotes and heredoc
+# bodies included -- because that is where the payload still is, and asked
+# before whether there is a commit or a push at all, because a wrapped one has
+# no command word for the tokeniser to find.
+#
+# The trade, taken knowingly: an `sh -c` anywhere in a command that also commits
+# plainly is refused for the company it keeps. That is the direction this file
+# takes throughout -- a blocked command is visible and one edit away.
+if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))' \
+   && echo "$COMMAND" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?(commit|push)([^-A-Za-z0-9_]|$)'; then
+  echo "Blocked: git commit or push inside a shell wrapper. Whether it lands on main cannot be read through a quoted payload. Run it plainly." >&2
+  exit 2
+fi
+
+# Is there a commit or a push here at all? Anything else costs one pass and
+# leaves without an opinion -- including every `cd` this file has no business
+# refusing.
+HAVE=
+while IFS= read -r CMD; do
+  if cs_git_args commit <<<"$CMD" >/dev/null || cs_git_args push <<<"$CMD" >/dev/null; then
+    HAVE=1
+    break
+  fi
+done <<CMDLIST
+$CMDS
+CMDLIST
+[ -n "$HAVE" ] || exit 0
+
+# The branch below is read where this hook runs, which is the session's
+# directory and not necessarily the command's. Everything that could make those
+# two differ is refused first, which is what makes the read sound. The
+# environment spellings come from the un-split text, because cs_split removes
+# assignments to find the command word behind them.
+if printf '%s\n' "$CMDS" | grep -qE '^(cd|pushd|popd)([^-A-Za-z0-9_]|$)'; then
+  echo "$ELSEWHERE_REFUSE" >&2
+  exit 2
+fi
+if echo "$SCAN" | grep -qE '(GIT_DIR|GIT_WORK_TREE|GIT_COMMON_DIR)='; then
+  echo "$ELSEWHERE_REFUSE" >&2
+  exit 2
+fi
+
+# Changing branch defeats the branch read exactly as changing directory does,
+# and is much the likelier of the two: `git checkout main && git commit` is a
+# shape an agent writes without meaning anything by it. Refusing the directory
+# half while permitting this one left the soundness claim above half-made.
+#
+# The trade: `git checkout -b spike && git commit -m x` is refused although it
+# lands nowhere near main. Two commands instead of one, and visible.
+while IFS= read -r CMD; do
+  if cs_git_args checkout <<<"$CMD" >/dev/null || cs_git_args switch <<<"$CMD" >/dev/null; then
+    echo "$ELSEWHERE_REFUSE" >&2
+    exit 2
+  fi
+done <<CMDLIST
+$CMDS
+CMDLIST
+
+# git's own directory options, matched only where git accepts them -- in front
+# of the subcommand. Matching them anywhere on the line, which is what the
+# sibling does for a push, would read `git commit -m "drop the -C flag"` as a
+# redirection; a commit message is the one argument on this path that carries
+# arbitrary prose.
+ELSEWHERE_OPT='^git[[:space:]]+(-[cC][[:space:]]+[^[:space:]]+[[:space:]]+|--(git-dir|work-tree|namespace|exec-path)=[^[:space:]]*[[:space:]]+|-[^[:space:]]+[[:space:]]+)*(-C|--git-dir|--work-tree)([[:space:]]|=)'
 
 BRANCH=$(git branch --show-current 2>/dev/null)
 
-if echo "$COMMAND" | grep -qE '(^|[;&|]|\s)git\s+(-[^ ]+\s+)*commit(\s|$)'; then
-  if [ "$BRANCH" = "main" ]; then
-    echo "Blocked: committing to main. CLAUDE.md requires sequential dev-NN branches, merged into main by PR only. Create or switch to a dev-NN branch first." >&2
-    exit 2
-  fi
-fi
+# One push's arguments. Returns 1 with a reason on stderr if its destination is
+# main, or cannot be shown not to be.
+check_push() {
+  local ARGS="$1" TOK SPEC DST SKIP REMOTE_SEEN REFSPEC_SEEN
 
-# Destination-side match: `git push origin main`, `git push origin HEAD:main`,
-# `git push -f origin main`. The refspec's destination is what matters, so a
-# trailing :main counts and a leading main: (source side) does not.
-if echo "$COMMAND" | grep -qE '(^|[;&|]|\s)git\s+(-[^ ]+\s+)*push(\s|$)'; then
-  if echo "$COMMAND" | grep -qE '(\s|:)main(\s|$)'; then
-    echo "Blocked: pushing to main. CLAUDE.md requires that main is only ever updated by pull request. Push your dev-NN branch and open a PR instead." >&2
-    exit 2
+  # These name no branch and advance every one, main included. Refusing main by
+  # name could not see them, which is the same hole PR #35 closed in
+  # no-git-push.sh; --tags is left alone, because it cannot move a branch.
+  if printf ' %s ' "$ARGS" | grep -qE '[[:space:]](--all|--mirror)([[:space:]]|=|$)'; then
+    echo "$PUSH_REFUSE That form pushes every branch, main among them." >&2
+    return 1
   fi
-  if [ "$BRANCH" = "main" ] && echo "$COMMAND" | grep -qE 'git\s+(-[^ ]+\s+)*push\s*($|[;&|])'; then
+
+  # A backslash the join did not consume means the arguments continue past
+  # where this can read them. An unreadable argument list must not be allowed
+  # to look like an empty one, which is the bare push judged on the branch.
+  if printf '%s' "$ARGS" | grep -q '\\[[:space:]]*$'; then
+    echo "$PUSH_REFUSE The arguments continue past where this check can read them." >&2
+    return 1
+  fi
+
+  if printf '%s' "$ARGS" | grep -q '[*]'; then
+    echo "$PUSH_REFUSE A wildcard refspec does not rule main out." >&2
+    return 1
+  fi
+
+  SKIP=
+  REMOTE_SEEN=
+  REFSPEC_SEEN=
+  for TOK in $ARGS; do
+    if [ -n "$SKIP" ]; then SKIP=; continue; fi
+    case "$TOK" in
+      -o|--push-option|--repo|--receive-pack|--exec) SKIP=1; continue ;;
+      -*) continue ;;
+    esac
+    # The first bare token is the remote. Which remote it is belongs to
+    # no-git-push.sh; this file only asks what the refspecs name.
+    if [ -z "$REMOTE_SEEN" ]; then REMOTE_SEEN=1; continue; fi
+    REFSPEC_SEEN=1
+    # A leading + forces; the destination is what it says either way. The
+    # destination is the half after the colon, so `main:spike` names spike and
+    # `HEAD:main`, `:main` and `refs/heads/main` all name main.
+    SPEC=${TOK#+}
+    case "$SPEC" in
+      *:*) DST=${SPEC#*:} ;;
+      *)   DST=$SPEC ;;
+    esac
+    # HEAD names whatever is checked out, so on main it names main. Comparing
+    # the literal text let `git push -u origin HEAD` through from main -- and
+    # worse, HEAD counts as a refspec, so it also switched off the bare-push
+    # case below that would otherwise have caught the same push.
+    case "$DST" in
+      HEAD|@|refs/heads/HEAD) DST=$BRANCH ;;
+    esac
+    case "${DST#refs/heads/}" in
+      main)
+        echo "$PUSH_REFUSE" >&2
+        return 1 ;;
+    esac
+  done
+
+  # A push naming no refspec takes its destination from configuration, and on
+  # main every default spelling of it pushes main. Off main this file says
+  # nothing: a configured refspec could still name main, and answering that
+  # would mean reading configuration a command can set for itself. That is
+  # no-git-push.sh's answer to make -- it requires the branch to be named
+  # outright -- and this file is not the place to re-derive it.
+  if [ -z "$REFSPEC_SEEN" ] && [ "$BRANCH" = "main" ]; then
     echo "Blocked: bare 'git push' while on main pushes main. CLAUDE.md requires that main is only ever updated by pull request." >&2
-    exit 2
+    return 1
   fi
-fi
+
+  return 0
+}
+
+# Every commit and every push, not the first of each: `git push origin spike &&
+# git push origin main` is refused on its second half.
+while IFS= read -r CMD; do
+  if cs_git_args commit <<<"$CMD" >/dev/null; then
+    if printf '%s' "$CMD" | grep -qE "$ELSEWHERE_OPT"; then
+      echo "$ELSEWHERE_REFUSE" >&2
+      exit 2
+    fi
+    if [ "$BRANCH" = "main" ]; then
+      echo "$COMMIT_REFUSE" >&2
+      exit 2
+    fi
+  fi
+  if ARGS=$(cs_git_args push <<<"$CMD"); then
+    if printf '%s' "$CMD" | grep -qE "$ELSEWHERE_OPT"; then
+      echo "$ELSEWHERE_REFUSE" >&2
+      exit 2
+    fi
+    # -c and --config-env set configuration for this one command, including the
+    # push defaults the bare-push case rests on: `git -c push.default=matching
+    # push` advances main from a dev branch. Reading the value back cannot close
+    # that, because the command has already replaced it.
+    if printf '%s' "$CMD" | grep -qE '^git[[:space:]]+(-[^[:space:]]+[[:space:]]+[^[:space:]-][^[:space:]]*[[:space:]]+|-[^[:space:]]+[[:space:]]+)*(-c|--config-env)([[:space:]]|=)'; then
+      echo "$PUSH_REFUSE This command sets git configuration for itself, which decides where a push lands." >&2
+      exit 2
+    fi
+    check_push "$(printf '%s' "$ARGS" | tr -d '\042\047')" || exit 2
+  fi
+done <<CMDLIST
+$CMDS
+CMDLIST
 
 exit 0


### PR DESCRIPTION
Closes #43.

`no-commit-to-main.sh` was the last hook answering the command-position
question on its own terms. It now sources `lib/command-scan.sh`, like the two
rebuilt on PR #35.

## The evidence is the difference between two classes of check, not a green run

Behaviour is **not** preserved — this file's behaviour included its defects.
Its purpose is, and `check-hooks.sh` now separates the two:

- **16 invariants**, written before the migration in identical literals and
  green on both sides of it: a commit on `main` refused, a commit on a dev
  branch permitted, a destination of `main` refused in three spellings, a
  source-side `main:` permitted, a bare push while on `main` refused.
- **18 flipped verdicts**, each carrying the verdict it measured against the
  old file — `ok ALLOW (was BLOCK)`. Red before the migration, green after.

Three of the invariants and one of the flips depend on which branch is checked
out where the hook runs, so those run with the hook's working directory inside
a throwaway repository created on `main` or on a dev branch. `git branch
--show-current` reports an unborn branch, so the fixtures need no commits.

**Mutation-checked twice.** Reverting the hook alone fails the 18 flips, each
with `got` equal to its recorded `was`, and no invariant — plus two checks that
are neither, `no lib/, anything at all` and one message check, so the count is
20 rather than 18. Reverting
`lib/command-scan.sh` alone fails exactly the 11 checks that pin its two fixes.

## What changed in the hook

Heredoc bodies are no longer scanned, so a ticket or a dev-log entry quoting a
refused command is not that command — which is what blocked the writing of #36.
A quoted string is not a command position. Shell wrappers, directory changes
and directory redirections are refused, consistent with the siblings; so are
**branch** changes, which defeat the branch read in the likelier way. Spellings
that name no branch — `--all`, `--mirror` — are refused rather than looked past.

The branch is still read where the hook runs, which is the session's directory
and not necessarily the command's. What makes that sound is not a better read
but the refusals in front of it. That is what #40 was waiting for.

## A review of the migration found eight more permitting verdicts

Seven were shapes an agent writes without meaning anything by them. Four were
fixed in the hook — `git push -u origin HEAD` from `main` named `main` and, by
counting as a refspec, also switched off the bare-push case; a branch change was
not refused; the file permitted everything when its library was not beside it, a
single point of failure that failed **open**; the header's counts were wrong.

Four were fixed in `lib/command-scan.sh`, where they were holes in **every** hook
at once, `no-git-push.sh` included:

- a wrapper word's operand was not stripped, so `timeout 30 git push --all
  origin` left a bare `30` where the command word had to be
- `sudo`, `doas`, `setsid`, `chronic` were not wrapper words at all
- git's `--git-dir`, `--work-tree`, `--namespace`, `--exec-path` were skipped
  only in their `=` spelling, so the separated form hid the subcommand behind
  its own value and `git --namespace n push origin main` was not a push

Each is pinned by a check that fails without the fix.

## Trades taken knowingly, all in the refusing direction

An `sh -c` anywhere in a command that also commits plainly is refused for the
company it keeps; `git checkout -b spike && git commit` is refused although it
lands nowhere near `main`; a push naming `--all` or `--mirror` is refused from
any branch. A blocked command is visible and one edit away.

## Not covered, and now said so in the header

`git merge`, `git rebase`, `git cherry-pick` and `git revert` put commits on
`main` without a `git commit`, and none of them is matched here or was before.
`git merge --no-ff dev-NN` on `main` is the nearest miss; the server-side
ruleset refuses it, not this hook.

## Checks

`bash .claude/hooks/check-hooks.sh` — **all passing.** Measured on this branch
it is 207 → 266; merged onto `dev-05`, which has moved by #46 and #48 since this
branch was cut, it is 221 → **280**. No Python
changed; `make test` is 571 passed / 5 xfailed, with the one pre-existing
`test_environment_sync` failure (the `migrations` group is not installed in
`.venv`), untouched by this branch.

https://claude.ai/code/session_01Xd9V6GEHW7hAiBW2EALedU



## Added in review: the wrapper fix was short by one turn

Stripping a wrapper word and its options leaves the value of any option that
took one exactly where the command word has to be. The operand rule above closes
`timeout 30` and not `timeout -s KILL 30`, whose `-s` consumes `KILL` and leaves
the duration behind; and it closes nothing at all for the wrapper words that
have no operand rule. Six shapes were still permitted after the migration, none
of them a regression and all of them the same shape it fixes:

```
PERMITTED  sudo -u root git push --all origin
PERMITTED  nice -n 10 git push --all origin
PERMITTED  ionice -c 2 git push --all origin
PERMITTED  timeout -s KILL 30 git push --all origin
PERMITTED  xargs -n 1 git push --all origin
PERMITTED  env -C /tmp git push --all origin
```

Which options take a separate value is a list, and this file already keeps two
of them — for the git globals and for the gh ones — so a third would be the same
answer written a third time, wrong wherever it is short. `cs_split` offers the
tail as further candidates instead: three at most, stopping at a token that
opens a quote, and only on a line where a wrapper word was actually consumed.
Offering cannot hide a command, which trimming the head can — `sudo apt-get
install jq` still yields itself — and it is the rule already stated at the top
of the file, that splitting more eagerly than a shell only ever refuses more.

Eleven checks: three at the `cs_split` seam pinning the tail, its stop at a
quoted argument and the moved literal for the existing wrapper check, seven
verdicts for the shapes above, and two that pin what stays allowed. Disabling
the tail turns exactly those eleven red and no other.
