### PR TITLE
Refuse the group, not the verb, inside a shell wrapper

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -219,6 +219,19 @@ commit -m "git push --all origin"
 tok 'continuation joined before anything else' \
     'git push   --all origin' \
     "$(printf 'git push \\\n  --all origin\n' | cs_normalise)"
+# The joining half on its own, for a caller that wants it without the heredoc
+# drop -- no-pr-decisions.sh reads raw text because `bash <<EOF` is a wrapper
+# whose payload the drop would take with the body. Same joining as the line
+# above, written as the same literal, because it is the same code.
+tok 'cs_join joins a continuation' \
+    'git push   --all origin' \
+    "$(printf 'git push \\\n  --all origin\n' | cs_join)"
+# And leaves a heredoc body where it stands, which is the whole difference.
+tok 'cs_join keeps a heredoc body' \
+    'cat > f <<EOF
+gh pr merge 5
+EOF' \
+    "$(printf 'cat > f <<EOF\ngh pr merge 5\nEOF\n' | cs_join)"
 tok 'heredoc body dropped' \
     'cat > f <<EOF
 echo after' \
@@ -486,9 +499,10 @@ echo "=== REGRESSION: #51, a flag before the group evaded the wrapper rules ==="
 # The wrapper rules carried the blind spot the section above removed from the
 # ordinary ones, one word earlier. They are unanchored, but `pr` still had to
 # follow `gh` immediately, so a global flag in front of the group hid it and
-# every shape refused above came back the moment it was wrapped. Each row here
-# was PERMITTED against this file's siblings on dev-05 (6f2434c), measured
-# before the fix; each is a reserved act.
+# every shape refused above came back the moment it was wrapped. Each of the
+# eight rows below was PERMITTED by no-pr-decisions.sh on dev-05 (6f2434c),
+# measured before the fix; each is a reserved act. The ninth row is the boundary
+# they marked and was refused there already.
 check no-pr-decisions.sh BLOCK 'bash -c gh -R o/r pr merge'       'bash -c "gh -R o/r pr merge 5"'
 check no-pr-decisions.sh BLOCK 'bash -c gh --repo o/r pr merge'   'bash -c "gh --repo o/r pr merge 5"'
 check no-pr-decisions.sh BLOCK 'bash -c gh --hostname h pr merge' 'bash -c "gh --hostname h pr merge 5"'
@@ -502,6 +516,23 @@ check no-pr-decisions.sh BLOCK 'eval gh -R o/r release delete'    'eval "gh -R o
 # escaped. Kept so a later change cannot lose the half that worked.
 check no-pr-decisions.sh BLOCK 'bash -c gh pr --repo o/r merge'   'bash -c "gh pr --repo o/r merge 5"'
 
+echo "=== REGRESSION: review of #51, a continuation split the payload ==="
+# These rules read raw text, because cs_normalise drops heredoc bodies and
+# `bash <<EOF` is a wrapper. Raw text is line-oriented and grep matches within a
+# line, so a backslash continuation between the command word and the group hid
+# the group -- from these rules only: the ordinary rules read $SCAN, where
+# cs_normalise had already joined it. Found by the Standards review of 48ca05d,
+# which measured the claim "anything may stand between gh and the group" rather
+# than taking it. The joining half of cs_normalise is cs_join now, and these
+# rules call it.
+check no-pr-decisions.sh BLOCK 'continuation between gh and pr'   $'bash -c "gh \\\n pr merge 5"'
+check no-pr-decisions.sh BLOCK 'continuation after a repo flag'   $'bash -c "gh -R o/r \\\n pr merge 5"'
+check no-pr-decisions.sh BLOCK 'continuation before the wrapper'  $'bash \\\n -c "gh pr merge 5"'
+# The ordinary rules were never blind to this, and still are not.
+check no-pr-decisions.sh BLOCK 'continuation, unwrapped merge'    $'gh \\\n pr merge 5'
+# Joining is not dropping: a continuation inside heredoc prose is still prose.
+check no-pr-decisions.sh ALLOW 'a continuation in heredoc prose'  $'cat > /tmp/n.md <<\'MD\'\nthe hook refuses a wrapped \\\ngh pr merge 5\nMD'
+
 echo "=== ACCEPTED false positive: #51, the verb is not read inside a wrapper ==="
 # What refusing the group outright gives up. These are reads and ordinary edits,
 # refused with the writes because a wrapped payload is quoted text with no
@@ -513,8 +544,22 @@ check no-pr-decisions.sh BLOCK 'bash -c gh pr list'          'bash -c "gh pr lis
 check no-pr-decisions.sh BLOCK 'bash -c gh release list'     'bash -c "gh release list"'
 check no-pr-decisions.sh BLOCK 'eval gh api on an issue'     'eval "gh api repos/o/r/issues/27"'
 # And the word alone is enough, wherever it sits: inside a wrapper there is no
-# argument structure to say whether it is a subcommand or prose.
+# argument structure to say whether it is a subcommand or prose. All three
+# words, not just the one that names this file's subject.
 check no-pr-decisions.sh BLOCK 'bash -c a comment naming pr' 'bash -c "gh issue comment 5 -b \"the pr looks fine\""'
+check no-pr-decisions.sh BLOCK 'bash -c a comment naming release' "bash -c \"gh issue comment 5 --body 'approved release notes'\""
+check no-pr-decisions.sh BLOCK 'bash -c a comment naming api'     "bash -c \"gh issue comment 5 --body 'the api is down'\""
+# The third part of the trade: these rules read the whole command rather than
+# the payload, because nothing here can tell the two apart, so an entirely
+# unwrapped gh command sharing a line with a wrapper is refused with it. Under
+# the old rules only merge|close|reopen reached across the line like this;
+# naming the group widens the reach to the reads. Measured dev-05 -> here, each
+# of these went ALLOW -> BLOCK.
+check no-pr-decisions.sh BLOCK 'a wrapper elsewhere, then a view'  'bash -c "make test" && gh pr view 5'
+check no-pr-decisions.sh BLOCK 'a wrapper elsewhere, then an api'  'bash -c "echo hi"; gh api repos/o/r/issues/27'
+# The reach needs a wrapper on the line to begin with. Without one these rules
+# never run, which is what keeps the cost to lines that have both.
+check no-pr-decisions.sh ALLOW 'the same view with no wrapper'     'make test && gh pr view 5'
 # The rule reaches gh's three deciding surfaces and stops there. A wrapped
 # command that is none of them is answered by whatever else covers it, and by
 # this file not at all.

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -482,6 +482,46 @@ check no-pr-decisions.sh BLOCK 'gh release --repo o/r create v1' 'gh release --r
 check no-pr-decisions.sh ALLOW 'gh pr --repo o/r view 35'       'gh pr --repo o/r view 35'
 check no-pr-decisions.sh ALLOW 'gh pr --repo o/r list'          'gh pr --repo o/r list'
 
+echo "=== REGRESSION: #51, a flag before the group evaded the wrapper rules ==="
+# The wrapper rules carried the blind spot the section above removed from the
+# ordinary ones, one word earlier. They are unanchored, but `pr` still had to
+# follow `gh` immediately, so a global flag in front of the group hid it and
+# every shape refused above came back the moment it was wrapped. Each row here
+# was PERMITTED against this file's siblings on dev-05 (6f2434c), measured
+# before the fix; each is a reserved act.
+check no-pr-decisions.sh BLOCK 'bash -c gh -R o/r pr merge'       'bash -c "gh -R o/r pr merge 5"'
+check no-pr-decisions.sh BLOCK 'bash -c gh --repo o/r pr merge'   'bash -c "gh --repo o/r pr merge 5"'
+check no-pr-decisions.sh BLOCK 'bash -c gh --hostname h pr merge' 'bash -c "gh --hostname h pr merge 5"'
+check no-pr-decisions.sh BLOCK 'bash -c gh -R o/r pr close'       'bash -c "gh -R o/r pr close 5"'
+check no-pr-decisions.sh BLOCK 'bash -c gh -R o/r pr review -a'   'bash -c "gh -R o/r pr review 5 --approve"'
+check no-pr-decisions.sh BLOCK 'bash -c gh -R o/r release create' 'bash -c "gh -R o/r release create v1"'
+check no-pr-decisions.sh BLOCK 'sh -c gh -R o/r pr reopen'        'sh -c "gh -R o/r pr reopen 5"'
+check no-pr-decisions.sh BLOCK 'eval gh -R o/r release delete'    'eval "gh -R o/r release delete v1"'
+# The boundary the table marked: a flag *between* the group and the verb was
+# caught by the `.*` all along, so it was the flag before the group alone that
+# escaped. Kept so a later change cannot lose the half that worked.
+check no-pr-decisions.sh BLOCK 'bash -c gh pr --repo o/r merge'   'bash -c "gh pr --repo o/r merge 5"'
+
+echo "=== ACCEPTED false positive: #51, the verb is not read inside a wrapper ==="
+# What refusing the group outright gives up. These are reads and ordinary edits,
+# refused with the writes because a wrapped payload is quoted text with no
+# command word in it -- the same reason the method of a wrapped `gh api` is not
+# read either, which is the check at 'a GET inside bash -c' above. Every one is
+# one edit away from working: run it unwrapped.
+check no-pr-decisions.sh BLOCK 'bash -c gh pr view'          'bash -c "gh pr view 5"'
+check no-pr-decisions.sh BLOCK 'bash -c gh pr list'          'bash -c "gh pr list"'
+check no-pr-decisions.sh BLOCK 'bash -c gh release list'     'bash -c "gh release list"'
+check no-pr-decisions.sh BLOCK 'eval gh api on an issue'     'eval "gh api repos/o/r/issues/27"'
+# And the word alone is enough, wherever it sits: inside a wrapper there is no
+# argument structure to say whether it is a subcommand or prose.
+check no-pr-decisions.sh BLOCK 'bash -c a comment naming pr' 'bash -c "gh issue comment 5 -b \"the pr looks fine\""'
+# The rule reaches gh's three deciding surfaces and stops there. A wrapped
+# command that is none of them is answered by whatever else covers it, and by
+# this file not at all.
+check no-pr-decisions.sh ALLOW 'bash -c gh issue close'      'bash -c "gh issue close 27"'
+check no-pr-decisions.sh ALLOW 'bash -c gh issue list'       'bash -c "gh issue list"'
+check no-pr-decisions.sh ALLOW 'bash -c an ordinary command' 'bash -c "make test"'
+
 echo "=== REGRESSION: review of 02a14d8, close and release through gh api ==="
 # Closing a PR and publishing a release were refused in the gh spelling and open
 # through gh api, so the boundary was spelling-dependent exactly where the file

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -114,7 +114,22 @@ cs_normalise() {
     # The terminator never arrived, so this was not a heredoc and the lines were
     # dropped in error. Give them back.
     END { for (i = 1; i <= nheld; i++) print held[i] }' \
-  | awk '
+  | cs_join
+}
+
+# Join backslash line continuations, and nothing else.
+#
+# The second half of cs_normalise, on its own, for a caller that needs the
+# joining without the heredoc drop. no-pr-decisions.sh is one: its wrapper rules
+# read raw text because cs_normalise drops heredoc bodies and `bash <<EOF` is
+# itself a wrapper, so the payload would go with the body -- but grep matches
+# within a line, and a continuation between a command word and its subcommand
+# hid the subcommand from a rule that could not tokenise it anyway.
+#
+# Extracted rather than copied. A rule written twice is answered twice, which is
+# the thing this file exists to stop.
+cs_join() {
+  awk '
     {
       line = $0
       while (line ~ /\\$/) {

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -38,14 +38,14 @@
 # Two things here are still position-dependent, and neither is an oversight of
 # the same kind. VERDICT anchors at ^, but at the start of a command's own
 # argument list rather than at a command word -- the opposite of a position
-# question, and why it can be written there at all. The wrapper rules below do
-# describe one, and that is a known open hole rather than a design: they require
-# the group to follow gh immediately, so `bash -c "gh -R o/r pr merge 5"` is
-# permitted while `bash -c "gh pr merge 5"` is refused. Measured, pre-existing,
-# and not fixable the way the rules above were -- a quoted payload has no
-# command word for cs_gh_args to find, which is the whole reason these are a
-# blunt text match. Issue #51 carries it, and the question it has to settle is
-# whether naming the verb inside a wrapper is worth doing at all.
+# question, and why it can be written there at all. The wrapper rules below no
+# longer describe one. They used to: the group had to follow gh immediately, so
+# `bash -c "gh -R o/r pr merge 5"` was permitted while `bash -c "gh pr merge 5"`
+# was refused. That was never fixable the way the rules above were -- a quoted
+# payload has no command word for cs_gh_args to find, which is the whole reason
+# these are a blunt text match. Issue #51 settled it the only other way, by not
+# reading the verb at all, so what these rules name now is a group standing
+# anywhere on the line and nothing after it.
 #
 # STOPPING RULE. A newly found evasion earns a fix only if it is a shape an
 # agent would plausibly write, not one it would have to construct. A flag

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -21,8 +21,9 @@
 #
 # The wrapper rule below is the exception to the method test, and stays blunt on
 # purpose: inside `bash -c '...'` the payload is quoted text, so neither the
-# method nor anything else can be read out of it. A read of a PR wrapped in a
-# shell is refused with the writes. Run it unwrapped.
+# method nor the subcommand nor anything else can be read out of it. A read of a
+# PR wrapped in a shell is refused with the writes, and so is every wrapped
+# `gh pr`, `gh release` and `gh api` whatever verb follows. Run it unwrapped.
 #
 # Finding commands in the text is lib/command-scan.sh's job. Each line it
 # returns is one command with everything before the command word removed, so
@@ -74,22 +75,40 @@ GHRELEASE='^gh[[:space:]]+release([[:space:]]+((-R|--repo|--hostname)[[:space:]]
 # contain, and --repo would read as --request-changes.
 VERDICT='[[:space:]](--approve|--request-changes|-[A-Za-z]*[ar][A-Za-z]*)([[:space:]]|=|"|$)'
 
+# Inside a wrapper the group is the whole of what a rule can honestly name.
+# These ran unanchored over the raw text and still wanted `pr` to follow `gh`
+# immediately, so `gh -R o/r pr merge 5` was permitted while
+# `gh pr --repo o/r merge 5` was refused -- the command-position question again,
+# one word later, in the sixth place. It is also the one place cs_gh_args cannot
+# answer it: the payload is quoted text with no command word for the tokeniser
+# to find, which is why these rules are a blunt text match to begin with.
+#
+# So the verb is not read at all. Anything may stand between `gh` and the group,
+# and whatever follows the group is not looked at. That is the answer the note
+# at the top of this file already gives -- if nothing can be read out of a
+# wrapped payload, then naming merge|close|reopen inside one is reading it, and
+# the table on issue #51 is what reading it badly looked like.
+#
+# The trade, taken knowingly: every wrapped `gh pr`, `gh release` and `gh api`
+# is refused whatever it goes on to say. It costs `bash -c "gh pr view 5"`,
+# `bash -c "gh release list"` and every wrapped read through `gh api`; it also
+# costs a wrapped `gh issue` whose body happens to contain the word `pr`, since
+# there is no argument structure in quoted text to say which is which. All are
+# reads or ordinary edits, all are refused with the writes for the same reason
+# the method of a wrapped `gh api` was already not read, and all are one edit
+# away from working. Run them unwrapped.
+GH_WRAPPED='gh[[:space:]]+(.*[^-A-Za-z0-9_])?(pr|release|api)([^-A-Za-z0-9_]|$)'
+
 # A wrapper's payload sits inside quotes, where there is no command word for the
 # tokeniser to find, so these run unanchored over the raw text -- and only once
 # a wrapper has been found, never over an ordinary command.
 if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
-  if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+.*(merge|close|reopen)([^-A-Za-z0-9_]|$)' \
-     || echo "$COMMAND" | grep -qE 'gh[[:space:]]+release[[:space:]]+.*(create|delete|delete-asset)([^-A-Za-z0-9_]|$)' \
+  if echo "$COMMAND" | grep -qE "$GH_WRAPPED" \
      || echo "$COMMAND" | grep -qE '/pulls/[^ ]*/(merge|reviews)' \
      || echo "$COMMAND" | grep -qE '/releases([^A-Za-z0-9_-]|$)' \
      || echo "$COMMAND" | grep -qiE 'state[[:space:]]*[=:][[:space:]]*"?(closed|open)"?' \
      || echo "$COMMAND" | grep -qE 'mergePullRequest|addPullRequestReview|closePullRequest|reopenPullRequest|createRelease|updateRelease|deleteRelease'; then
-    echo "$DECIDE A shell wrapper does not change what the command decides." >&2
-    exit 2
-  fi
-  if echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+review([^-A-Za-z0-9_]|$)' \
-     && echo "$COMMAND" | grep -qE "$VERDICT"; then
-    echo "$DECIDE A shell wrapper does not change what the command decides." >&2
+    echo "$DECIDE A shell wrapper does not change what the command decides, and nothing can be read out of its quoted payload -- so gh pr, gh release and gh api are refused there whatever the verb. Run it unwrapped." >&2
     exit 2
   fi
 fi

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -75,40 +75,65 @@ GHRELEASE='^gh[[:space:]]+release([[:space:]]+((-R|--repo|--hostname)[[:space:]]
 # contain, and --repo would read as --request-changes.
 VERDICT='[[:space:]](--approve|--request-changes|-[A-Za-z]*[ar][A-Za-z]*)([[:space:]]|=|"|$)'
 
-# Inside a wrapper the group is the whole of what a rule can honestly name.
-# These ran unanchored over the raw text and still wanted `pr` to follow `gh`
-# immediately, so `gh -R o/r pr merge 5` was permitted while
+# Once a wrapper is on the line, the group is the whole of what a rule can
+# honestly name. These ran unanchored over the raw text and still wanted `pr`
+# to follow `gh` immediately, so `gh -R o/r pr merge 5` was permitted while
 # `gh pr --repo o/r merge 5` was refused -- the command-position question again,
 # one word later, in the sixth place. It is also the one place cs_gh_args cannot
 # answer it: the payload is quoted text with no command word for the tokeniser
 # to find, which is why these rules are a blunt text match to begin with.
 #
-# So the verb is not read at all. Anything may stand between `gh` and the group,
-# and whatever follows the group is not looked at. That is the answer the note
-# at the top of this file already gives -- if nothing can be read out of a
-# wrapped payload, then naming merge|close|reopen inside one is reading it, and
-# the table on issue #51 is what reading it badly looked like.
+# So the verb is not read at all. Anything on the line may stand between `gh`
+# and the group, and whatever follows the group is not looked at. That is the
+# answer the note at the top of this file already gives -- if nothing can be
+# read out of a wrapped payload, then naming merge|close|reopen inside one is
+# reading it, and the table on issue #51 is what reading it badly looked like.
 #
-# The trade, taken knowingly: every wrapped `gh pr`, `gh release` and `gh api`
-# is refused whatever it goes on to say. It costs `bash -c "gh pr view 5"`,
-# `bash -c "gh release list"` and every wrapped read through `gh api`; it also
-# costs a wrapped `gh issue` whose body happens to contain the word `pr`, since
-# there is no argument structure in quoted text to say which is which. All are
-# reads or ordinary edits, all are refused with the writes for the same reason
-# the method of a wrapped `gh api` was already not read, and all are one edit
-# away from working. Run them unwrapped.
-GH_WRAPPED='gh[[:space:]]+(.*[^-A-Za-z0-9_])?(pr|release|api)([^-A-Za-z0-9_]|$)'
+# The name says surface rather than wrapper because a group is what it matches,
+# and says anywhere because that is where it looks: these rules read the whole
+# command and not the payload, there being nothing here that tells the two
+# apart. That is the third part of the trade below.
+#
+# The trade, taken knowingly, in three parts.
+#
+#   1. Every wrapped `gh pr`, `gh release` and `gh api` is refused whatever it
+#      goes on to say: `bash -c "gh pr view 5"`, `bash -c "gh release list"`,
+#      every wrapped read through `gh api`.
+#   2. So is a wrapped `gh` command that is none of the three but whose text
+#      carries one of the words anyway -- an issue comment whose body says
+#      `pr`, `release` or `api` -- because quoted text has no argument
+#      structure to say whether a word is a subcommand or prose.
+#   3. So is an entirely unwrapped one that merely shares a line with a
+#      wrapper: `bash -c "make test" && gh pr view 5`. Under the old rules only
+#      merge|close|reopen reached across the line this way; naming the group
+#      widens the reach to the reads. Matching inside the wrapper's own quotes
+#      is what would narrow it, and reading inside those quotes is the thing
+#      this entire section says cannot be done.
+#
+# All three are reads or ordinary edits, all are refused with the writes for the
+# same reason the method of a wrapped `gh api` was already not read, and all are
+# one edit away from working. Run them unwrapped, on a line of their own.
+GH_SURFACE_ANYWHERE='gh[[:space:]]+(.*[^-A-Za-z0-9_])?(pr|release|api)([^-A-Za-z0-9_]|$)'
 
 # A wrapper's payload sits inside quotes, where there is no command word for the
-# tokeniser to find, so these run unanchored over the raw text -- and only once
-# a wrapper has been found, never over an ordinary command.
-if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
-  if echo "$COMMAND" | grep -qE "$GH_WRAPPED" \
-     || echo "$COMMAND" | grep -qE '/pulls/[^ ]*/(merge|reviews)' \
-     || echo "$COMMAND" | grep -qE '/releases([^A-Za-z0-9_-]|$)' \
-     || echo "$COMMAND" | grep -qiE 'state[[:space:]]*[=:][[:space:]]*"?(closed|open)"?' \
-     || echo "$COMMAND" | grep -qE 'mergePullRequest|addPullRequestReview|closePullRequest|reopenPullRequest|createRelease|updateRelease|deleteRelease'; then
-    echo "$DECIDE A shell wrapper does not change what the command decides, and nothing can be read out of its quoted payload -- so gh pr, gh release and gh api are refused there whatever the verb. Run it unwrapped." >&2
+# tokeniser to find, so these run unanchored over the text -- and only once a
+# wrapper has been found, never over an ordinary command.
+#
+# Raw text rather than $SCAN, because cs_normalise drops heredoc bodies and
+# `bash <<EOF` is itself one of the wrappers: its payload would go with the
+# body. But grep matches within a line, so a backslash continuation between
+# `gh` and the group hid the group from these rules while the ordinary ones,
+# reading $SCAN, saw through it. Joining is the half of cs_normalise these rules
+# do want, and cs_join is that half on its own.
+WRAPTEXT=$(printf '%s\n' "$COMMAND" | cs_join)
+
+if echo "$WRAPTEXT" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
+  if echo "$WRAPTEXT" | grep -qE "$GH_SURFACE_ANYWHERE" \
+     || echo "$WRAPTEXT" | grep -qE '/pulls/[^ ]*/(merge|reviews)' \
+     || echo "$WRAPTEXT" | grep -qE '/releases([^A-Za-z0-9_-]|$)' \
+     || echo "$WRAPTEXT" | grep -qiE 'state[[:space:]]*[=:][[:space:]]*"?(closed|open)"?' \
+     || echo "$WRAPTEXT" | grep -qE 'mergePullRequest|addPullRequestReview|closePullRequest|reopenPullRequest|createRelease|updateRelease|deleteRelease'; then
+    echo "$DECIDE A shell wrapper does not change what the command decides, and its payload cannot be read. Run it unwrapped." >&2
     exit 2
   fi
 fi


### PR DESCRIPTION
Closes #51.

## What was wrong

The wrapper rules in `no-pr-decisions.sh` carried the blind spot #47 removed
from the ordinary rules, one word earlier. They run unanchored over the raw
text, but they still required the group to follow the command word
immediately, so a global flag written in front of it hid the group and every
shape #47 had just closed came back the moment it was wrapped.

All eight PERMITTED rows of the issue's Evidence table were reproduced against
`no-pr-decisions.sh` on dev-05 (6f2434c) before anything was changed, and each
of the eight is a reserved act. The two rows the table marks refused were
refused, so the boundary it describes held exactly: a flag *between* the group
and the verb was caught by the `.*` all along.

## The decision the issue left open

The issue asked whether the verb belongs in these rules at all, and proposed
that it does not. That proposal is taken.

The alternative — letting the pattern skip options between the command word
and the group, as #47 did for the ordinary rules — cannot be done here.
`cs_gh_args` needs a command word to tokenise from, and a wrapped payload is
quoted text that has none; that is why these rules are a blunt text match to
begin with. Writing a fourth positional regex would be the fifth answer to the
command-position question, in the one place the library cannot answer it.

So the verb is not read. `GH_SURFACE_ANYWHERE` names the command word and one
of `pr`, `release`, `api`, allows anything on the line between them, and reads
nothing after. That is the answer the file's own note already gave: if nothing
can be read out of a wrapped payload, then naming `merge|close|reopen` inside
one is reading it, and the Evidence table is what reading it badly looked like.

The second wrapper block, which matched `gh pr review` with a verdict flag, is
subsumed by this and gone.

## What it gives up

Recorded beside the pattern in three parts, and each part pinned by a check:

1. Every wrapped `gh pr`, `gh release` and `gh api` is refused whatever verb
   follows — `bash -c "gh pr view 5"`, `bash -c "gh release list"`, every
   wrapped read through `gh api`.
2. So is a wrapped `gh` command that is none of the three but whose text
   carries one of the words anyway — an issue comment whose body says `pr`,
   `release` or `api` — because quoted text has no argument structure to say
   whether a word is a subcommand or prose.
3. So is an entirely unwrapped one that merely shares a line with a wrapper:
   `bash -c "make test" && gh pr view 5`. Under the old rules only
   `merge|close|reopen` reached across the line this way; naming the group
   widens the reach to the reads.

All are reads or ordinary edits, refused with the writes for the same reason
the *method* of a wrapped `gh api` was already not read — and all are one edit
away from working unwrapped.

## The review round

Three findings, from a Standards and a Spec review of 48ca05d run in parallel:

- **A continuation split the payload.** The comment claimed anything may stand
  between the command word and the group. A newline may not: these rules read
  raw text, and raw text is line-oriented, so `bash -c "gh \` + newline +
  `pr merge 5"` was permitted — by these rules only, since the ordinary ones
  read `$SCAN`, where `cs_normalise` had already joined it. `cs_normalise`'s
  joining half is now `cs_join`, extracted rather than copied, and the wrapper
  rules call it. They still cannot use `cs_normalise` itself: it drops heredoc
  bodies, and `bash <<EOF` is one of the wrappers, so the payload would go with
  the body.
- **The third part of the trade above** was behaviour the diff introduced and
  did not record. Now written down and checked in both directions.
- **Only `pr` was pinned for the prose case**; `release` and `api` behave
  identically and are pinned too.

`GH_WRAPPED` was renamed `GH_SURFACE_ANYWHERE` — it matches a group, not a
wrapper, and it looks at the whole command, not the payload — and the refusal
message is one short sentence again, like its siblings.

## Evidence

`bash .claude/hooks/check-hooks.sh` — **309 checks, all green**. Twenty-eight
are new; every pre-existing check passes unchanged.

Four mutations, each reddening only new checks and no pre-existing one:

| mutation | turns red |
| --- | --- |
| the whole hook restored from dev-05 | 20 checks, all in the #51 sections |
| the wrapper rules read raw `COMMAND` again | the 3 continuation checks |
| the pattern widened to the bare command word | the 2 new ALLOW checks |
| the pattern narrowed back to adjacency | 12 checks |

`make test` — 572 passed, 5 xfailed. Nothing under `src/` or `tests/` is
touched. `make audit` reports one pre-existing advisory on `accelerate`;
`uv.lock` is unchanged by this branch.

## Not fixed here, and not claimed

Two adjacent holes in the wrapper *detection* regex, which this branch does not
touch: `timeout 30 bash -c "..."` is not seen as a wrapper (the regex wants the
wrapper at the start of a command and does not use `cs_split`), and
`bash -c "gh${IFS}pr merge 5"` gets past the whitespace class. Both predate
this work and are outside #51. Worth their own issue.

https://claude.ai/code/session_01V4MsqAQndz9WwmdxELfAPE


---

## 2026-09-09, merged dev-05 in (commit `8316f9f`)

`dev-05` moved twice while this sat open — #47 (PR #53) and #50 (PR #54) both
landed — and this branch went `CONFLICTING`. Merged rather than rebased:
`no-git-push.sh` refuses a forced push, so a rewritten history cannot be
delivered from a worktree.

Two resolutions, neither mechanical:

- **`check-hooks.sh`**, two conflicts, both two sides appending different
  material in the same place. Kept both in each. One sentence in #47's section
  claimed a flag in front of a *wrapped* command was still permitted and that
  no check said otherwise — this branch is what makes that false, so it now
  points at the sections below it.
- **`command-scan.sh` merged clean and wrong.** #50 added its redirect pass at
  the end of `cs_normalise`; this branch had cut `cs_join` out of that same
  spot. Git put the 120-line scanner *inside* `cs_join` — the one function
  whose purpose is joining without dropping, and the caller these wrapper
  rules use precisely because heredoc bodies must not vanish under them. The
  pass is back in `cs_normalise` after the `cs_join` call, which is where #50
  put it. `cs_join` is eleven lines again.

Evidence on the merge commit, superseding the 309 above:

- `check-hooks.sh` — **395 checks, all passing**.
- `cs_normalise` output is **byte-identical to `dev-05`** over a corpus of
  redirects, heredocs, process substitution, continuations and quoted text.
- `cs_join` leaves both a redirect and a heredoc body where they stand.
- All three streams hold together: a wrapped merge behind a global flag is
  refused, an unwrapped read is permitted, a push carrying a redirect is
  permitted while `main` and a forced push are not.

The trade in this PR is unchanged, and so is the open question for the
reviewer: this refuses **every** wrapped `gh pr`/`gh release`/`gh api`,
including reads. PR #55 pins the opposite for two of them
(`a wrapped listing`, `a wrapped label edit`) and cannot land beside this
as both stand.
