### PR TITLE
Ask cs_gh_args where a gh subcommand is, in every rule that has one

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -367,6 +367,64 @@ check no-pr-decisions.sh BLOCK 'gh release --repo o/r create v1' 'gh release --r
 check no-pr-decisions.sh ALLOW 'gh pr --repo o/r view 35'       'gh pr --repo o/r view 35'
 check no-pr-decisions.sh ALLOW 'gh pr --repo o/r list'          'gh pr --repo o/r list'
 
+echo "=== REGRESSION: #47, a flag before the group evaded every gh rule ==="
+# The same question one level up, and it had been applied at one level only.
+# GHPR and GHRELEASE skipped options between the group and the verb and never
+# before the group; the two gh api matches skipped none at all. Every BLOCK in
+# this block was PERMITTED by the hook on dev-05, and all but the release are a
+# decision on a pull request. -R/--repo before the group is not an evasion an
+# agent has to construct -- it is the ordinary way to work on a repository from
+# elsewhere. The same flag in front of a wrapped command is still permitted;
+# that is issue #51, and no check here claims otherwise.
+check no-pr-decisions.sh BLOCK 'gh -R o/r pr merge 5'          'gh -R o/r pr merge 5'
+check no-pr-decisions.sh BLOCK 'gh --repo o/r pr merge 5'      'gh --repo o/r pr merge 5'
+check no-pr-decisions.sh BLOCK 'gh -R o/r pr close 5'          'gh -R o/r pr close 5'
+check no-pr-decisions.sh BLOCK 'gh -R o/r pr reopen 5'         'gh -R o/r pr reopen 5'
+check no-pr-decisions.sh BLOCK 'gh -R o/r pr review 5 --approve' 'gh -R o/r pr review 5 --approve'
+check no-pr-decisions.sh BLOCK 'gh -R o/r release create v1'   'gh -R o/r release create v1'
+check no-pr-decisions.sh BLOCK 'gh --hostname h api -X PUT merge' 'gh --hostname h api -X PUT repos/o/r/pulls/5/merge'
+check no-pr-decisions.sh BLOCK 'gh -R o/r api graphql merge in a heredoc' $'gh -R o/r api graphql -f query=@- <<EOF\nmutation { mergePullRequest(input:{pullRequestId:"x"}) { clientMutationId } }\nEOF'
+# The verdict is matched against the arguments cs_gh_args returns, which are
+# this command's own, so it no longer has to say "in the same command as the
+# subcommand" as a regular expression -- and the flag may be the first argument
+# with no space in front of it, which a pattern requiring one would miss.
+check no-pr-decisions.sh BLOCK 'verdict as the first argument'    'gh -R o/r pr review -a 5'
+check no-pr-decisions.sh BLOCK 'bundled verdict, first argument'  'gh -R o/r pr review -ab lgtm 5'
+# A flag before the group does not make an ordinary subcommand a decision.
+check no-pr-decisions.sh ALLOW 'gh -R o/r pr view 5'           'gh -R o/r pr view 5'
+check no-pr-decisions.sh ALLOW 'gh -R o/r pr list'             'gh -R o/r pr list'
+check no-pr-decisions.sh ALLOW 'gh -R o/r pr create --fill'    'gh -R o/r pr create --fill'
+check no-pr-decisions.sh ALLOW 'gh -R o/r pr edit 5 --title x' 'gh -R o/r pr edit 5 --title x'
+check no-pr-decisions.sh ALLOW 'gh -R o/r pr review --comment' 'gh -R o/r pr review --comment -b x 5'
+check no-pr-decisions.sh ALLOW 'gh -R o/r release list'        'gh -R o/r release list'
+# A path word is matched whole, so `release delete` does not cover
+# `release delete-asset` the way the old alternation did. The regular
+# expression carried delete-asset and nothing asked about it; the rule that
+# replaced it names it separately, and this is what would notice if it stopped.
+check no-pr-decisions.sh BLOCK 'gh release delete-asset'       'gh release delete-asset v1.0.0 file.tgz'
+check no-pr-decisions.sh BLOCK 'gh -R o/r release delete-asset' 'gh -R o/r release delete-asset v1.0.0 file.tgz'
+check no-pr-decisions.sh ALLOW 'gh -R o/r api reads a PR'      'gh -R o/r api repos/o/r/pulls/5'
+check no-pr-decisions.sh ALLOW 'gh -R o/r issue close 27'      'gh -R o/r issue close 27'
+
+echo "=== REGRESSION: #47, a second gh command after ; or && is examined ==="
+# Every rule feeds cs_gh_args one command at a time. These three pin that a
+# second command is reached at all: a loop that stopped at the first command,
+# or at the first that is not a match, permits every one of them.
+check no-pr-decisions.sh BLOCK 'a release list, then a create'      'gh release list; gh release create v1'
+check no-pr-decisions.sh BLOCK 'a read api call, then a write'      'gh api repos/o/r/pulls/5 && gh api -X PUT repos/o/r/pulls/5/merge'
+check no-pr-decisions.sh BLOCK 'a pr create, then a merge'          'gh pr create --fill && gh pr merge 5'
+
+echo "=== REGRESSION: #47, cs_gh_args answers about the first match and stops ==="
+# What the three above do NOT pin, and were written believing they did. The
+# helper scans past a command that is not a match, so for a rule with no
+# argument expression the per-command loop and one whole-list call find the
+# same thing and the mutation is invisible. It is a rule *with* one that needs
+# the loop: the first match's arguments come back and a later command's are
+# never seen, so handing cs_gh_args the whole list reads this as the --comment
+# alone and permits the approval. Measured, not reasoned -- the whole-list
+# mutation fails this line and only this line.
+check no-pr-decisions.sh BLOCK 'a comment review, then an approval' 'gh pr review --comment -b x 5 && gh pr review -a 6'
+
 echo "=== REGRESSION: review of 02a14d8, close and release through gh api ==="
 # Closing a PR and publishing a release were refused in the gh spelling and open
 # through gh api, so the boundary was spelling-dependent exactly where the file

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -208,8 +208,14 @@ cs_git_args() {
 # between the group and the verb and never before the group, so `gh -R o/r pr
 # merge 5` was permitted while `gh pr --repo o/r merge 5` was refused. Issue #47
 # moved that file's merge, review, close, reopen, release and gh api rules onto
-# this function and deleted GHPR and GHRELEASE, so the question is answered here
-# and in no second place.
+# this function and deleted GHPR and GHRELEASE, so among the rules over ordinary
+# commands the question is answered here and in no second place. Not among all
+# of them: that file's wrapper rules match raw text, because a quoted payload
+# has no command word to find, and they still answer it themselves and still
+# answer it one level too late. Issue #51 carries that, and the header of
+# no-pr-decisions.sh says so rather than denying it -- which is the reason to
+# say it here too, since this is where a reader comes to find out whether the
+# question is settled.
 #
 # The exit status is what distinguishes `gh pr create` -- a create whose
 # argument list is empty, which is exactly the shape that lets gh choose the

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -202,12 +202,14 @@ cs_git_args() {
 # Cobra resolves each level at the first non-flag argument, so a flag may sit
 # between the group and the verb and `gh pr --repo o/r create` still creates;
 # -R/--repo and --hostname take their value as a separate token, which has to be
-# consumed with them or the value reads as the verb and hides it. That is the
-# same shape the GHPR pattern in no-pr-decisions.sh answers with a regular
-# expression of its own. So the question is answered in both places for now, and
-# will stay so while GHPR still carries the merge, review, close and reopen
-# rules; this is the answer the next rule is built on rather than a fourth
-# regular expression, which is the whole reason for adding it before its caller.
+# consumed with them or the value reads as the verb and hides it. That was the
+# same shape the GHPR pattern in no-pr-decisions.sh answered with a regular
+# expression of its own -- and answered one level too late, skipping options
+# between the group and the verb and never before the group, so `gh -R o/r pr
+# merge 5` was permitted while `gh pr --repo o/r merge 5` was refused. Issue #47
+# moved that file's merge, review, close, reopen, release and gh api rules onto
+# this function and deleted GHPR and GHRELEASE, so the question is answered here
+# and in no second place.
 #
 # The exit status is what distinguishes `gh pr create` -- a create whose
 # argument list is empty, which is exactly the shape that lets gh choose the
@@ -230,7 +232,7 @@ cs_git_args() {
 # it is the kind that gets discovered rather than read, and closing it would
 # need a check written against a caller that does not exist.
 #
-# It is written before the rule that uses it, so what it is for is worth saying:
+# It was written before the rule that used it, so what it is for is worth saying:
 # asking whether a flag belongs to *this* command is argument scoping, and
 # scoping answered ad hoc is where two of the five defects above came from --
 # the whole line read an unrelated option as the command's own, and the

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -24,11 +24,27 @@
 # method nor anything else can be read out of it. A read of a PR wrapped in a
 # shell is refused with the writes. Run it unwrapped.
 #
-# Finding commands in the text is lib/command-scan.sh's job. Each line it
-# returns is one command with everything before the command word removed, so
-# every rule below anchors at ^ and none of them describes a command position.
+# Finding commands in the text is lib/command-scan.sh's job, and so is finding
+# the subcommand inside one: cs_split returns one command per line with
+# everything before the command word removed, and cs_gh_args then names a gh
+# subcommand by its whole path and hands back that command's own arguments. No
+# rule that goes through gh_rule describes a command position or anchors at ^.
 # That is where all of PR #35's defects lived, this file's included: it was the
-# sibling that had the wrapper rule, and this one that did not.
+# sibling that had the wrapper rule, and this one that did not. It was also, for
+# longer, the file that answered the position question one word too late; see
+# gh_rule.
+#
+# Two things here are still position-dependent, and neither is an oversight of
+# the same kind. VERDICT anchors at ^, but at the start of a command's own
+# argument list rather than at a command word -- the opposite of a position
+# question, and why it can be written there at all. The wrapper rules below do
+# describe one, and that is a known open hole rather than a design: they require
+# the group to follow gh immediately, so `bash -c "gh -R o/r pr merge 5"` is
+# permitted while `bash -c "gh pr merge 5"` is refused. Measured, pre-existing,
+# and not fixable the way the rules above were -- a quoted payload has no
+# command word for cs_gh_args to find, which is the whole reason these are a
+# blunt text match. Issue #51 carries it, and the question it has to settle is
+# whether naming the verb inside a wrapper is worth doing at all.
 #
 # STOPPING RULE. A newly found evasion earns a fix only if it is a shape an
 # agent would plausibly write, not one it would have to construct. A flag
@@ -44,27 +60,61 @@
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 SCAN=$(printf '%s\n' "$COMMAND" | cs_normalise)
-
-# gh api reading a heredoc is a decision hiding in text that was just dropped --
-# a heredoc is the ordinary way to send a graphql mutation. The raw command is
-# re-admitted for that shape alone.
-if printf '%s\n' "$SCAN" | cs_split | grep -qE '^gh[[:space:]]+api([^-A-Za-z0-9_]|$)' \
-   && echo "$COMMAND" | grep -q '<<'; then
-  SCAN="$SCAN
-$COMMAND"
-fi
 CMDS=$(printf '%s\n' "$SCAN" | cs_split)
 
 DECIDE="Blocked: deciding a pull request is Bertan's call, not an agent's. Opening a PR, commenting on it and editing it are allowed; accepting, rejecting, merging and reopening are not."
 
-# `gh pr merge` is not the only way to write `gh pr merge`. Cobra resolves the
-# subcommand at the first non-flag argument, so a flag may sit in front of it:
-# `gh pr --repo o/r merge 35` merges, and every rule here wanted the subcommand
-# as the third word. -R/--repo takes its value as a separate token and has to
-# consume it, or the value would be read as the subcommand. Written once and
-# interpolated, so the group and the verb are still all a rule has to name.
-GHPR='^gh[[:space:]]+pr([[:space:]]+((-R|--repo|--hostname)[[:space:]]+[^[:space:]]+|-[^[:space:]]+))*[[:space:]]+'
-GHRELEASE='^gh[[:space:]]+release([[:space:]]+((-R|--repo|--hostname)[[:space:]]+[^[:space:]]+|-[^[:space:]]+))*[[:space:]]+'
+# Every rule over an ordinary command asks through here, and none of them
+# describes where in a command the subcommand sits. The two that do not are the
+# wrapper block, which has no command word to find and is discussed in the
+# header, and the API_WRITE loop, which needs the command itself and says why.
+#
+# cs_gh_args answers the position question: it skips options before every word
+# of the path, so `gh -R o/r pr merge 5`, `gh pr --repo o/r merge 5` and
+# `gh pr merge 5` are one command to every rule below.
+#
+# That is what this file got wrong for as long as it had rules. GHPR and
+# GHRELEASE skipped options between the group and the verb and never before it,
+# and the two gh api matches were raw `^gh[[:space:]]+api` skipping none at all,
+# so a single flag written first walked past all four rules -- six of the nine
+# shapes in #47's table were a merge. The comment above GHPR stated the
+# principle that GHPR then applied at one level only. The helper is #39's.
+#
+# One command at a time, because cs_gh_args answers about the first match and
+# stops. Worth being exact about when that matters, because three checks were
+# written here believing it mattered always: the helper scans past a command
+# that is not a match, so for a rule with no ARGRE the loop and one whole-list
+# call find the same thing. It is a rule *with* ARGRE that needs the loop --
+# there the first match's arguments come back and a later command's are never
+# seen, so `gh pr review --comment -b x 5 && gh pr review -a 6` would read as
+# the comment alone. no-git-push.sh loops the same way over cs_git_args.
+#
+# ARGRE, when given, is matched against the arguments cs_gh_args returns -- and
+# those are that command's own, so a rule that used to have to express "in the
+# same command as the subcommand" as a regular expression now expresses nothing
+# about position at all.
+gh_rule() {  # gh_rule <subcommand path> [<extended regex over that command's arguments>]
+  local WANT="$1" ARGRE="$2" CMD ARGS
+  while IFS= read -r CMD; do
+    ARGS=$(cs_gh_args "$WANT" <<<"$CMD") || continue
+    if [ -n "$ARGRE" ]; then
+      printf '%s\n' "$ARGS" | grep -qE "$ARGRE" || continue
+    fi
+    return 0
+  done <<CMDLIST
+$CMDS
+CMDLIST
+  return 1
+}
+
+# gh api reading a heredoc is a decision hiding in text that was just dropped --
+# a heredoc is the ordinary way to send a graphql mutation. The raw command is
+# re-admitted for that shape alone, and the split redone over what it added.
+if gh_rule api && echo "$COMMAND" | grep -q '<<'; then
+  SCAN="$SCAN
+$COMMAND"
+  CMDS=$(printf '%s\n' "$SCAN" | cs_split)
+fi
 
 # The verdict flags, bundled or not. gh takes shorthand flags together, so
 # `gh pr review -ab "lgtm" 35` is --approve --body and was allowed while
@@ -72,7 +122,12 @@ GHRELEASE='^gh[[:space:]]+release([[:space:]]+((-R|--repo|--hostname)[[:space:]]
 # this file had not -- the same asymmetry twice. Only single-dash bundles are
 # scanned for a or r: a long flag would match on any letter it happens to
 # contain, and --repo would read as --request-changes.
-VERDICT='[[:space:]](--approve|--request-changes|-[A-Za-z]*[ar][A-Za-z]*)([[:space:]]|=|"|$)'
+#
+# It is matched against the review's own arguments, where the flag may be the
+# very first token -- `gh pr review -a 35` returns `-a 35` -- so ^ is an
+# alternative to the leading space. Against a whole command there was always a
+# space in front of it and the anchor was not needed.
+VERDICT='(^|[[:space:]])(--approve|--request-changes|-[A-Za-z]*[ar][A-Za-z]*)([[:space:]]|=|"|$)'
 
 # A wrapper's payload sits inside quotes, where there is no command word for the
 # tokeniser to find, so these run unanchored over the raw text -- and only once
@@ -94,26 +149,30 @@ if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Z
   fi
 fi
 
-if printf '%s\n' "$CMDS" | grep -qE "${GHPR}merge([^-A-Za-z0-9_]|\$)"; then
+if gh_rule 'pr merge'; then
   echo "$DECIDE Leave the PR open and say it is ready to merge." >&2
   exit 2
 fi
 
-# Only the verdict flags, and only in the same command as the subcommand.
-# Reviewing with --comment leaves remarks without a verdict and stays allowed.
-if printf '%s\n' "$CMDS" | grep -qE "${GHPR}review([[:space:]].*)?${VERDICT}"; then
+# Only the verdict flags. The arguments gh_rule matches VERDICT against are the
+# review's own, so nothing here has to say so. Reviewing with --comment leaves
+# remarks without a verdict and stays allowed.
+if gh_rule 'pr review' "$VERDICT"; then
   echo "$DECIDE Review with --comment to leave remarks without a verdict." >&2
   exit 2
 fi
 
 # Rejecting a pull request by outcome rather than by verdict.
-if printf '%s\n' "$CMDS" | grep -qE "${GHPR}(close|reopen)([^-A-Za-z0-9_]|\$)"; then
+if gh_rule 'pr close' || gh_rule 'pr reopen'; then
   echo "$DECIDE Closing a PR rejects it; say why it should be closed instead." >&2
   exit 2
 fi
 
-# Outward-facing publication. This repository is public.
-if printf '%s\n' "$CMDS" | grep -qE "${GHRELEASE}(create|delete|delete-asset)([^-A-Za-z0-9_]|\$)"; then
+# Outward-facing publication. This repository is public. delete-asset is named
+# separately because a path word is matched whole: `release delete` does not
+# match `gh release delete-asset`, which is the same shape that keeps
+# `gh pr create` out of the `pr close` rule.
+if gh_rule 'release create' || gh_rule 'release delete' || gh_rule 'release delete-asset'; then
   echo "Blocked: publishing or deleting a GitHub release is Bertan's call. This repository is public; a release is visible the moment it exists." >&2
   exit 2
 fi
@@ -151,9 +210,17 @@ gh_api_is_write() {
 # command word and the payload can be separated by the tokeniser -- a mutation
 # body splits on its own braces and parens -- so gh api is looked for among the
 # commands and what it carries anywhere in the text.
+#
+# This is the one gh rule gh_rule cannot express: the question is about the
+# command, not about a pattern over its arguments. Finding the call still goes
+# through cs_gh_args, so `gh --hostname h api -X PUT ...` is an api call here as
+# it is everywhere else. The method is then read from the whole command rather
+# than from the returned arguments -- cs_split has already scoped it to this one
+# invocation, and every option that can precede `api` is a global one carrying
+# neither a method nor a field.
 API_WRITE=
 while IFS= read -r CMD; do
-  printf '%s\n' "$CMD" | grep -qE '^gh[[:space:]]+api([^-A-Za-z0-9_]|$)' || continue
+  cs_gh_args api <<<"$CMD" >/dev/null || continue
   if gh_api_is_write "$CMD"; then API_WRITE=1; break; fi
 done <<CMDLIST
 $CMDS


### PR DESCRIPTION
Closes #47.

`no-pr-decisions.sh` answered the command-position question one word too late.
`GHPR` and `GHRELEASE` skipped options between the group and the verb and never
before the group, and the two `gh api` matches skipped none at all — so a flag
written first walked past all four rules. `gh pr --repo o/r merge 5` was refused
and `gh -R o/r pr merge 5` was permitted.

The rules go through `cs_gh_args` now. `GHPR` and `GHRELEASE` are deleted, and a
`gh_rule <path> [<args regex>]` helper loops over `cs_split`'s output one command
at a time. `VERDICT` is matched against the arguments `cs_gh_args` hands back —
that command's own — so the "in the same command as the subcommand" qualifier is
gone; it gains `^` as an alternative to the leading space, because the flag can
now be the first argument.

All nine rows of #47's Evidence table are refused, each pinned by a check. Every
pre-existing check passes unchanged; the diff to `check-hooks.sh` is additive.

### One thing the migration nearly lost silently

A path word is matched whole, so `release delete` does **not** cover
`gh release delete-asset` the way the old alternation did. The old regular
expression carried `delete-asset` and no check ever asked about it. It is now
its own rule with two checks behind it.

### Mutation evidence

Run against a disposable copy, so no weakened hook was written into the tree.

| mutation | checks reddened |
| --- | --- |
| revert the migration | all 10 Evidence rows |
| drop `^` from `VERDICT` | 10 |
| `continue` → `break` in `gh_rule` | 19 |
| `continue` → `break` in the ARGRE branch | 1 |
| drop the `delete-asset` rule | 2 |
| hand `cs_gh_args` the whole list at once | 1 |
| skip options only from the 2nd path word (#46's mutation) | 11 |

### Two corrections made during review

**The sequencing checks were split in two.** Three of them were written believing
a per-command loop is what reaches a second command's rule at all. It is not:
`cs_gh_args` scans *past* a command that is not a match, so for a rule with no
argument expression the loop and one whole-list call find the same thing. Only a
rule *with* one can tell them apart — measured, and the whole-list mutation
reddens exactly that one line. The three are kept for what they do pin, under a
heading that says so.

**Two comments this branch first shipped were false.** "No gh rule below
describes a command position" was untrue of the wrapper rules, and "every gh rule
asks through here" was untrue of them and of the `API_WRITE` loop. Both denials
hid the same thing, now filed as #51: the wrapper rules require the group to
follow `gh` immediately, so `bash -c "gh -R o/r pr merge 5"` is **permitted**
while `bash -c "gh pr merge 5"` is refused. Pre-existing on `dev-05`, measured in
both, and not fixable the way these rules were — a quoted payload has no command
word for `cs_gh_args` to find. The header points at #51 instead of denying it.

https://claude.ai/code/session_01MRQtCjJouaz6TGadR9XPhN
