### PR TITLE
Record why the OpenRouter key is left wrapped in the roster entry

### DIFF
--- a/src/llm_config.py
+++ b/src/llm_config.py
@@ -88,6 +88,22 @@ def get_llm_config():
     # provider it has no alias for. Before adding a panelist, check the alias
     # dict for the *provider*, not just the model.
     provider = LlmServers.OPENROUTER
+    # Left wrapped, deliberately. `OPENROUTER_API_KEY` is a `SecretStr` and goes
+    # into every roster entry below still wrapped; `get_llm` is handed it as-is,
+    # and nothing here unwraps it. So an entry renders as
+    # `{'model': ..., 'api_key': SecretStr('**********')}` under str(), an
+    # f-string and %s alike.
+    #
+    # Nothing prints a whole entry today -- the ten probe and eval sites that
+    # report a model all print `entry["model"]` alone -- and that is exactly why
+    # calling `.get_secret_value()` here would be a silent change: no test and no
+    # output would differ, and the masking would be gone from every future
+    # rendering, including a traceback that shows the dict.
+    #
+    # It is also why CodeQL's py/clear-text-logging-sensitive-data on
+    # `probe_three_shape_pool.py` is a false positive. It taints the whole entry
+    # and flags the line that logs `entry["model"]` -- a ModelNames enum -- while
+    # the field it is tainted by is masked anyway.
     api_key = settings.OPENROUTER_API_KEY
 
     # Every panelist runs on the same settings, so that a disagreement between


### PR DESCRIPTION
A comment, and nothing else.

`OPENROUTER_API_KEY` is a `SecretStr`, and `llm_config.py` puts it into every
roster entry **still wrapped** — `get_llm` is handed it as-is and nothing in this
repository unwraps it. So an entry renders as
`{'model': ..., 'api_key': SecretStr('**********')}` under `str()`, an f-string
and `%s` alike.

Nothing depends on that today: the ten probe and eval sites that report a model
all print `entry["model"]` alone, never the dict. Which is precisely the risk.
Calling `.get_secret_value()` at line 91 looks like a tidy-up — every consumer
needs the raw string eventually — and **no test and no output would change if
someone did it**, while the masking would be gone from every future rendering, a
traceback showing the dict included.

The comment also records why CodeQL's `py/clear-text-logging-sensitive-data` on
`scripts/probe_three_shape_pool.py:833` is a false positive, so the next person
does not re-derive it: the whole entry is tainted, the flagged line logs a
`ModelNames` enum, and the field the taint comes from is masked anyway. Two
independent reasons it cannot leak.

## Why this is a comment and not a change

The defence is already in place and deliberate. Removing the key from the entry
was considered and dropped: `api_key` is a field of the roster contract read at
five call sites and passed into `ai_common.get_llm`, so taking it out is a
cross-cutting change bought for no defect.

## Checks

`uv run --group test pytest tests/test_llm_config.py` — 5 passed. No behaviour
changed; the file compiles and the diff is 16 comment lines.

## Provenance

Found while reviewing #49. That pull request's CodeQL run failed only because it
was briefly based on `main`, which made its diff 31 commits wide and pulled this
pre-existing line into "code changed by this pull request". `dev-05` carries no
open code-scanning alerts.

https://claude.ai/code/session_01XRX8DS8KXhZKppc86hFk97
