### PR TITLE
Require a pull request to name an active dev branch as its base

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -27,6 +27,16 @@
 # evidence about the cases it names and about nothing else, and every case here
 # was named by someone who went looking for one it had missed.
 #
+# The base checks come from issue #40 rather than from a review: all four
+# spellings that create or retarget a pull request were permitted, and the
+# quietest of them named nothing at all -- with no base given, a pull request
+# goes to the repository's default branch, which is main. They are grouped by
+# what they establish rather than by spelling, because a rule that held for
+# gh pr create and not for gh api would be the defect that ticket was filed
+# against. Each was mutation-checked: weakening the dev-NN test, dropping the
+# missing-base refusal, dropping either gh api rule, and dropping the wrapper
+# rule each turn a named group of them red.
+#
 # One expectation is not a literal but a context: whether pushing this branch is
 # permitted depends on where the suite runs, because that is exactly what
 # no-git-push.sh decides. Run from a linked worktree on a worktree branch, a push
@@ -385,6 +395,82 @@ check no-pr-decisions.sh ALLOW 'PATCH a PR title'            'gh api -X PATCH re
 check no-pr-decisions.sh ALLOW 'GET the releases list'       'gh api repos/o/r/releases'
 check no-pr-decisions.sh ALLOW 'gh pr edit retitles'         'gh pr edit 35 --title newtitle'
 
+echo "=== issue #40, a pull request must name an active dev branch as its base ==="
+# The quietest of the four spellings names nothing at all: with no base given,
+# gh sends the pull request to the repository's default branch, which is main.
+# Nothing in the command mentions main, so a denylist over the text could not
+# have seen it -- the same shape as the bare push, which is answered the same
+# way. The four spellings are checked together because closing one and leaving
+# the others is the defect this ticket was filed against.
+check no-pr-decisions.sh BLOCK 'create into main'                'gh pr create --base main --title x'
+check no-pr-decisions.sh BLOCK 'create into main, --base='       'gh pr create --base=main --title x'
+check no-pr-decisions.sh BLOCK 'create into main, -B'            'gh pr create -B main --title x'
+check no-pr-decisions.sh BLOCK 'create into main, -B attached'   'gh pr create -Bmain --title x'
+check no-pr-decisions.sh BLOCK 'create into main, bundled -dB'   'gh pr create -dB main --title x'
+check no-pr-decisions.sh BLOCK 'create into main, bundled -dBmain' 'gh pr create -dBmain --title x'
+check no-pr-decisions.sh BLOCK 'create naming no base at all'    'gh pr create --title x --body y'
+check no-pr-decisions.sh BLOCK 'a bare create'                   'gh pr create'
+check no-pr-decisions.sh BLOCK 'create with --fill and no base'  'gh pr create --fill'
+check no-pr-decisions.sh BLOCK 'a base flag whose value never came' 'gh pr create --title x -B'
+check no-pr-decisions.sh BLOCK 'create into master'              'gh pr create --base master --title x'
+check no-pr-decisions.sh BLOCK 'create into a worktree branch'   'gh pr create --base worktree-issue-40-pr-base'
+check no-pr-decisions.sh BLOCK 'create into dev-05-ish, not dev-NN' 'gh pr create --base dev-05-old'
+# A flag may sit in front of the verb, which is what cs_gh_args is for; and the
+# check is of every create on the line rather than the first, which is what
+# obliges the loop to hand it one command at a time.
+check no-pr-decisions.sh BLOCK 'flag before the verb, no base'   'gh pr --repo o/r create --title x'
+check no-pr-decisions.sh BLOCK 'a good create, then one into main' 'gh pr create --base dev-05 --title x && gh pr create --base main --title y'
+# Retargeting is choosing the destination a second time.
+check no-pr-decisions.sh BLOCK 'retarget to main'                'gh pr edit 35 --base main'
+check no-pr-decisions.sh BLOCK 'retarget to main, -B'            'gh pr edit 35 -B main'
+check no-pr-decisions.sh BLOCK 'retarget, flag before the verb'  'gh pr --repo o/r edit 35 --base main'
+# The API forms. The gate is the write test the file already had, not the
+# endpoint: matching an endpoint is what once refused a read of a pull request
+# as though it were a decision.
+check no-pr-decisions.sh BLOCK 'REST create into main'           'gh api -X POST repos/o/r/pulls -f base=main -f head=x'
+check no-pr-decisions.sh BLOCK 'REST create, value attached'     'gh api -X POST repos/o/r/pulls -fbase=main'
+check no-pr-decisions.sh BLOCK 'REST create naming no base'      'gh api -X POST repos/o/r/pulls -f head=x -f title=y'
+check no-pr-decisions.sh BLOCK 'REST retarget to main'           'gh api -X PATCH repos/o/r/pulls/35 -f base=main'
+check no-pr-decisions.sh BLOCK 'graphql create into main'        'gh api graphql -f query="mutation{createPullRequest(input:{baseRefName:main})}"'
+check no-pr-decisions.sh BLOCK 'graphql create, base quoted'     "gh api graphql -f query='mutation{createPullRequest(input:{baseRefName:\"main\"})}'"
+check no-pr-decisions.sh BLOCK 'graphql create naming no base'   'gh api graphql -f query="mutation{createPullRequest(input:{headRefName:x})}"'
+# A wrapper hides the base behind quotes, where there is no command position to
+# find and nothing to read. Refused outright, as a wrapped push and a wrapped
+# read of a pull request already are.
+check no-pr-decisions.sh BLOCK 'a good create inside bash -c'    "bash -c 'gh pr create --base dev-05 --title x'"
+check no-pr-decisions.sh BLOCK 'a REST create inside bash -c'    "bash -c 'gh api -X POST repos/o/r/pulls -f base=dev-05'"
+# The accepted false positive, recorded rather than worked around: cs_split cuts
+# on the parens of a command substitution, so a base written after one lands in
+# a later fragment and the create no longer names one. Put the base first.
+check no-pr-decisions.sh BLOCK 'base written after a substitution' 'gh pr create --title x --body "$(cat b.md)" --base dev-05'
+
+echo "=== issue #40, a base naming a dev branch is permitted in every spelling ==="
+check no-pr-decisions.sh ALLOW 'create into the dev branch'      'gh pr create --base dev-05 --title x --body y'
+check no-pr-decisions.sh ALLOW 'create into dev, --base='        'gh pr create --base=dev-05 --title x'
+check no-pr-decisions.sh ALLOW 'create into dev, -B'             'gh pr create -B dev-05 --title x'
+check no-pr-decisions.sh ALLOW 'create into dev, -B attached'    'gh pr create -Bdev-05 --title x'
+check no-pr-decisions.sh ALLOW 'create into an older dev-NN'     'gh pr create --base dev-04 --title x'
+check no-pr-decisions.sh ALLOW 'flag before the verb, good base' 'gh pr --repo o/r create --base dev-05 --title x'
+check no-pr-decisions.sh ALLOW 'base first, then a substitution' 'gh pr create --base dev-05 --body "$(cat b.md)"'
+# The browser hand-off creates nothing: a person on the prefilled page chooses
+# the base and confirms. That exempts a missing base and nothing else.
+check no-pr-decisions.sh ALLOW 'browser hand-off, --web'         'gh pr create --web'
+check no-pr-decisions.sh ALLOW 'browser hand-off, -w'            'gh pr create -w'
+check no-pr-decisions.sh BLOCK '--web does not launder a base'   'gh pr create --web --base main'
+check no-pr-decisions.sh ALLOW 'retarget to the dev branch'      'gh pr edit 35 --base dev-05'
+check no-pr-decisions.sh ALLOW 'edit without touching the base'  'gh pr edit 35 --add-label bug'
+check no-pr-decisions.sh ALLOW 'REST create into dev'            'gh api -X POST repos/o/r/pulls -f base=dev-05 -f head=x'
+check no-pr-decisions.sh ALLOW 'graphql create into dev'         "gh api graphql -f query='mutation{createPullRequest(input:{baseRefName:\"dev-05\"})}'"
+# Reads name no destination and are not asked for one, which is what keeps the
+# write test doing this work rather than the endpoint.
+check no-pr-decisions.sh ALLOW 'listing pull requests'           'gh api repos/o/r/pulls'
+check no-pr-decisions.sh ALLOW 'reading one pull request'        'gh api repos/o/r/pulls/35'
+check no-pr-decisions.sh ALLOW 'listing beside another write'    'gh api -X POST repos/o/r/issues -f title=x && gh api repos/o/r/pulls'
+# A write that names no base and creates nothing is not a pull request at all.
+check no-pr-decisions.sh ALLOW 'PATCH a PR body, the -F habit'   'gh api -X PATCH repos/o/r/pulls/35 -F body=@body.md'
+check no-pr-decisions.sh ALLOW 'creating an issue'               'gh api -X POST repos/o/r/issues -f title=x'
+check no-pr-decisions.sh ALLOW 'gh issue create names no base'   'gh issue create --title x --body y'
+
 echo "=== the push argument split does not glob against the worktree ==="
 # `for TOK in $ARGS` is unquoted because the split is the point; set -f stops
 # the same line expanding ? and [...] against the files sitting next to it.
@@ -540,7 +626,7 @@ for c in 'gh pr merge 5' \
 do check no-pr-decisions.sh BLOCK "$c" "$c"; done
 
 echo "=== no-pr-decisions.sh : must ALLOW ==="
-for c in 'gh pr create --title x --body y' \
+for c in 'gh pr create --base dev-05 --title x --body y' \
          'gh pr comment 5 --body "looks fine"' \
          'gh pr review --comment -b "a remark"' \
          'gh pr view 5' \

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -892,12 +892,45 @@ check no-pr-decisions.sh BLOCK 'a label value beginning -w'  'gh pr create -l -w
 check no-pr-decisions.sh BLOCK 'a bundle holding w'          'gh pr create -twibble --body y'
 check no-pr-decisions.sh BLOCK 'a title naming -w'           'gh pr create --title "Handle -w in gh_pr_web" --body y'
 check no-pr-decisions.sh BLOCK 'a body naming -watch'        'gh pr create --title x --body "adds -watch mode"'
-# The exemption itself still works, and quoted prose may still refuse: the
-# asymmetry is the point. Deleting a quoted span cannot invent a flag; unquoting
-# one can, so only the permitting test reads the deleted form.
+# The exemption itself still works. The asymmetry that used to be recorded here
+# is gone: both readers drop a quoted span whole now. Unquoting one can invent a
+# flag, and inventing a --base in a command that named none removes a refusal
+# just as inventing a -w does, which is the half this comment used to miss. See
+# base_args, and group 5.
 check no-pr-decisions.sh ALLOW 'the web form, unbundled'     'gh pr create -w --title x'
 check no-pr-decisions.sh ALLOW 'the web form, long'          'gh pr create --web --title x'
+# Still refused, and now for naming no base rather than for naming a bad one.
 check no-pr-decisions.sh BLOCK 'a title naming -B main'      'gh pr create --title "-B main" --body y'
+
+# 5. A base read out of prose. `tr -d` deleted the quote characters and kept
+# what stood between them, so a body naming the flag named a base in a command
+# that named none -- and gh would have sent that create to the repository
+# default branch with this hook satisfied, which is the one shape #40 exists to
+# refuse, arriving through a body. The trigger is not contrived: a body quoting
+# the command it is about is how the pull requests in this repository are
+# written. base_args drops a quoted span whole and unquotes only a base flag own
+# value.
+check no-pr-decisions.sh BLOCK 'a base named only in a body'      'gh pr create --title t --body "--base dev-05"'
+check no-pr-decisions.sh BLOCK 'a base named only in a title'     'gh pr create --title "--base dev-05" --body b'
+check no-pr-decisions.sh BLOCK 'a body quoting the command'       'gh pr create --title x --body "Write: gh pr create --base dev-05 --title ..."'
+check no-pr-decisions.sh BLOCK 'a shorthand base in a body'       'gh pr create --title t --body "-B dev-05"'
+# The other direction, which the same defect caused: prose naming the flag made
+# a correct create refuse.
+check no-pr-decisions.sh ALLOW 'a body naming the base flag'      'gh pr create --base dev-05 --title t --body "the --base flag"'
+check no-pr-decisions.sh ALLOW 'a body naming a main retarget'    'gh pr create --base dev-05 --title t --body "use -B main to retarget"'
+check no-pr-decisions.sh ALLOW 'an edit titled after the flag'    'gh pr edit 5 --title "--base main"'
+# A base flag own value is the one quoted span that is kept, in either quote,
+# because gh takes either. Dropping it would refuse a correctly based create.
+check no-pr-decisions.sh ALLOW 'a double-quoted base value'       'gh pr create --base "dev-05" --title t'
+check no-pr-decisions.sh ALLOW 'a single-quoted base value'       "gh pr create --base 'dev-05' --title t"
+check no-pr-decisions.sh BLOCK 'a quoted base naming main'        'gh pr create --base "main" --title t'
+check no-pr-decisions.sh BLOCK 'a quoted retarget to main'        'gh pr edit 5 --base "main"'
+# 6. A graphql string value is quoted, and the shell quoting around the query
+# commonly escapes those quotes. gql_bases read the backslash as the whole value
+# and refused a dev-NN base for not being one. Refusing direction, so it sat
+# behind the two spellings that did work, both of which are pinned above.
+check no-pr-decisions.sh ALLOW 'graphql into dev, escaped'        'gh api graphql -f query="mutation{createPullRequest(input:{baseRefName:\"dev-05\"})}"'
+check no-pr-decisions.sh BLOCK 'graphql into main, escaped'       'gh api graphql -f query="mutation{createPullRequest(input:{baseRefName:\"main\"})}"'
 # 3. The gh api base was read from the whole line, so a neighbouring command
 # answered for this one -- in both directions. This is the first of the five
 # defects lib/command-scan.sh exists to end, reintroduced for gh api after being

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -471,6 +471,61 @@ check no-pr-decisions.sh ALLOW 'PATCH a PR body, the -F habit'   'gh api -X PATC
 check no-pr-decisions.sh ALLOW 'creating an issue'               'gh api -X POST repos/o/r/issues -f title=x'
 check no-pr-decisions.sh ALLOW 'gh issue create names no base'   'gh issue create --title x --body y'
 
+echo "=== REGRESSION: review of be0e3c7, the base rule's own permitting holes ==="
+# Four found by review, none of them named by the section above, which was green.
+# The pattern of this repository holds a fifth time: every one was silent and in
+# the permitting direction.
+#
+# 1. A repeated flag. gh takes the last; the rule read the first, so a create
+# that had already shown a dev branch could name main after it and go there.
+# Every base must now be dev-NN, which does not depend on knowing gh's
+# precedence.
+check no-pr-decisions.sh BLOCK 'good base, then a bad one'   'gh pr create --base dev-05 -B main'
+check no-pr-decisions.sh BLOCK 'bad base, then a good one'   'gh pr create -B main --base dev-05'
+check no-pr-decisions.sh BLOCK 'two long bases disagreeing'  'gh pr create --base dev-05 --base main'
+# 2. The web exemption read any single-dash token holding a w, and read it out of
+# quoted prose. Both halves mattered: a label value, and a title naming a flag --
+# a title a session working on this very file would write.
+check no-pr-decisions.sh BLOCK 'a label value beginning -w'  'gh pr create -l -wip --title x'
+check no-pr-decisions.sh BLOCK 'a bundle holding w'          'gh pr create -twibble --body y'
+check no-pr-decisions.sh BLOCK 'a title naming -w'           'gh pr create --title "Handle -w in gh_pr_web" --body y'
+check no-pr-decisions.sh BLOCK 'a body naming -watch'        'gh pr create --title x --body "adds -watch mode"'
+# The exemption itself still works, and quoted prose may still refuse: the
+# asymmetry is the point. Deleting a quoted span cannot invent a flag; unquoting
+# one can, so only the permitting test reads the deleted form.
+check no-pr-decisions.sh ALLOW 'the web form, unbundled'     'gh pr create -w --title x'
+check no-pr-decisions.sh ALLOW 'the web form, long'          'gh pr create --web --title x'
+check no-pr-decisions.sh BLOCK 'a title naming -B main'      'gh pr create --title "-B main" --body y'
+# 3. The gh api base was read from the whole line, so a neighbouring command
+# answered for this one -- in both directions. This is the first of the five
+# defects lib/command-scan.sh exists to end, reintroduced for gh api after being
+# fixed for gh pr.
+check no-pr-decisions.sh BLOCK 'a base on a neighbour'       'echo base=dev-05 && gh api -X POST repos/o/r/pulls -f head=x'
+check no-pr-decisions.sh BLOCK 'good create, then one to main' 'gh api -X POST repos/o/r/pulls -f base=dev-05 && gh api -X POST repos/o/r/pulls -f base=main'
+check no-pr-decisions.sh BLOCK 'a dev base hidden in a title' 'gh api -X POST repos/o/r/pulls -f base=main -f title="retarget of base=dev-05"'
+check no-pr-decisions.sh BLOCK 'a title standing in for a base' 'gh api -X POST repos/o/r/pulls -f head=x -f title="base: dev-05"'
+check no-pr-decisions.sh BLOCK 'two REST bases disagreeing'  'gh api -X POST repos/o/r/pulls -f base=dev-05 -f base=main'
+# This one is what makes the scoping load-bearing rather than merely tidy. The
+# base belongs to the issue write; the create beside it names none of its own,
+# and a rule reading the line would let that base answer for both. Anchoring on
+# the field flag and requiring every base to be dev-NN fixes the other leaks
+# whatever the scope, so without this case the scope could be widened again and
+# the suite would not notice -- which is exactly what a mutation run showed.
+check no-pr-decisions.sh BLOCK 'a base belonging to another write' 'gh api -X POST repos/o/r/issues -f base=dev-05 && gh api -X POST repos/o/r/pulls -f head=x'
+# ... and an unrelated write must not be refused by a neighbour either.
+check no-pr-decisions.sh ALLOW 'an issue write beside prose' 'gh api -X POST repos/o/r/issues -f title=x && echo "base=main"'
+check no-pr-decisions.sh ALLOW 'an issue write naming rebase' 'gh api -X POST repos/o/r/issues -f title="rebase onto main"'
+# The graphql retarget carries the same field as the create, and is refused with
+# it rather than by naming the verb.
+check no-pr-decisions.sh BLOCK 'graphql retarget to main'    'gh api graphql -f query="mutation{updatePullRequest(input:{baseRefName:main})}"'
+# 4. Scope creep, reported and removed: the wrapper rule refused a wrapped
+# listing and a wrapped edit that touched no base. Only a create or a retarget
+# is refused there now.
+check no-pr-decisions.sh ALLOW 'a wrapped listing'           "bash -c 'gh api repos/o/r/pulls'"
+check no-pr-decisions.sh ALLOW 'a wrapped label edit'        "bash -c 'gh pr edit 35 --add-label bug'"
+check no-pr-decisions.sh BLOCK 'a wrapped retarget'          "bash -c 'gh pr edit 35 --base main'"
+check no-pr-decisions.sh BLOCK 'a wrapped REST create'       "bash -c 'gh api -X POST repos/o/r/pulls -f base=dev-05'"
+
 echo "=== the push argument split does not glob against the worktree ==="
 # `for TOK in $ARGS` is unquoted because the split is the point; set -f stops
 # the same line expanding ? and [...] against the files sitting next to it.

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -164,6 +164,27 @@ gh_pr_bases() {
 #
 # The asymmetry with gh_pr_bases is deliberate and is the whole point: quoted
 # text may still trigger a refusal there, and may not grant an exemption here.
+# The arguments a base is read out of, with quoted text taken out of them but a
+# quoted base value kept.
+#
+# `tr -d` over the quotes was doing the opposite of what the comment below the
+# create rule claimed. Deleting the quote characters and keeping what stood
+# between them turns prose into tokens, so `--body "--base dev-05"` named a base
+# in a command that named none, and the create went to the default branch with
+# the hook satisfied -- the one shape issue #40 exists to refuse, arriving
+# through a body. It is not only an added refusal: where no base is named at
+# all, prose is what supplies one.
+#
+# So a base flag has its own value unquoted first, and every remaining quoted
+# span is then dropped whole, which is what gh_pr_web already did for -w and
+# what rest_bases already did by anchoring on the field flag. Three readers of
+# the same argument list, and this was the one that still read prose.
+base_args() {
+  printf '%s' "$1" \
+    | sed -E "s/(--base|-[A-Za-z]*B)([[:space:]]*=?[[:space:]]*)[\"']([^\"']*)[\"']/\1\2\3/g" \
+    | sed -e 's/"[^"]*"//g' -e "s/'[^']*'//g"
+}
+
 gh_pr_web() {
   local TOK
   for TOK in $1; do
@@ -358,6 +379,7 @@ rest_bases() {
 # agent writes by accident.
 gql_bases() {
   printf '%s\n' "$1" \
+    | sed -E 's/\\(["'"'"'])/\1/g' \
     | grep -oiE "baseRefName[[:space:]]*:[[:space:]]*[\"']?[^[:space:]\"',})]*" \
     | sed -E "s/.*:[[:space:]]*[\"']?//"
 }
@@ -422,10 +444,10 @@ fi
 # defects came from being answered ad hoc.
 while IFS= read -r CMD; do
   if RAW=$(cs_gh_args 'pr create' <<<"$CMD"); then
-    # Two readings of one argument list, because the two questions want opposite
-    # errors. Unquoting exposes prose as tokens, which can only add a refusal;
-    # deleting the quoted span cannot invent the flag that would remove one.
-    ARGS=$(printf '%s' "$RAW" | tr -d '\042\047')
+    # Two readings of one argument list. Both drop quoted spans; the base reader
+    # keeps a base flag's own quoted value, which is the only quoted text either
+    # question wants.
+    ARGS=$(base_args "$RAW")
     WEBARGS=$(printf '%s' "$RAW" | sed -e 's/"[^"]*"//g' -e "s/'[^']*'//g")
     BASES=$(gh_pr_bases "$ARGS")
     if [ -n "$BASES" ]; then
@@ -449,7 +471,7 @@ while IFS= read -r CMD; do
   # Editing a pull request stays allowed; moving its base is the same choice of
   # destination made a second time, so it is checked, and only when it is there.
   if RAW=$(cs_gh_args 'pr edit' <<<"$CMD"); then
-    ARGS=$(printf '%s' "$RAW" | tr -d '\042\047')
+    ARGS=$(base_args "$RAW")
     if ! bases_all_dev "$(gh_pr_bases "$ARGS")"; then
       echo "$BASE Retargeting to $BAD_BASE chooses that destination just as creating it there would. Edit anything else you like." >&2
       exit 2

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -1,18 +1,45 @@
 #!/bin/bash
-# Agents may open pull requests and talk on them; they may not decide them.
-# Accepting, rejecting, merging or reopening a PR is Bertan's call, and so is
-# publishing a release.
+# Agents may open pull requests and talk on them; they may not decide them, and
+# may propose one only into the active dev branch. Accepting, rejecting, merging
+# or reopening a PR is Bertan's call, and so is publishing a release.
 #
 # CLAUDE.md: "merge into main by PR only, never commit to main." Opening the
-# pull request is the agent's half of that sentence; closing it is not.
+# pull request is the agent's half of that sentence; closing it is not. Where
+# the pull request goes is the other half of it, and that is the base rule.
 #
-# Still allowed: creating a PR, commenting on one, editing one, viewing,
-# listing, diffing and checking one, reviewing with --comment, every gh issue
-# subcommand, and reading a PR through gh api -- including the two endpoints
-# that decide one when they are written to. GET /pulls/N/reviews lists reviews
-# and GET /pulls/N/merge reports whether the PR is merged; refusing those by
-# endpoint refused a listing, not a decision, which the review on PR #35 caught.
-# The method is what separates them, so the method is what is tested.
+# THE BASE IS A REQUIRED, CHECKED ARGUMENT. `gh pr create` with no base sends
+# the pull request to the repository's default branch, which is main. That is
+# not an evasion; it is the shape of an ordinary mistake, which is the thing
+# these hooks exist to stop, and it is the quietest of the four spellings
+# because nothing in the command mentions main at all. The reasoning is the one
+# already settled for pushes in the sibling hook: a destination that comes from
+# configuration cannot be judged from here, because an agent can set
+# configuration, so the command has to say where it is going.
+#
+# All four spellings that create or retarget a pull request are answered in one
+# place -- gh pr create, gh pr edit --base, the REST write and the graphql
+# mutation. Closing the convenient one alone would leave this branch in the
+# state that was filed as a defect against it: the ordinary command refused
+# while the API route stayed open.
+#
+# "Active dev branch" is read as the dev-NN shape and not as a particular
+# branch. Naming the one live dev branch would mean reading repository state --
+# which branches exist, or which is newest -- and repository state is what the
+# sibling hook declines to rest on, for the reason it declines to rest on
+# configuration: an agent can make a branch. The trade, taken knowingly: a pull
+# request into a dev branch that is no longer the active one is permitted. main,
+# master, a worktree branch and a typo are all refused, and those are the
+# mistakes in question.
+#
+# Still allowed: creating a PR into a dev-NN branch, commenting on one, editing
+# one without moving its base, viewing, listing, diffing and checking one,
+# reviewing with --comment, every gh issue subcommand, and reading a PR through
+# gh api -- including the two endpoints that decide one when they are written
+# to. GET /pulls/N/reviews lists reviews and GET /pulls/N/merge reports whether
+# the PR is merged; refusing those by endpoint refused a listing, not a
+# decision, which the review on PR #35 caught. The method is what separates
+# them, so the method is what is tested -- and it is what gates the base rule
+# too, for the same reason: a read names no destination to check.
 #
 # The convenient spelling is only one way in. The same merge is one REST call
 # (PUT /repos/O/R/pulls/N/merge) or one graphql mutation away, and gh api is
@@ -41,6 +68,13 @@
 # growing when the spellings stop being ones an agent would plausibly write.
 . "$(dirname "$0")/lib/command-scan.sh"
 
+# The base rule splits a scoped argument list with `for TOK in $ARGS`, unquoted
+# because the split is the point. That also globs the tokens against the
+# worktree, so a base spelled `*` or `[a-z]*` would be read as whatever file sat
+# beside it. The sibling hook answered this for the push refspec; the same
+# asymmetry between the two, a third time, is not worth having.
+set -f
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 SCAN=$(printf '%s\n' "$COMMAND" | cs_normalise)
@@ -56,6 +90,64 @@ fi
 CMDS=$(printf '%s\n' "$SCAN" | cs_split)
 
 DECIDE="Blocked: deciding a pull request is Bertan's call, not an agent's. Opening a PR, commenting on it and editing it are allowed; accepting, rejecting, merging and reopening are not."
+
+BASE="Blocked: a pull request may be proposed only into the active dev branch, and the base has to be named in the command. Write: gh pr create --base dev-NN --title ... --body ..."
+
+# The base named in one gh pr command's arguments. Prints it and succeeds;
+# prints nothing and fails if no base flag is there at all, which is the shape
+# that lets gh pick the repository's default branch for itself.
+#
+# -B is the shorthand, and gh takes shorthand flags bundled with their value
+# attached or separate, so `-B main`, `-Bmain`, `-dB main` and `-dBmain` are one
+# flag written four ways -- the same bundling that let `-ab` approve a pull
+# request while `-a` alone was refused. Only single-dash tokens are scanned for
+# B: a long flag would match on any letter it happens to contain, and --body is
+# not --base.
+#
+# A flag whose value never arrives -- `gh pr create -B` at the end of the line
+# -- reports no base, and the caller refuses that as a create naming none. An
+# unreadable destination is refused rather than left to look like the permitted
+# shape, which is the answer the bare push already has.
+#
+# The trade: quotes are stripped before this runs, so `--title "-B main"` reads
+# as a base of main and is refused. A blocked title is visible and one edit
+# away; this file has taken that direction throughout.
+gh_pr_base() {
+  local TOK WANT=
+  for TOK in $1; do
+    if [ -n "$WANT" ]; then printf '%s' "$TOK"; return 0; fi
+    case "$TOK" in
+      --base=*) printf '%s' "${TOK#--base=}"; return 0 ;;
+      --base)   WANT=1 ;;
+      --*)      ;;
+      -*B)      WANT=1 ;;
+      -*B*)     printf '%s' "${TOK#*B}"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Does this gh pr create hand the pull request off to a browser? The web form
+# creates nothing: it opens a prefilled page where a person chooses the base and
+# confirms, so gh choosing a default is not this command choosing a destination.
+# The exemption covers a missing base and nothing else -- a --base written into
+# the command is still that command naming a destination, and --web does not
+# launder it.
+gh_pr_web() {
+  local TOK
+  for TOK in $1; do
+    case "$TOK" in
+      --web)      return 0 ;;
+      --*)        ;;
+      -*w*)       return 0 ;;
+    esac
+  done
+  return 1
+}
+
+is_dev_base() {
+  printf '%s' "$1" | grep -qE '^dev-[0-9]+$'
+}
 
 # `gh pr merge` is not the only way to write `gh pr merge`. Cobra resolves the
 # subcommand at the first non-flag argument, so a flag may sit in front of it:
@@ -74,6 +166,20 @@ GHRELEASE='^gh[[:space:]]+release([[:space:]]+((-R|--repo|--hostname)[[:space:]]
 # contain, and --repo would read as --request-changes.
 VERDICT='[[:space:]](--approve|--request-changes|-[A-Za-z]*[ar][A-Za-z]*)([[:space:]]|=|"|$)'
 
+# A base carried in a gh api call: `-f base=dev-05`, `-fbase=dev-05`, and the
+# graphql field `baseRefName: "dev-05"`. Two patterns rather than one negated
+# one -- is a base named here at all, and is the one named a dev branch --
+# because they answer different questions, and a base that matches the first and
+# not the second is a destination this file cannot read, which is refused.
+#
+# The alternation puts baseRefName first: POSIX matching is leftmost-longest and
+# would take it anyway, but a rule this file rests on should not need that to be
+# recalled. The character before `base` is required to be a non-word one, or the
+# `-f`/`-F` it can be written against, so that `rebase` and `database` are the
+# words they are and not this field.
+API_BASE_ANY='(^|[^A-Za-z0-9_]|-[fF])(baseRefName|base)[[:space:]]*[=:]'
+API_BASE_DEV="(^|[^A-Za-z0-9_]|-[fF])(baseRefName|base)[[:space:]]*[=:][[:space:]]*[\"']?dev-[0-9]+[\"']?([^A-Za-z0-9_.-]|\$)"
+
 # A wrapper's payload sits inside quotes, where there is no command word for the
 # tokeniser to find, so these run unanchored over the raw text -- and only once
 # a wrapper has been found, never over an ordinary command.
@@ -90,6 +196,19 @@ if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Z
   if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+review([^-A-Za-z0-9_]|$)' \
      && echo "$COMMAND" | grep -qE "$VERDICT"; then
     echo "$DECIDE A shell wrapper does not change what the command decides." >&2
+    exit 2
+  fi
+  # Making or retargeting a pull request inside a wrapper is refused outright,
+  # for the reason the sibling hook refuses a wrapped push: the destination sits
+  # in quotes, where there is no command position for the tokeniser to find, so
+  # the base cannot be read at all. Permitting a pull request whose destination
+  # is unknown is not the same as permitting one into the active dev branch.
+  # This refuses a wrapped listing of pull requests along with the writes, as
+  # the wrapped read of one is already refused above. Run it unwrapped.
+  if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+([^;&|]*[[:space:]])?(create|edit)([^-A-Za-z0-9_]|$)' \
+     || echo "$COMMAND" | grep -qE '/pulls([^/A-Za-z0-9_-]|$)' \
+     || echo "$COMMAND" | grep -q 'createPullRequest'; then
+    echo "$BASE A shell wrapper hides the base behind quotes, so where this would go cannot be read. Run it unwrapped." >&2
     exit 2
   fi
 fi
@@ -117,6 +236,47 @@ if printf '%s\n' "$CMDS" | grep -qE "${GHRELEASE}(create|delete|delete-asset)([^
   echo "Blocked: publishing or deleting a GitHub release is Bertan's call. This repository is public; a release is visible the moment it exists." >&2
   exit 2
 fi
+
+# The base of every create and every retarget on the line, not the first.
+# cs_gh_args answers about the first match in what it is handed and stops, so it
+# is handed one command at a time -- the fifth defect in lib/command-scan.sh's
+# list, where a second command after ; or && was never examined at all. The
+# scoping is that helper's job rather than a regular expression here: asking
+# whether a flag belongs to *this* command is the question two of the five
+# defects came from being answered ad hoc.
+while IFS= read -r CMD; do
+  if ARGS=$(cs_gh_args 'pr create' <<<"$CMD"); then
+    ARGS=$(printf '%s' "$ARGS" | tr -d '\042\047')
+    if BASE_NAMED=$(gh_pr_base "$ARGS"); then
+      if ! is_dev_base "$BASE_NAMED"; then
+        echo "$BASE This names $BASE_NAMED, which is not a dev-NN branch." >&2
+        exit 2
+      fi
+    elif ! gh_pr_web "$ARGS"; then
+      echo "$BASE No base is named here, so this would go to the repository's default branch." >&2
+      exit 2
+    fi
+  fi
+  # An accepted false positive, and the reason the missing-base message is worth
+  # reading rather than working around: cs_split cuts on the parens of a command
+  # substitution, so a base written after one sits in a later fragment and this
+  # scope does not hold it. Refusing more than a shell would is the direction
+  # lib/command-scan.sh takes throughout, and the remedy is one edit -- put the
+  # base ahead of the substitution. The alternative is a rule that reaches
+  # across the cut for a base that may belong to a different command entirely.
+  #
+  # Editing a pull request stays allowed; moving its base is the same choice of
+  # destination made a second time, so it is checked, and only when it is there.
+  if ARGS=$(cs_gh_args 'pr edit' <<<"$CMD"); then
+    ARGS=$(printf '%s' "$ARGS" | tr -d '\042\047')
+    if BASE_NAMED=$(gh_pr_base "$ARGS") && ! is_dev_base "$BASE_NAMED"; then
+      echo "$BASE Retargeting to $BASE_NAMED chooses that destination just as creating it there would. Edit anything else you like." >&2
+      exit 2
+    fi
+  fi
+done <<CMDLIST
+$CMDS
+CMDLIST
 
 # Is this gh api call a write? Succeeds if it is, or if that cannot be told.
 #
@@ -152,12 +312,24 @@ gh_api_is_write() {
 # body splits on its own braces and parens -- so gh api is looked for among the
 # commands and what it carries anywhere in the text.
 API_WRITE=
+API_CREATE=
 while IFS= read -r CMD; do
   printf '%s\n' "$CMD" | grep -qE '^gh[[:space:]]+api([^-A-Za-z0-9_]|$)' || continue
-  if gh_api_is_write "$CMD"; then API_WRITE=1; break; fi
+  gh_api_is_write "$CMD" || continue
+  API_WRITE=1
+  # The collection endpoint is where a pull request is made; /pulls/N is one
+  # that already exists. Asked of the writing command's own arguments rather
+  # than of the whole line, so that listing pull requests beside an unrelated
+  # write is still a listing. The loop no longer stops at the first write for
+  # that reason.
+  if printf '%s\n' "$CMD" | grep -qE '/pulls([^/A-Za-z0-9_-]|$)'; then API_CREATE=1; fi
 done <<CMDLIST
 $CMDS
 CMDLIST
+# The graphql spelling cannot be scoped the same way: cs_split cuts a mutation
+# body on its own braces and parens, so the verb and the command word are not
+# in the same fragment. It is looked for in the text, as the other mutations are.
+if printf '%s\n' "$SCAN" | grep -q 'createPullRequest'; then API_CREATE=1; fi
 
 if [ -n "$API_WRITE" ]; then
   if echo "$SCAN" | grep -qE '/pulls/[^ ]*/(merge|reviews)'; then
@@ -181,6 +353,30 @@ if [ -n "$API_WRITE" ]; then
   fi
   if echo "$SCAN" | grep -qE 'mergePullRequest|addPullRequestReview|closePullRequest|reopenPullRequest|createRelease|updateRelease|deleteRelease'; then
     echo "$DECIDE Reaching the same decision through a graphql mutation is the same decision by another name." >&2
+    exit 2
+  fi
+
+  # Where a pull request is going, reached through gh api rather than gh pr.
+  # gh_api_is_write is the gate and the endpoint is not: refusing by endpoint is
+  # what once refused a read of a pull request as though it were a decision, and
+  # a read names no destination to check.
+  #
+  # A base written into a write is that command choosing a destination, whatever
+  # the endpoint carrying it -- POST to the collection creates there, PATCH on
+  # one retargets it, and graphql spells the same field baseRefName. Retitling
+  # through that same PATCH names no base and stays allowed, so the field
+  # decides this as it already decides state.
+  #
+  # A base that is present but not readable as dev-NN is refused: an unreadable
+  # destination must not be able to look like the permitted one, which is the
+  # answer the bare push already has. Accepted with it: prose in a written field
+  # spelling `base:` reads as a base and is refused.
+  if echo "$SCAN" | grep -qiE "$API_BASE_ANY" && ! echo "$SCAN" | grep -qiE "$API_BASE_DEV"; then
+    echo "$BASE Naming it through gh api makes it the same destination under another spelling." >&2
+    exit 2
+  fi
+  if [ -n "$API_CREATE" ] && ! echo "$SCAN" | grep -qiE "$API_BASE_ANY"; then
+    echo "$BASE No base is named here, so this would go to the repository's default branch." >&2
     exit 2
   fi
 fi

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -93,9 +93,17 @@ DECIDE="Blocked: deciding a pull request is Bertan's call, not an agent's. Openi
 
 BASE="Blocked: a pull request may be proposed only into the active dev branch, and the base has to be named in the command. Write: gh pr create --base dev-NN --title ... --body ..."
 
-# The base named in one gh pr command's arguments. Prints it and succeeds;
-# prints nothing and fails if no base flag is there at all, which is the shape
-# that lets gh pick the repository's default branch for itself.
+# Every base named in one gh pr command's arguments, one per line. Prints
+# nothing when no base flag is there at all, which is the shape that lets gh
+# pick the repository's default branch for itself.
+#
+# Every, not the first, and not the last. gh takes the last of a repeated flag,
+# so a rule reading one occurrence can be answered by the other: reading the
+# first, `--base dev-05 -B main` opened into main while satisfying a check that
+# had already seen a dev branch. Reading the last would only move which half
+# lies. Requiring all of them to be dev-NN is the answer that does not depend on
+# knowing gh's precedence, and it is the refusing direction when they disagree.
+# Found by review of be0e3c7, not by the suite.
 #
 # -B is the shorthand, and gh takes shorthand flags bundled with their value
 # attached or separate, so `-B main`, `-Bmain`, `-dB main` and `-dBmain` are one
@@ -105,26 +113,25 @@ BASE="Blocked: a pull request may be proposed only into the active dev branch, a
 # not --base.
 #
 # A flag whose value never arrives -- `gh pr create -B` at the end of the line
-# -- reports no base, and the caller refuses that as a create naming none. An
-# unreadable destination is refused rather than left to look like the permitted
-# shape, which is the answer the bare push already has.
+# -- names no base, and the caller refuses it as a create naming none, which is
+# what it is.
 #
 # The trade: quotes are stripped before this runs, so `--title "-B main"` reads
 # as a base of main and is refused. A blocked title is visible and one edit
-# away; this file has taken that direction throughout.
-gh_pr_base() {
+# away; this file has taken that direction throughout. The opposite direction is
+# not symmetrical and is not taken -- see gh_pr_web.
+gh_pr_bases() {
   local TOK WANT=
   for TOK in $1; do
-    if [ -n "$WANT" ]; then printf '%s' "$TOK"; return 0; fi
+    if [ -n "$WANT" ]; then printf '%s\n' "$TOK"; WANT=; continue; fi
     case "$TOK" in
-      --base=*) printf '%s' "${TOK#--base=}"; return 0 ;;
+      --base=*) printf '%s\n' "${TOK#--base=}" ;;
       --base)   WANT=1 ;;
       --*)      ;;
       -*B)      WANT=1 ;;
-      -*B*)     printf '%s' "${TOK#*B}"; return 0 ;;
+      -*B*)     printf '%s\n' "${TOK#*B}" ;;
     esac
   done
-  return 1
 }
 
 # Does this gh pr create hand the pull request off to a browser? The web form
@@ -133,13 +140,27 @@ gh_pr_base() {
 # The exemption covers a missing base and nothing else -- a --base written into
 # the command is still that command naming a destination, and --web does not
 # launder it.
+#
+# Two narrowings, both because this is the one test here that PERMITS, so a
+# token read too generously is a pull request into main rather than a refusal
+# someone can see. It was written both ways round first, and both were holes
+# found by review of be0e3c7:
+#
+#   - only `--web` and exactly `-w` count, where any single-dash token holding a
+#     w counted before. A label value of `-wip` and an assignee of `-w` are not
+#     the web form, and `gh pr create -l -wip` opened into main.
+#   - the caller hands this the arguments with QUOTED SPANS REMOVED, not merely
+#     unquoted. `--title "Handle -w in gh_pr_web"` is prose, and prose in this
+#     repository names flags -- that title is one a session on this very file
+#     would write. Deleting the span cannot invent a flag; unquoting one can.
+#
+# The asymmetry with gh_pr_bases is deliberate and is the whole point: quoted
+# text may still trigger a refusal there, and may not grant an exemption here.
 gh_pr_web() {
   local TOK
   for TOK in $1; do
     case "$TOK" in
-      --web)      return 0 ;;
-      --*)        ;;
-      -*w*)       return 0 ;;
+      --web|-w) return 0 ;;
     esac
   done
   return 1
@@ -147,6 +168,53 @@ gh_pr_web() {
 
 is_dev_base() {
   printf '%s' "$1" | grep -qE '^dev-[0-9]+$'
+}
+
+# Is this gh api call a write? Succeeds if it is, or if that cannot be told.
+#
+# gh sends GET unless told otherwise, and switches to POST the moment a field or
+# input flag appears, so a call carrying neither is a read. The test is the
+# method and not the endpoint because the endpoint does not distinguish them:
+# GET /pulls/N/reviews lists reviews and GET /pulls/N/merge reports whether the
+# PR is merged. Both are reading a pull request, which CLAUDE.md allows in the
+# same sentence that forbids deciding one.
+#
+# Any token beginning -f or -F counts, not just `-f x=y`: gh accepts the value
+# attached, and `-fevent=APPROVE` is the same request as `-f event=APPROVE`.
+# A method that cannot be parsed is treated as a write.
+#
+# It is defined here, above every rule, rather than beside the gh api rules it
+# was written for: the wrapper rule calls it too and runs first.
+gh_api_is_write() {
+  local CMD="$1" METHOD
+  METHOD=$(printf '%s' "$CMD" | sed -nE 's/.*(^|[[:space:]])(-X|--method)[[:space:]=]*([A-Za-z]+).*/\3/p')
+  if [ -n "$METHOD" ]; then
+    case "$METHOD" in
+      GET|get|Get|HEAD|head|Head) ;;
+      *) return 0 ;;
+    esac
+  elif printf '%s' "$CMD" | grep -qE '(^|[[:space:]])(-X|--method)([[:space:]]|=|$)'; then
+    return 0
+  fi
+  if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])(-[fF]|--field|--raw-field|--input)'; then
+    return 0
+  fi
+  return 1
+}
+
+# Refuse unless every base in a newline-separated list is a dev-NN branch. The
+# offending one is left in BAD_BASE for the caller's message. An empty list is
+# no bases, which is a different question and the caller's to ask.
+bases_all_dev() {
+  local B
+  BAD_BASE=
+  [ -n "$1" ] || return 0
+  while IFS= read -r B; do
+    if ! is_dev_base "$B"; then BAD_BASE=$B; return 1; fi
+  done <<BASELIST
+$1
+BASELIST
+  return 0
 }
 
 # `gh pr merge` is not the only way to write `gh pr merge`. Cobra resolves the
@@ -166,19 +234,37 @@ GHRELEASE='^gh[[:space:]]+release([[:space:]]+((-R|--repo|--hostname)[[:space:]]
 # contain, and --repo would read as --request-changes.
 VERDICT='[[:space:]](--approve|--request-changes|-[A-Za-z]*[ar][A-Za-z]*)([[:space:]]|=|"|$)'
 
-# A base carried in a gh api call: `-f base=dev-05`, `-fbase=dev-05`, and the
-# graphql field `baseRefName: "dev-05"`. Two patterns rather than one negated
-# one -- is a base named here at all, and is the one named a dev branch --
-# because they answer different questions, and a base that matches the first and
-# not the second is a destination this file cannot read, which is refused.
+# Every base a gh api call names, in the two shapes gh accepts one. Both print
+# the values, one per line, for bases_all_dev -- the same "every, not the last"
+# answer gh_pr_bases gives, and for the same reason: `-f base=dev-05 -f
+# base=main` must not be answered by whichever occurrence a rule happened to
+# look at.
 #
-# The alternation puts baseRefName first: POSIX matching is leftmost-longest and
-# would take it anyway, but a rule this file rests on should not need that to be
-# recalled. The character before `base` is required to be a non-word one, or the
-# `-f`/`-F` it can be written against, so that `rebase` and `database` are the
-# words they are and not this field.
-API_BASE_ANY='(^|[^A-Za-z0-9_]|-[fF])(baseRefName|base)[[:space:]]*[=:]'
-API_BASE_DEV="(^|[^A-Za-z0-9_]|-[fF])(baseRefName|base)[[:space:]]*[=:][[:space:]]*[\"']?dev-[0-9]+[\"']?([^A-Za-z0-9_.-]|\$)"
+# REST: the value is a FIELD, so the field flag is part of the pattern. Matching
+# the bare word instead read `-f title="base: dev-05"` as a base, so a create
+# naming none of its own was permitted. Reported on the review of be0e3c7.
+# `-f base=x`, `-fbase=x` and `--field base=x` are one request written three
+# ways; anchoring on the flag is also what keeps `rebase` and `database` the
+# words they are.
+rest_bases() {
+  printf '%s\n' "$1" \
+    | grep -oiE "(-[fF]|--field|--raw-field)[[:space:]]*base[[:space:]]*=[[:space:]]*[\"']?[^[:space:]\"',}]*" \
+    | sed -E "s/.*=[[:space:]]*[\"']?//"
+}
+
+# graphql: baseRefName stands on its own, and has to. cs_split cuts a mutation
+# body on its own braces and parens, so the field and the command word are never
+# in the same fragment -- which is why this one is asked of the whole normalised
+# text where the REST pair is asked of a single command. The cost is the bleed
+# the REST rule no longer has: a mutation on one command and a baseRefName on
+# another read as one. Accepted, because scoping it would mean re-deriving the
+# split this file delegates to lib/command-scan.sh, and the shape is not one an
+# agent writes by accident.
+gql_bases() {
+  printf '%s\n' "$1" \
+    | grep -oiE "baseRefName[[:space:]]*:[[:space:]]*[\"']?[^[:space:]\"',})]*" \
+    | sed -E "s/.*:[[:space:]]*[\"']?//"
+}
 
 # A wrapper's payload sits inside quotes, where there is no command word for the
 # tokeniser to find, so these run unanchored over the raw text -- and only once
@@ -203,10 +289,21 @@ if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Z
   # in quotes, where there is no command position for the tokeniser to find, so
   # the base cannot be read at all. Permitting a pull request whose destination
   # is unknown is not the same as permitting one into the active dev branch.
-  # This refuses a wrapped listing of pull requests along with the writes, as
-  # the wrapped read of one is already refused above. Run it unwrapped.
-  if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+([^;&|]*[[:space:]])?(create|edit)([^-A-Za-z0-9_]|$)' \
-     || echo "$COMMAND" | grep -qE '/pulls([^/A-Za-z0-9_-]|$)' \
+  #
+  # It reaches only as far as that, and no further -- each of these three names
+  # a create or a retarget, not a pull request. A first version refused any
+  # wrapped /pulls, which took a wrapped LISTING with it, and justified itself
+  # by saying the wrapped read of one was already refused. That was not true:
+  # `bash -c 'gh api repos/o/r/pulls/35'` is permitted here and was before. A
+  # comment that argues from a false premise is worse than none, so the premise
+  # is gone and the rule is narrowed to what the ticket asked for. Reported on
+  # the review of be0e3c7. The write test is reused for the REST shape rather
+  # than a second guess at what a write looks like.
+  if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+([^;&|]*[[:space:]])?create([^-A-Za-z0-9_]|$)' \
+     || { echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+([^;&|]*[[:space:]])?edit([^-A-Za-z0-9_]|$)' \
+          && echo "$COMMAND" | grep -qE '(--base|[[:space:]]-[A-Za-z]*B)([[:space:]]|=|$)'; } \
+     || { echo "$COMMAND" | grep -qE '/pulls([^/A-Za-z0-9_-]|$)' \
+          && gh_api_is_write "$COMMAND"; } \
      || echo "$COMMAND" | grep -q 'createPullRequest'; then
     echo "$BASE A shell wrapper hides the base behind quotes, so where this would go cannot be read. Run it unwrapped." >&2
     exit 2
@@ -245,14 +342,19 @@ fi
 # whether a flag belongs to *this* command is the question two of the five
 # defects came from being answered ad hoc.
 while IFS= read -r CMD; do
-  if ARGS=$(cs_gh_args 'pr create' <<<"$CMD"); then
-    ARGS=$(printf '%s' "$ARGS" | tr -d '\042\047')
-    if BASE_NAMED=$(gh_pr_base "$ARGS"); then
-      if ! is_dev_base "$BASE_NAMED"; then
-        echo "$BASE This names $BASE_NAMED, which is not a dev-NN branch." >&2
+  if RAW=$(cs_gh_args 'pr create' <<<"$CMD"); then
+    # Two readings of one argument list, because the two questions want opposite
+    # errors. Unquoting exposes prose as tokens, which can only add a refusal;
+    # deleting the quoted span cannot invent the flag that would remove one.
+    ARGS=$(printf '%s' "$RAW" | tr -d '\042\047')
+    WEBARGS=$(printf '%s' "$RAW" | sed -e 's/"[^"]*"//g' -e "s/'[^']*'//g")
+    BASES=$(gh_pr_bases "$ARGS")
+    if [ -n "$BASES" ]; then
+      if ! bases_all_dev "$BASES"; then
+        echo "$BASE This names $BAD_BASE, which is not a dev-NN branch." >&2
         exit 2
       fi
-    elif ! gh_pr_web "$ARGS"; then
+    elif ! gh_pr_web "$WEBARGS"; then
       echo "$BASE No base is named here, so this would go to the repository's default branch." >&2
       exit 2
     fi
@@ -267,10 +369,10 @@ while IFS= read -r CMD; do
   #
   # Editing a pull request stays allowed; moving its base is the same choice of
   # destination made a second time, so it is checked, and only when it is there.
-  if ARGS=$(cs_gh_args 'pr edit' <<<"$CMD"); then
-    ARGS=$(printf '%s' "$ARGS" | tr -d '\042\047')
-    if BASE_NAMED=$(gh_pr_base "$ARGS") && ! is_dev_base "$BASE_NAMED"; then
-      echo "$BASE Retargeting to $BASE_NAMED chooses that destination just as creating it there would. Edit anything else you like." >&2
+  if RAW=$(cs_gh_args 'pr edit' <<<"$CMD"); then
+    ARGS=$(printf '%s' "$RAW" | tr -d '\042\047')
+    if ! bases_all_dev "$(gh_pr_bases "$ARGS")"; then
+      echo "$BASE Retargeting to $BAD_BASE chooses that destination just as creating it there would. Edit anything else you like." >&2
       exit 2
     fi
   fi
@@ -278,58 +380,43 @@ done <<CMDLIST
 $CMDS
 CMDLIST
 
-# Is this gh api call a write? Succeeds if it is, or if that cannot be told.
-#
-# gh sends GET unless told otherwise, and switches to POST the moment a field or
-# input flag appears, so a call carrying neither is a read. The test is the
-# method and not the endpoint because the endpoint does not distinguish them:
-# GET /pulls/N/reviews lists reviews and GET /pulls/N/merge reports whether the
-# PR is merged. Both are reading a pull request, which CLAUDE.md allows in the
-# same sentence that forbids deciding one.
-#
-# Any token beginning -f or -F counts, not just `-f x=y`: gh accepts the value
-# attached, and `-fevent=APPROVE` is the same request as `-f event=APPROVE`.
-# A method that cannot be parsed is treated as a write.
-gh_api_is_write() {
-  local CMD="$1" METHOD
-  METHOD=$(printf '%s' "$CMD" | sed -nE 's/.*(^|[[:space:]])(-X|--method)[[:space:]=]*([A-Za-z]+).*/\3/p')
-  if [ -n "$METHOD" ]; then
-    case "$METHOD" in
-      GET|get|Get|HEAD|head|Head) ;;
-      *) return 0 ;;
-    esac
-  elif printf '%s' "$CMD" | grep -qE '(^|[[:space:]])(-X|--method)([[:space:]]|=|$)'; then
-    return 0
-  fi
-  if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])(-[fF]|--field|--raw-field|--input)'; then
-    return 0
-  fi
-  return 1
-}
+# gh_api_is_write is defined with the other helpers at the top of this file. It
+# used to sit here, where it reads most naturally -- but the wrapper rule calls
+# it, and the wrapper rule runs first, so a definition here was not yet in scope
+# when it was wanted and the call would have failed quietly to "not a write".
+# That is the permitting direction, and it would not have shown as an error.
 
 # The REST endpoints and the graphql mutations behind those commands. The
 # command word and the payload can be separated by the tokeniser -- a mutation
 # body splits on its own braces and parens -- so gh api is looked for among the
 # commands and what it carries anywhere in the text.
+# Every question here is asked of ONE writing command's own text, never of the
+# line. Asked of the line, a base on a neighbouring command answered for this
+# one in both directions: a create naming no base was permitted because
+# something else on the line said dev-05, and an unrelated issue write was
+# refused because something else said main. That is the first of the five
+# defects lib/command-scan.sh exists to end, reintroduced here for gh api after
+# being fixed for gh pr -- exactly the split between the two spellings that this
+# rule was written to close. Reported on the review of be0e3c7. The loop no
+# longer stops at the first write, because a second write is a second command.
 API_WRITE=
-API_CREATE=
+API_BAD_BASE=
+API_NO_BASE=
 while IFS= read -r CMD; do
   printf '%s\n' "$CMD" | grep -qE '^gh[[:space:]]+api([^-A-Za-z0-9_]|$)' || continue
   gh_api_is_write "$CMD" || continue
   API_WRITE=1
+  CMD_BASES=$(rest_bases "$CMD")
+  if [ -n "$CMD_BASES" ]; then
+    bases_all_dev "$CMD_BASES" || API_BAD_BASE=${BAD_BASE:-nothing readable}
   # The collection endpoint is where a pull request is made; /pulls/N is one
-  # that already exists. Asked of the writing command's own arguments rather
-  # than of the whole line, so that listing pull requests beside an unrelated
-  # write is still a listing. The loop no longer stops at the first write for
-  # that reason.
-  if printf '%s\n' "$CMD" | grep -qE '/pulls([^/A-Za-z0-9_-]|$)'; then API_CREATE=1; fi
+  # that already exists and is not asked for a base it already has.
+  elif printf '%s\n' "$CMD" | grep -qE '/pulls([^/A-Za-z0-9_-]|$)'; then
+    API_NO_BASE=1
+  fi
 done <<CMDLIST
 $CMDS
 CMDLIST
-# The graphql spelling cannot be scoped the same way: cs_split cuts a mutation
-# body on its own braces and parens, so the verb and the command word are not
-# in the same fragment. It is looked for in the text, as the other mutations are.
-if printf '%s\n' "$SCAN" | grep -q 'createPullRequest'; then API_CREATE=1; fi
 
 if [ -n "$API_WRITE" ]; then
   if echo "$SCAN" | grep -qE '/pulls/[^ ]*/(merge|reviews)'; then
@@ -369,13 +456,24 @@ if [ -n "$API_WRITE" ]; then
   #
   # A base that is present but not readable as dev-NN is refused: an unreadable
   # destination must not be able to look like the permitted one, which is the
-  # answer the bare push already has. Accepted with it: prose in a written field
-  # spelling `base:` reads as a base and is refused.
-  if echo "$SCAN" | grep -qiE "$API_BASE_ANY" && ! echo "$SCAN" | grep -qiE "$API_BASE_DEV"; then
-    echo "$BASE Naming it through gh api makes it the same destination under another spelling." >&2
+  # answer the bare push already has.
+  #
+  # The graphql half is settled here rather than in the loop above, on the whole
+  # text, for the reason gql_bases gives. It covers the retarget as well as the
+  # create: updatePullRequest carries the same field, and a rule keyed on the
+  # verb would have answered for one and not the other.
+  GQL_BASES=$(gql_bases "$SCAN")
+  if [ -n "$GQL_BASES" ]; then
+    bases_all_dev "$GQL_BASES" || API_BAD_BASE=${BAD_BASE:-nothing readable}
+  elif echo "$SCAN" | grep -q 'createPullRequest'; then
+    API_NO_BASE=1
+  fi
+
+  if [ -n "$API_BAD_BASE" ]; then
+    echo "$BASE This names $API_BAD_BASE; reaching it through gh api makes it the same destination under another spelling." >&2
     exit 2
   fi
-  if [ -n "$API_CREATE" ] && ! echo "$SCAN" | grep -qiE "$API_BASE_ANY"; then
+  if [ -n "$API_NO_BASE" ]; then
     echo "$BASE No base is named here, so this would go to the repository's default branch." >&2
     exit 2
   fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,12 +232,15 @@ move the rule to a ruleset. Why it was not done, and what would have to be
 checked first, is in `docs/adr/0001-hooks-not-ruleset.md`.
 
 **Deliberately left open.** These stop mistakes, not adversaries: they read the
-text of a command, so a caller that means to evade them can. Three consequences
-are accepted rather than fixed. A push or a decision inside `sh -c` is refused
-outright rather than assessed, because a destination inside quotes cannot be
-read. A quoted multi-line string whose continuation line begins with one of
-these commands is refused although it is only prose — a blocked comment is
-visible and one edit away, a silently permitted push is neither. And nothing in
+text of a command, so a caller that means to evade them can. Four consequences
+are accepted rather than fixed. A push, a decision or a pull request inside
+`sh -c` is refused outright rather than assessed, because a destination inside
+quotes cannot be read — so opening a pull request from a wrapper is refused even
+into the right base. A quoted multi-line string whose continuation line begins
+with one of these commands is refused although it is only prose — a blocked
+comment is visible and one edit away, a silently permitted push is neither. A
+base written after a command substitution is not seen as that command's, because
+the tokeniser cuts on its parens; name the base first. And nothing in
 this repository guards `.claude/`: the only `Edit|Write` hook covers three
 `docs/` directories, so the hook files and `settings.json` that carry this
 boundary are not themselves covered by the boundary. Whether an edit to them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,9 +209,15 @@ An agent may push the branch of the linked worktree it is working in —
 non-forced, and naming that branch in the command, because a bare `git push`
 takes its destination from configuration an agent can itself change: write
 `git push origin <branch>`. That is the whole of what it may push. It may open a
-pull request, comment on one, edit one and read one, through `gh pr view` or
-through a `gh api` request that does not write. It may not merge one, review one
-with a verdict, close or reopen one, or create or delete a release. `main` and
+pull request into the active dev branch — naming that base in the command, for
+the reason a push names its branch: with no base given a pull request goes to
+the repository's default branch, which is `main`. Write
+`gh pr create --base dev-NN`, and the same base in whichever of the four
+spellings is used, `gh pr edit --base` and the two `gh api` forms included. It
+may comment on one, edit one without moving its base, and read one, through
+`gh pr view` or through a `gh api` request that does not write. It may not merge
+one, review one with a verdict, close or reopen one, or create or delete a
+release. `main` and
 `dev-NN` are Bertan's to push; `main` is additionally protected server-side by
 the `main-branch-protection` ruleset, which requires a pull request. Enforced by
 `.claude/hooks/no-git-push.sh` and `no-pr-decisions.sh`, both built on


### PR DESCRIPTION
Closes #40.

All four spellings that create or retarget a pull request were permitted, and
the quietest of them was the most dangerous: with no base given, a pull request
goes to the repository's default branch, which is `main`. Nothing in that
command mentions `main`, so a rule reading the text for a destination could not
have seen it. That is not an evasion but the shape of an ordinary mistake.

The base is now a required, checked argument, on the reasoning already settled
for pushes: a destination that comes from configuration cannot be judged from a
hook, because an agent can set configuration, so the command has to say where it
is going. `gh pr create`, `gh pr edit --base`, the REST write and the graphql
mutation are answered in one place, and the pull-request hook's header widens
from "an agent may not decide a pull request" to "may not decide one, and may
propose one only into the active dev branch". Argument scoping goes through
`cs_gh_args`, added for this in #39.

## Two trades, taken knowingly

**"Active dev branch" is read as the dev-NN shape**, not as a particular branch.
Naming the one live dev branch would mean reading repository state — which
branches exist, or which is newest — and an agent can make a branch as readily
as it can set configuration. A pull request into a dev branch that is no longer
the active one is therefore permitted; `main`, `master`, a worktree branch and a
typo are all refused.

**A base written after a command substitution is not seen**, because the
tokeniser cuts on its parens. The refusal message says to name the base first,
and `CLAUDE.md`'s "Deliberately left open" list now records it.

## The second commit

The first commit's suite was green and named none of the four defects a review
then found — three of them silent and in the permitting direction, which is the
pattern this repository has recorded before:

- a repeated base flag: gh takes the last, the rule read the first, so
  `--base dev-05 -B main` opened into `main`
- the web exemption read any single-dash token holding a `w`, so a label value
  of `-wip` was the browser hand-off — and it read tokens out of quoted prose,
  so `--title "Handle -w in gh_pr_web"` was too
- the `gh api` base was read from the whole line rather than one command, so a
  neighbour answered for a create that named none
- and one scope creep: the wrapper rule refused a wrapped *listing*, justified
  by a comment whose premise was false

A mutation run then showed the new checks did not pin the per-command scoping at
all, so the case that distinguishes it is now named too.

## Verification

- `bash .claude/hooks/check-hooks.sh` — ALL CHECKS PASSED, 292 checks.
- Mutation-checked in both rounds: weakening the dev-NN test, dropping the
  missing-base refusal, dropping either `gh api` rule, dropping the wrapper
  rule, loosening the web match, feeding the web test unquoted arguments, and
  widening the base scope back to the line each turn a named group red.
- Merges cleanly onto the current `dev-05` (which has moved since this branch
  was cut), and the merged hooks pass the merged suite.

Not run: `make upgrade-safe`. This change touches no dependencies, and the
working environment has pre-existing drift from `uv.lock` (`alembic`, `mako`
installed but unsynced) which fails `tests/test_environment_sync.py` on `dev-05`
as well.

https://claude.ai/code/session_01KNJHfbNb2uFLzm41i714Fu


---

## 2026-09-09, merged dev-05 in (commit `42a02d9`)

`dev-05` moved three times while this sat open — #47 (PR #53), #50 (PR #54) and
#51 (PR #56) all landed — and this branch went `CONFLICTING`. Merged rather
than rebased: `no-git-push.sh` refuses a forced push.

Three conflicts in `no-pr-decisions.sh`, none mechanical:

- **The helper block.** This branch's `BASE` message and its six helpers kept;
  `gh_rule` and the heredoc re-admission from `dev-05`; `GHPR` and `GHRELEASE`
  dropped — defined here, referenced nowhere after #47.
- **The `API_WRITE` loop.** `dev-05` finds the call with `cs_gh_args` (#47's
  fix, and what makes `gh --hostname h api -X PUT` an api call); this branch
  keeps the body, which reads *every* write rather than stopping at the first.
  Reverting the detection alone turns two checks red, so both halves are
  load-bearing.
- **The wrapper rule this branch added is gone.** It required `pr` to follow
  `gh` immediately, so `bash -c "gh -R o/r pr create --base main"` opened into
  `main` and was permitted — the command-position question again, in a rule
  written after #47 named it. #51 refuses every wrapped `gh pr`/`gh release`/
  `gh api` whatever follows, covering all four of those shapes, so the rule is
  removed as answered elsewhere rather than reinstated in a fixed form.

**One thing it caught that #51 does not:** a wrapped `curl` posting to
`/pulls`. Left permitted, because the same `curl` written *without* the wrapper
was permitted with this rule in place and still is. Refusing the wrapped
spelling of a command whose plain spelling is allowed is not a boundary, and
#40 asked about the four `gh` spellings.

**Checks.** The two rows pinned ALLOW on the strength of this branch's own
wrapper rule — `a wrapped listing`, `a wrapped label edit` — are refused now
and say why. #47's `gh -R o/r pr create --fill` was ALLOW to show a flag before
the group leaves an ordinary subcommand alone; a create must name a base now,
so it is given one and the baseless spelling is pinned BLOCK beside it. Three
rows added for what this branch used to refuse itself.

**Evidence**, superseding the 292 above:

- `check-hooks.sh` — **470 checks, all passing**.
- Five mutations, each reddening only named checks: dev-NN test widened (27),
  missing-base refusal dropped (11), `gh api` base read from the line (1), the
  api call found by the old positional grep (2), the web exemption reading
  quoted prose (1).
- All four streams verified together: every `#40` spelling correct, a flag
  before the group correct, wrapped shapes refused by #51, the decision rules
  and the redirect drop untouched.

**Flagged, not fixed.** `CLAUDE.md`'s "Deliberately left open" list is now
incomplete rather than wrong: #51 also refuses wrapped *reads* (`gh pr list`,
`gh pr view`), which no entry records. That is #51's consequence, not this
branch's, and the governing document's own claims are not an agent's to
rewrite.


## 2026-09-09, two defects in reading a base (commit `92311cf`)

Found by probing the parsers after the merge above. The suite was green through
both.

**Permitting direction.** `ARGS` was built with `tr -d` over the quote
characters, which keeps what stood between them, so prose became tokens:

```
gh pr create --title t --body "--base dev-05"        was PERMITTED
```

That command names no base, so `gh` sends it to the repository's default
branch — `main`. It is the one shape this branch exists to refuse, arriving
through a body. The trigger is ordinary: a body that quotes the command it is
about is how the pull requests in this repository are written — this one
included.

The same cause refused correct commands: a create with a good base whose body
mentioned `--base`, and an edit whose title did.

Two comments recorded the reasoning that missed it — that unquoting "can only
add a refusal", and that "only the permitting test reads the deleted form".
Where no base is named at all, prose is what supplies one, so the base reader
is a permitting test too. Both comments are corrected rather than left standing.

`base_args` replaces the two ad hoc readings: a base flag's own value is
unquoted, then every remaining quoted span is dropped whole. That is what
`gh_pr_web` already did for `-w` and what `rest_bases` already did by anchoring
on the field flag — three readers of one argument list, and this was the one
still reading prose. Written once, used by both the create and the edit rule,
which had a copy each.

**Refusing direction.** A graphql string value is quoted, and shell quoting
around the query commonly escapes those quotes; `gql_bases` read the backslash
as the whole value and refused a `dev-NN` base for not being one. It sat behind
the two spellings that did work, both already pinned.

**Evidence:** `check-hooks.sh` — **483 checks, all passing**, 13 new. Three
mutations, each reddening only new checks: `base_args` back to `tr -d` (7, in
both directions), `base_args` dropping a base value's quotes too (3),
`gql_bases` no longer unescaping (1).
