### PR TITLE
Drop redirections in cs_normalise, so a redirect is not read as a refspec

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -23,6 +23,14 @@
 # fi` was permitted, and passed again while a commit message mentioning `<<EOF`
 # blinded both hooks for the rest of the command.
 #
+# The redirect checks come from a fourth review, of PR #48, and are the first
+# of these to name a defect in the refusing direction rather than the
+# permitting one: every redirect on an otherwise permitted push was refused,
+# because nothing removed redirections and the operator read as a refspec. It
+# survived three rounds of review for that reason -- it refuses too much, and
+# the workaround is to drop the redirect -- and was filed anyway, because the
+# question it gets wrong is the one lib/command-scan.sh exists to answer once.
+#
 # So the number below is not a measure of the boundary. A check suite is
 # evidence about the cases it names and about nothing else, and every case here
 # was named by someone who went looking for one it had missed.
@@ -104,8 +112,11 @@ tok 'wrapper word and its options removed' \
 tok 'continuation joined before anything else' \
     'git push   --all origin' \
     "$(printf 'git push \\\n  --all origin\n' | cs_normalise)"
+# The one expectation issue #50 changed. It pins that the body is dropped and
+# that `echo after` survives, which is what it has always been about; the `> f`
+# is gone from the opener because cs_normalise now drops redirections too.
 tok 'heredoc body dropped' \
-    'cat > f <<EOF
+    'cat <<EOF
 echo after' \
     "$(printf 'cat > f <<EOF\ngit push origin main\nEOF\necho after\n' | cs_normalise)"
 tok 'here-string is not a heredoc' \
@@ -120,6 +131,135 @@ tok 'unterminated heredoc gives its lines back' \
     'git commit -m "fix <<EOF handling"
     git push --all origin' \
     "$(printf 'git commit -m "fix <<EOF handling"\n    git push --all origin\n' | cs_normalise)"
+# Redirections. A redirect is not an argument, and nothing removed it, so its
+# operator or its target was read as a refspec and every redirect on an
+# otherwise permitted push was refused. Issue #50.
+#
+# The two that come first are the ones the drop must not get wrong, because
+# they are the ones where it would hide something: a process substitution
+# carries a command, and a redirect inside quotes is text. Both are written
+# before the drops themselves for that reason.
+tok 'process substitution is not a redirect, <(' \
+    'cat <(git push --all origin)' \
+    "$(printf 'cat <(git push --all origin)\n' | cs_normalise)"
+tok 'process substitution is not a redirect, >(' \
+    'tee >(git push --all origin)' \
+    "$(printf 'tee >(git push --all origin)\n' | cs_normalise)"
+# The process substitution is tested before the fd digits are taken, so a digit
+# standing in front of one does not turn it into a redirect and take the
+# command with it.
+tok 'process substitution behind an fd digit' \
+    'cat 2>(git push --all origin)' \
+    "$(printf 'cat 2>(git push --all origin)\n' | cs_normalise)"
+tok 'a redirect inside double quotes is text' \
+    'git commit -m "redirect 2>/dev/null in the notes"' \
+    "$(printf 'git commit -m "redirect 2>/dev/null in the notes"\n' | cs_normalise)"
+tok 'a redirect inside single quotes is text' \
+    "git commit -m 'see > out.txt and 2>&1'" \
+    "$(printf "git commit -m 'see > out.txt and 2>&1'\n" | cs_normalise)"
+tok 'an escaped operator is not a redirect' \
+    'echo a \> b' \
+    "$(printf 'echo a \\> b\n' | cs_normalise)"
+# A target that is a command substitution is not a target at all. Without the
+# backtick and the paren ending the target scan, the command inside would be
+# swallowed with it -- the same mistake as hiding a process substitution.
+tok 'a backticked target ends the target scan' \
+    'echo `git push --all origin`' \
+    "$(printf 'echo > `git push --all origin`\n' | cs_normalise)"
+tok 'a $( ) target ends the target scan' \
+    'echo $(git push --all origin)' \
+    "$(printf 'echo > $(git push --all origin)\n' | cs_normalise)"
+# Now the drops. Every spelling, with and without a space before the target.
+tok 'redirect dropped, > with a space' \
+    'git push origin b' \
+    "$(printf 'git push origin b > out.txt\n' | cs_normalise)"
+tok 'redirect dropped, > with no space' \
+    'git push origin b' \
+    "$(printf 'git push origin b >out.txt\n' | cs_normalise)"
+tok 'redirect dropped, >> with a space' \
+    'git push origin b' \
+    "$(printf 'git push origin b >> push.log\n' | cs_normalise)"
+tok 'redirect dropped, >> with no space' \
+    'git push origin b' \
+    "$(printf 'git push origin b >>push.log\n' | cs_normalise)"
+tok 'redirect dropped, 2> with a space' \
+    'git push origin b' \
+    "$(printf 'git push origin b 2> /dev/null\n' | cs_normalise)"
+tok 'redirect dropped, 2> with no space' \
+    'git push origin b' \
+    "$(printf 'git push origin b 2>/dev/null\n' | cs_normalise)"
+tok 'redirect dropped, 2>> with a space' \
+    'git push origin b' \
+    "$(printf 'git push origin b 2>> push.log\n' | cs_normalise)"
+tok 'redirect dropped, 2>> with no space' \
+    'git push origin b' \
+    "$(printf 'git push origin b 2>>push.log\n' | cs_normalise)"
+tok 'redirect dropped, &> with a space' \
+    'git push origin b' \
+    "$(printf 'git push origin b &> out.txt\n' | cs_normalise)"
+tok 'redirect dropped, &> with no space' \
+    'git push origin b' \
+    "$(printf 'git push origin b &>out.txt\n' | cs_normalise)"
+tok 'redirect dropped, >& with a space' \
+    'git push origin b' \
+    "$(printf 'git push origin b >& out.txt\n' | cs_normalise)"
+tok 'redirect dropped, >& with no space' \
+    'git push origin b' \
+    "$(printf 'git push origin b >&out.txt\n' | cs_normalise)"
+tok 'redirect dropped, a leading < with a space' \
+    'cat' \
+    "$(printf 'cat < input.txt\n' | cs_normalise)"
+tok 'redirect dropped, a leading < with no space' \
+    'cat' \
+    "$(printf 'cat <input.txt\n' | cs_normalise)"
+tok 'redirect dropped, two of them' \
+    'git push origin b' \
+    "$(printf 'git push origin b >/dev/null 2>&1\n' | cs_normalise)"
+# The fd belongs to the operator, so it goes with it; the pipe does not, and
+# staying is the whole point -- it is what still shows tail as a command.
+tok 'the pipe after 2>&1 survives the drop' \
+    'git push origin b | tail -3' \
+    "$(printf 'git push origin b 2>&1 | tail -3\n' | cs_normalise)"
+# A digit is an fd only when it is a word of its own. `origin b2` is a token
+# that happens to end in one, and taking the 2 would change the refspec.
+tok 'a digit attached to a word is not an fd' \
+    'git push origin b2' \
+    "$(printf 'git push origin b2>out.txt\n' | cs_normalise)"
+# && is a separator, not the & of &>. The strip only reaches a & that touches
+# the operator, so the spelling that exercises the guard is the adjacent one --
+# and the spaced spelling is here beside it to say the strip never fires there.
+# No hook verdict turns on this pair: cs_split breaks on a single & as readily
+# as on a double one, so a separator half-eaten still ends the command. It is
+# pinned at the tokeniser because that is where the rule is written, and the
+# rule is that the strip takes the & of &> and never a separator.
+tok 'an adjacent && is not the & of &>' \
+    'git push origin b &&' \
+    "$(printf 'git push origin b &&> out.txt\n' | cs_normalise)"
+tok 'a spaced && is not touched at all' \
+    'git push origin b &&' \
+    "$(printf 'git push origin b && > out.txt\n' | cs_normalise)"
+# << <<- <<< are the heredoc pass's question, answered above. This pass leaves
+# them alone rather than answering it a second time and differently.
+# Quote state is per line, so a string left open at a newline protects nothing
+# on the line after it. That can only drop more, never less, and dropping more
+# of a line already inside quotes changes no verdict -- but it is behaviour, so
+# it is named rather than left to be discovered.
+tok 'quote state does not carry across a newline' \
+    'echo "unclosed
+cat' \
+    "$(printf 'echo "unclosed\ncat > f\n' | cs_normalise)"
+# >| is the clobber operator. The | is not consumed with it, so the target
+# becomes a command candidate of its own -- over-splitting, which can only
+# refuse more, and preferred to eating a | that is a separator everywhere else.
+tok '>| leaves its pipe standing' \
+    'git push origin b | out.txt' \
+    "$(printf 'git push origin b >| out.txt\n' | cs_normalise)"
+tok 'the heredoc operator survives the redirect drop' \
+    'cat <<EOF' \
+    "$(printf 'cat <<EOF\nbody\nEOF\n' | cs_normalise)"
+tok 'the here-string operator survives the redirect drop' \
+    'cat <<< "hello"' \
+    "$(printf 'cat <<< "hello"\n' | cs_normalise)"
 tok 'control word removed, then/fi' \
     'true
 git push --mirror origin' \
@@ -404,6 +544,74 @@ check no-git-push.sh "$OWN_BRANCH_PUSH" 'indented push, own branch'        $'if 
 # An unrelated -f elsewhere on the line is not the push's own flag. Every option
 # check reads the push's arguments, not the whole command, so this still passes.
 check no-git-push.sh "$OWN_BRANCH_PUSH" 'rm -f before an ordinary push'    "rm -f notes.md && git push origin $CURRENT"
+
+echo "=== REGRESSION: issue #50, a redirect was read as a refspec ==="
+# Nothing removed redirections, so `2>/dev/null` was the refspec and the message
+# said so in as many words. A stderr redirect is a shape an agent writes without
+# meaning anything by it -- `2>&1 | tail -3` on a push is how you read the result
+# of one -- so by the stopping rule in no-git-push.sh that is a defect.
+#
+# PR #48 reported the `2>&1` spelling and blamed the split on &. That is true of
+# that spelling and was not the cause: `2>/dev/null` holds no & and was refused
+# just the same. cs_normalise drops the redirection now, before cs_split sees it.
+check no-git-push.sh "$OWN_BRANCH_PUSH" 'push with 2>/dev/null'     "git push origin $CURRENT 2>/dev/null"
+check no-git-push.sh "$OWN_BRANCH_PUSH" 'push with > out.txt'       "git push origin $CURRENT > out.txt"
+check no-git-push.sh "$OWN_BRANCH_PUSH" 'push with 2>> push.log'    "git push origin $CURRENT 2>> push.log"
+check no-git-push.sh "$OWN_BRANCH_PUSH" 'push with >/dev/null 2>&1' "git push origin $CURRENT >/dev/null 2>&1"
+check no-git-push.sh "$OWN_BRANCH_PUSH" 'push with 2>&1 | tail -3'  "git push origin $CURRENT 2>&1 | tail -3"
+check no-git-push.sh "$OWN_BRANCH_PUSH" 'push with &> out.txt'      "git push origin $CURRENT &> out.txt"
+check no-git-push.sh "$OWN_BRANCH_PUSH" 'push with >& out.txt'      "git push origin $CURRENT >& out.txt"
+check no-git-push.sh "$OWN_BRANCH_PUSH" 'push with a redirect first' "git push origin >out.txt $CURRENT"
+check no-git-push.sh "$OWN_BRANCH_PUSH" 'push with >| out.txt'      "git push origin $CURRENT >| out.txt"
+# The redirect changes what the hook can see, never what it decides. Every
+# refused destination is still refused wearing one, and so is every refused
+# form -- the drop must not carry the flag off with the redirect.
+check no-git-push.sh BLOCK 'push to main with 2>/dev/null'    'git push origin main 2>/dev/null'
+check no-git-push.sh BLOCK 'push to dev-05 with > out.txt'    'git push origin dev-05 > out.txt'
+check no-git-push.sh BLOCK 'push to main with 2>> push.log'   'git push origin main 2>> push.log'
+check no-git-push.sh BLOCK 'push to dev-05, >/dev/null 2>&1'  'git push origin dev-05 >/dev/null 2>&1'
+check no-git-push.sh BLOCK 'push to main with 2>&1 | tail'    'git push origin main 2>&1 | tail -3'
+check no-git-push.sh BLOCK 'push --all with a redirect'       'git push --all origin >/dev/null 2>&1'
+check no-git-push.sh BLOCK 'push --mirror with a redirect'    'git push --mirror origin 2>&1'
+check no-git-push.sh BLOCK 'forced push of own branch, redirected' "git push -f origin $CURRENT 2>/dev/null"
+check no-git-push.sh BLOCK 'bare push with a redirect'        'git push 2>/dev/null'
+# A pipe is not a redirect and still ends the command, so what follows one is
+# still a command. Dropping must never hide it.
+check no-git-push.sh BLOCK 'legit push 2>&1 then push --all'  "git push origin $CURRENT 2>&1 | tail -3; git push --all origin"
+check no-pr-decisions.sh BLOCK 'gh pr merge with a redirect'  'gh pr merge 35 >/dev/null 2>&1'
+check no-pr-decisions.sh BLOCK 'gh pr review -a, redirected'  'gh pr review -a 35 2>&1 | tail -1'
+check no-pr-decisions.sh ALLOW 'gh pr view with a redirect'   'gh pr view 35 > /tmp/pr.json'
+
+echo "=== ACCEPTED false positive: a quoted redirect target ==="
+# The target scan stops at a quote, so a quoted target is not consumed and its
+# text stays in the push's arguments, where it reads as a refspec. Issue #50
+# asked for every redirect on a permitted push to be allowed and granted no
+# exception, so this is a shortfall against it rather than a decision the issue
+# made -- taken because consuming a quoted target would mean the drop swallowing
+# text it cannot see the end of, which is the direction that has gone wrong
+# three times in this file. The targets an agent writes -- /dev/null, out.txt,
+# push.log -- carry no quotes.
+#
+# Pinned in both directions so a later change cannot move it silently. If these
+# become ALLOW, that is a decision to take knowingly, not a bug fix.
+tok 'a quoted target is left in the arguments' \
+    'git push origin b "push log"' \
+    "$(printf 'git push origin b 2> "push log"\n' | cs_normalise)"
+check no-git-push.sh BLOCK 'push with a quoted redirect target' "git push origin $CURRENT 2> \"push log\""
+check no-git-push.sh "$OWN_BRANCH_PUSH" 'the same target unquoted' "git push origin $CURRENT 2> push.log"
+
+echo "=== REGRESSION: issue #50, the drop must not hide a command ==="
+# Dropping is the one step in cs_normalise that hides text rather than exposing
+# it, and the heredoc question was got wrong three times in exactly that
+# direction. A process substitution carries a command, so it is not a redirect;
+# a command substitution used as a target is not a target. Both are pinned here
+# with a refused command inside, so hiding one would show up as ALLOW.
+check no-git-push.sh     BLOCK 'push inside <( )'             'cat <(git push --all origin)'
+check no-git-push.sh     BLOCK 'push inside >( )'             'tee >(git push --all origin)'
+check no-git-push.sh     BLOCK 'push as a backticked target'  'echo > `git push --all origin`'
+check no-git-push.sh     BLOCK 'push as a $( ) target'        'echo > $(git push --all origin)'
+check no-pr-decisions.sh BLOCK 'merge inside <( )'            'cat <(gh pr merge 35)'
+check no-pr-decisions.sh BLOCK 'merge as a $( ) target'       'echo > $(gh pr merge 35)'
 
 echo "=== REGRESSION: PR #35 review, a bare push is answered by configuration ==="
 # A push naming no refspec is sent where push.default, a remote.<name>.push

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -42,7 +42,12 @@
 # now, has been to report the permitted answer.
 
 # Reduce a raw command to lines that can be scanned: heredoc bodies dropped,
-# line continuations joined.
+# line continuations joined, redirections dropped -- in that order, so that
+# every caller gets a command whose remaining words are its arguments. Where a
+# command's arguments end is the question this file exists to answer once, and
+# a redirect answered it in no-git-push.sh by accident: nothing removed one, so
+# `git push origin <branch> 2>/dev/null` was refused for naming 2>/dev/null as
+# its refspec. See the third pass.
 #
 # A heredoc body is data, not commands. This repository writes dev-log entries
 # and commit messages through a quoted heredoc, and those texts name the very
@@ -108,6 +113,121 @@ cs_normalise() {
         if ((getline nxt) > 0) line = line nxt; else break
       }
       print line
+    }' \
+  | awk '
+    # A redirection is not an argument. Nothing removed one, so its operator or
+    # its target was read as a refspec and every redirect on an otherwise
+    # permitted push was refused -- `git push origin <branch> 2>/dev/null`
+    # answered "This names 2>/dev/null, not <branch>". Issue #50.
+    #
+    # It runs last, so a redirect written across a continuation is joined before
+    # it is read, and so `2>&1` is gone before cs_split reaches the & it would
+    # otherwise split on. That split is what PR #48 reported as the cause; it is
+    # a second effect on top of this one, and `2>/dev/null` holds no & at all.
+    #
+    # Where the last three defects here came from: this is the second step that
+    # hides text rather than exposing it, so the two cases where hiding would
+    # cost something are answered first and answered narrowly.
+    #
+    #   - `<(...)` and `>(...)` carry a command, which is the one thing a drop
+    #     must never swallow. They are not redirections and are left whole.
+    #   - a redirect inside quotes is text. A commit message naming one is the
+    #     mistake the heredoc opener made three times, so quotes are tracked
+    #     character by character rather than matched around.
+    #   - `<<`, `<<-` and `<<<` belong to the heredoc pass above. Answering
+    #     what a heredoc is a second time, here, is how the answers came to
+    #     disagree in the first place; a run of two or more < is emitted whole.
+    #   - the target scan stops at a backtick and at a paren, so a command
+    #     substitution standing where a target would be is left standing.
+    #
+    # The trade, taken knowingly: a quoted redirect target -- `2> "push log"` --
+    # is not consumed, so its text stays in the arguments and refuses the push.
+    # That is the direction this file takes everywhere, and the targets an agent
+    # actually writes (/dev/null, out.txt, push.log) carry no quotes.
+    #
+    # `>|` is left half-standing: the operator goes and the | does not, so the
+    # target becomes a command candidate of its own. That is the over-splitting
+    # this file takes everywhere -- an extra candidate can only refuse more --
+    # and it is preferred to consuming a | , which is a separator everywhere
+    # else and whose loss would hide the command after it.
+    #
+    # Quote state is per line. A string left open at a newline protects nothing
+    # on the next line, which can only drop more, never less -- and dropping
+    # more of a line that is already inside quotes changes no verdict, because
+    # the quoted text was never a command position to begin with.
+    #
+    # Which leaves this pass knowing two things the passes above also know:
+    # what a quote is, and what `<<` is. One answer per question is the premise
+    # of this file, so that is a cost rather than an oversight. It is paid
+    # because the two answers are to different questions. Pass one asks where a
+    # heredoc body ends, and answers it fail-safe, by giving the lines back.
+    # This one asks whether a character is text, and a fail-safe there would
+    # mean dropping nothing, which is the defect being fixed. Unifying them
+    # would put the heredoc fail-safe at risk to save a dozen lines.
+    # BOUND is what an fd digit run may follow; STOP is that plus the quotes,
+    # and ends a redirect target. STOP is derived rather than written twice, so
+    # the two cannot drift apart in a later edit.
+    BEGIN {
+      BOUND = " \t;|&()`<>"
+      STOP  = BOUND "\042\047"
+    }
+    {
+      line = $0
+      n = length(line)
+      out = ""
+      q = ""
+      i = 1
+      while (i <= n) {
+        c = substr(line, i, 1)
+        if (q != "") {
+          if (q == "\042" && c == "\\") { out = out c substr(line, i + 1, 1); i += 2; continue }
+          out = out c
+          if (c == q) q = ""
+          i++
+          continue
+        }
+        if (c == "\\") { out = out c substr(line, i + 1, 1); i += 2; continue }
+        if (c == "\042" || c == "\047") { q = c; out = out c; i++; continue }
+        if (c != ">" && c != "<") { out = out c; i++; continue }
+        nxt = substr(line, i + 1, 1)
+        # Process substitution carries a command. Not a redirection.
+        if (nxt == "(") { out = out c; i++; continue }
+        # A run of two or more < is a heredoc or a here-string, already answered.
+        if (c == "<" && nxt == "<") {
+          while (i <= n && substr(line, i, 1) == "<") { out = out "<"; i++ }
+          continue
+        }
+        # The fd, or the & of &>, sits in front of the operator and belongs to
+        # it. A digit run counts only where it is a word of its own: in
+        # `origin b2>f` the 2 is part of the refspec, and bash reads it that way
+        # too. A single & is the & of &>; two are the separator &&, which ends a
+        # command and must survive, or the command after it disappears.
+        if (match(out, /[0-9]+$/) \
+            && (RSTART == 1 || index(BOUND, substr(out, RSTART - 1, 1)) > 0)) {
+          out = substr(out, 1, RSTART - 1)
+        } else if (c == ">" && substr(out, length(out), 1) == "&" \
+                   && substr(out, length(out) - 1, 1) != "&") {
+          out = substr(out, 1, length(out) - 1)
+        }
+        sub(/[[:space:]]+$/, "", out)
+        i++
+        if (c == ">" && substr(line, i, 1) == ">") i++
+        if (substr(line, i, 1) == "&") i++
+        while (i <= n && (substr(line, i, 1) == " " || substr(line, i, 1) == "\t")) i++
+        while (i <= n) {
+          t = substr(line, i, 1)
+          if (index(STOP, t) > 0) break
+          if (t == "$" && substr(line, i + 1, 1) == "(") break
+          i++
+        }
+        # The drop takes the whitespace on both sides of the redirect with it,
+        # so what stood either side of it must not close up into one word. A
+        # target that was never consumed -- a command substitution standing
+        # where one would be -- is exactly where that happens.
+        t = substr(line, i, 1)
+        if (i <= n && out != "" && t != " " && t != "\t") out = out " "
+      }
+      print out
     }'
 }
 


### PR DESCRIPTION
Closes #50.

## The defect

Nothing removed redirections from a command's arguments, so a redirect's
operator or its target was read as a refspec. Every redirect on an otherwise
permitted push was refused, and the message said so in as many words:

```
git push origin <branch> 2>/dev/null   ->  "This names 2>/dev/null, not <branch>."
```

Confirmed while making this branch: the installed hook refused this branch's
own first push over a `2>` before the redirect was dropped from the command,
the same way PR #48 hit it.

PR #48 reported the `2>&1` spelling and explained it by the split on `&`.
That is true of that spelling and is not the cause — `2>/dev/null` holds no
`&` and was refused just the same. The cause is that nothing dropped
redirections at all; the split is a second effect on top of it.

## The fix

A third pass in `cs_normalise`, after the heredoc drop and the continuation
join and so before `cs_split` — a character scanner that tracks quote state
and drops `>`, `>>`, `2>`, `2>>`, `&>`, `>&` and a leading `<` together with
their fd and their target, spaced or not. Every caller now gets a command
whose remaining words are its arguments, and no hook answers the question for
itself.

Dropping is the step that hides text rather than exposing it, and the heredoc
question was got wrong three times in exactly that direction. So the cases
where hiding would cost something are answered first and narrowly, and each
is pinned by a check that a mutation turns red:

- `<(...)` and `>(...)` carry a command and are not redirections. The test for
  one runs before the fd digits are taken, so a digit in front of a process
  substitution does not turn it into a redirect and take the command with it.
- A redirect inside quotes is text, so quotes are tracked character by
  character rather than matched around.
- `<<`, `<<-` and `<<<` stay the heredoc pass's question, unanswered here.
- The target scan stops at a backtick and at `$(`, so a command substitution
  standing where a target would be is left standing.

Two shapes are left half-standing on purpose, both over-splitting rather than
under-splitting: `>|` loses its operator and keeps its pipe, so its target
becomes a command candidate of its own; and quote state does not carry across
a newline. Each can only refuse more, never less, and each is now named by a
check rather than left to be discovered.

## The trade, and the one line the suite lost

A **quoted** redirect target — `2> "push log"` — is not consumed, so its text
stays in the arguments and refuses the push. Issue #50 granted no such
exception, so this is a shortfall against it rather than a decision the issue
made. It is taken because consuming a quoted target means the drop swallowing
text whose end it cannot see, which is the direction that has gone wrong three
times in this file. Pinned in both directions, quoted and unquoted, so a later
change cannot move it silently.

One pre-existing expectation changed with the drop: `heredoc body dropped`
read `cat > f <<EOF`, and the opener now arrives as `cat <<EOF`. What the
check is about — the body dropped, `echo after` surviving — is unchanged, and
it is the only pre-existing line the suite lost.

## Evidence

- `bash .claude/hooks/check-hooks.sh` — **221 → 283 checks, all passing**.
- Every row of the issue's table is ALLOW from a linked worktree on its own
  branch, and BLOCK with the working directory set to the main checkout, and
  BLOCK when the refspec names `main` or `dev-05`. The redirect changes what
  the hook can see, never what it decides.
- **Mutation-checked with nine mutations** of the new pass — dropping nothing,
  treating `<(` as a redirect, not tracking quotes, treating `<<` as a
  redirect, eating `&&`, not stopping the target scan at `$(`, closing two
  words up, consuming a quoted target, and ignoring a backslash escape. Each
  turns named new checks red; none survives.
- Reviewed on two axes before commit. The standards axis probed roughly sixty
  adversarial strings through `cs_normalise`, `cs_split` and both hooks and
  found no input where the drop hides a command. Both axes raised gaps in the
  checks rather than in the behaviour — the missing spacing variants, two
  table rows never tested against a reserved refspec, and the unpinned trade
  above — and all are fixed in this branch.
- `make test` is unchanged from the base: 571 passed, 5 xfailed, and the one
  failure is `test_installed_packages_match_uv_lock`, pre-existing venv drift.
  This branch touches no Python and no lockfile.

## Not done here

`CLAUDE.md` says the shared tokeniser has had "nine defects found by review
rather than by the suite ... every one was silent and in the permitting
direction". This is a tenth, from a fourth round, and the first in the
refusing direction, so it does not fit that sentence as written. The
governing document's own claim is not an agent's to rewrite; flagging it
instead.

https://claude.ai/code/session_01AxhMeTFgcyms5JkThUzqjZ
