### PR TITLE
Refuse work on a worktree branch whose life is over, and arm the detectors that see it

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Regression checks for no-git-push.sh, no-pr-decisions.sh and
-# no-commit-to-main.sh.
+# Regression checks for no-git-push.sh, no-pr-decisions.sh,
+# no-commit-to-main.sh and no-work-on-stale-branch.sh.
 #
 # A hook is a process, so the only way to test one is to run it; what the rule
 # against calling the function under test forbids is deriving the expectation
@@ -158,6 +158,43 @@ says() {  # says <dir> <script> <fragment> <label> <cmd>
          "$label" "$want" "$err"
        FAILED=1 ;;
   esac
+}
+
+# The other half of says: a refusal that must not say something. The fallback
+# detector cannot tell a merged branch from one cut before the dev branch moved,
+# so a message claiming a merge there would be a claim the hook cannot support.
+# Nothing above can catch a message saying too much.
+says_not() {  # says_not <dir> <script> <fragment> <label> <cmd>
+  local dir="$1" script="$2" unwanted="$3" label="$4" cmd="$5" err
+  err=$(printf '%s' "$cmd" | jq -Rs '{tool_name:"Bash",tool_input:{command:.}}' \
+        | ( cd "$dir" && "$HOOKS/$script" ) 2>&1 >/dev/null)
+  case "$err" in
+    *"$unwanted"*) printf '  FAIL %s\n         the refusal must not say |%s|\n         it said |%s|\n' \
+         "$label" "$unwanted" "$err"
+       FAILED=1 ;;
+    *) printf '  ok   says  %s\n' "$label" ;;
+  esac
+}
+
+# A property of a file rather than of a process. See the arming section at the
+# foot of this suite for why one file in .claude/ needs this and the others do
+# not. Fixed strings, not patterns: the expectation is the line as written.
+armed() {  # armed <label> <file> <literal>
+  if grep -qF -- "$3" "$2" 2>/dev/null; then
+    printf '  ok   armed %s\n' "$1"
+  else
+    printf '  FAIL %s\n         expected %s to contain |%s|\n' "$1" "$2" "$3"
+    FAILED=1
+  fi
+}
+
+unarmed() {  # unarmed <label> <file> <literal>
+  if grep -qF -- "$3" "$2" 2>/dev/null; then
+    printf '  FAIL %s\n         %s must not contain |%s|\n' "$1" "$2" "$3"
+    FAILED=1
+  else
+    printf '  ok   armed %s\n' "$1"
+  fi
 }
 
 . ./lib/command-scan.sh
@@ -853,6 +890,267 @@ says "$ON_MAIN" no-commit-to-main.sh "bare 'git push' while on main" \
   'the bare push keeps its own wording' 'git push'
 says "$ON_DEV"  no-commit-to-main.sh 'whether it lands on main' \
   'a directory move says what cannot be judged' "cd $ON_MAIN && git commit -m 'wip'"
+
+echo "=== no-work-on-stale-branch.sh: a branch whose life is over ==="
+# Three lifecycle states in one throwaway repository, all built locally: the
+# remote-tracking refs are written with update-ref, so nothing here reaches a
+# network. Unlike the fixtures above, these need real commits -- ahead/behind
+# is the whole question -- so an identity is set on each commit rather than
+# borrowed from whatever global configuration the runner happens to have.
+LIFE="$FIXTURES/lifecycle"
+git init -q -b main "$LIFE"
+GL="git -C $LIFE -c user.email=checks@example.invalid -c user.name=checks"
+# A remote named origin has to exist for git to resolve an upstream at all --
+# without one, `%(upstream:track)` is empty rather than `[gone]` and the first
+# detector cannot fire. Nothing here ever reaches the URL; the fetch refspec it
+# brings is what maps refs/heads/x to refs/remotes/origin/x.
+$GL remote add origin "$FIXTURES/unreachable-remote.git"
+$GL commit -q --allow-empty -m base
+LIFE_BASE=$($GL rev-parse HEAD)
+$GL commit -q --allow-empty -m advance
+LIFE_TIP=$($GL rev-parse HEAD)
+# The active dev branch, one commit ahead of base. Two decoys stand beside it:
+# origin/dev-foo would win a lexical sort of the glob, and origin/dev-4 would
+# win one against dev-05 unless the sort is a version sort.
+$GL update-ref refs/remotes/origin/dev-05 "$LIFE_TIP"
+$GL update-ref refs/remotes/origin/dev-foo "$LIFE_BASE"
+$GL update-ref refs/remotes/origin/dev-4 "$LIFE_BASE"
+
+# ahead == 0, behind == 1. The fallback detector's case, and nothing else: this
+# branch has no upstream configured, so `[gone]` cannot be what refuses it.
+$GL branch stale-branch "$LIFE_BASE"
+$GL worktree add -q "$LIFE/wt-stale" stale-branch
+
+# upstream configured, remote-tracking ref absent -- what a pruning fetch leaves
+# behind after delete_branch_on_merge removes the branch. Placed at the dev tip
+# so ahead == 0 and behind == 0: the fallback cannot fire here, and a refusal is
+# the gone detector's alone.
+$GL branch gone-branch "$LIFE_TIP"
+$GL config -f "$LIFE/.git/config" branch.gone-branch.remote origin
+$GL config -f "$LIFE/.git/config" branch.gone-branch.merge refs/heads/gone-branch
+$GL worktree add -q "$LIFE/wt-gone" gone-branch
+
+# A fresh worktree branch at the dev tip: ahead == 0, behind == 0.
+$GL branch fresh-branch "$LIFE_TIP"
+$GL worktree add -q "$LIFE/wt-fresh" fresh-branch
+
+# A worktree branch carrying work of its own: ahead == 1.
+$GL branch work-branch "$LIFE_TIP"
+$GL worktree add -q "$LIFE/wt-work" work-branch
+git -C "$LIFE/wt-work" -c user.email=checks@example.invalid -c user.name=checks \
+  commit -q --allow-empty -m own
+
+# The main checkout is moved to the same commit as the stale worktree branch, so
+# the two differ in exactly one thing: where the command runs. An identical
+# command is BLOCK in one and ALLOW in the other, which is the keying claim
+# stated as a check rather than as a sentence in a header.
+$GL update-ref refs/heads/main "$LIFE_BASE"
+
+WT_STALE="$LIFE/wt-stale"
+WT_GONE="$LIFE/wt-gone"
+WT_FRESH="$LIFE/wt-fresh"
+WT_WORK="$LIFE/wt-work"
+
+[ -d "$WT_STALE" ] && [ -d "$WT_GONE" ] && [ -d "$WT_WORK" ] && [ -d "$WT_FRESH" ] || {
+  echo "the lifecycle worktrees were not created; every check below would pass without running the hook" >&2
+  exit 1
+}
+
+echo "--- upstream gone: the branch was merged and its remote half is pruned ---"
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'commit on a merged branch' \
+  'git commit -m "wip"'
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'cherry-pick, the recovery procedure own command' \
+  'git cherry-pick 1234abc'
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'revert on a merged branch' \
+  'git revert HEAD'
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'am on a merged branch' \
+  'git am /tmp/patch.mbox'
+# Merging into a branch that no longer exists on the remote is meaningless, so
+# the carve-out that exists under the fallback does not exist here.
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'merge naming the dev branch is still refused' \
+  'git merge origin/dev-05'
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'rebase naming the dev branch is still refused' \
+  'git rebase origin/dev-05'
+# A refusal mid-rebase strands state the agent cannot exit.
+check_in "$WT_GONE" no-work-on-stale-branch.sh ALLOW 'rebase --continue' \
+  'git rebase --continue'
+check_in "$WT_GONE" no-work-on-stale-branch.sh ALLOW 'merge --abort' \
+  'git merge --abort'
+check_in "$WT_GONE" no-work-on-stale-branch.sh ALLOW 'cherry-pick --skip' \
+  'git cherry-pick --skip'
+check_in "$WT_GONE" no-work-on-stale-branch.sh ALLOW 'a read is not work' \
+  'git log --oneline -5'
+check_in "$WT_GONE" no-work-on-stale-branch.sh ALLOW 'a command with no git in it at all' \
+  'ls -la'
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'a commit wrapped in a shell' \
+  "sh -c 'git commit -m \"wip\"'"
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'a cherry-pick wrapped in eval' \
+  'eval "git cherry-pick 1234abc"'
+
+echo "--- the fallback: ahead == 0, behind > 0 against the active dev branch ---"
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'commit on a branch dev has moved past' \
+  'git commit -m "wip"'
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'cherry-pick' \
+  'git cherry-pick 1234abc'
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'revert' \
+  'git revert HEAD'
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'am' \
+  'git am /tmp/patch.mbox'
+# ahead == 0 means this branch is a strict ancestor of the dev branch, so this
+# is a fast-forward: it creates no commit and masks nothing. Refusing it would
+# deadlock the branch -- no commit, no catch-up, and removing a worktree is a
+# reserved act.
+check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'the catch-up merge, remote spelling' \
+  'git merge origin/dev-05'
+check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'the catch-up merge, short spelling' \
+  'git merge dev-05'
+check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'the catch-up merge, full ref' \
+  'git merge refs/remotes/origin/dev-05'
+check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'the catch-up merge, --ff-only' \
+  'git merge --ff-only origin/dev-05'
+check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'the catch-up rebase' \
+  'git rebase origin/dev-05'
+# Anything else a merge or rebase can name would write a real commit here.
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'a merge naming another branch' \
+  'git merge some-other-branch'
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'a rebase naming another branch' \
+  'git rebase some-other-branch'
+# --no-ff exists to write a merge commit where a fast-forward would do, which is
+# the one thing the carve-out is for not doing.
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'the catch-up merge forced to commit' \
+  'git merge --no-ff origin/dev-05'
+# --onto is where a rebase's destination really is; naming the dev branch after
+# it names it as the source.
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'rebase --onto somewhere else' \
+  'git rebase --onto some-other-branch origin/dev-05'
+# A bare merge takes its argument from configuration and names nothing.
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'a merge naming nothing at all' \
+  'git merge'
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'a rebase naming nothing at all' \
+  'git rebase'
+# The carve-out is the only permitting path out of a refused state, so anything
+# that moves git elsewhere or moves the branch underneath it withdraws it: the
+# state was read here, and these make here the wrong place to have read it.
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'the catch-up merge after a directory change' \
+  "cd $WT_WORK && git merge origin/dev-05"
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'the catch-up merge after a checkout' \
+  'git checkout fresh-branch && git merge origin/dev-05'
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'the catch-up merge with git pointed elsewhere' \
+  'git --git-dir /elsewhere/.git merge origin/dev-05'
+# Every command, not the first: the permitted half does not license the second.
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'a permitted merge followed by a commit' \
+  'git merge origin/dev-05 && git commit -m "wip"'
+check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'rebase --continue' \
+  'git rebase --continue'
+check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'a read is not work' \
+  'git status'
+
+echo "--- branches whose life is not over, and the main checkout ---"
+check_in "$WT_WORK"  no-work-on-stale-branch.sh ALLOW 'a branch carrying work of its own, ahead == 1' \
+  'git commit -m "wip"'
+check_in "$WT_FRESH" no-work-on-stale-branch.sh ALLOW 'a fresh branch at the dev tip, ahead == 0 behind == 0' \
+  'git commit -m "wip"'
+# The same commit, the same state, the same command -- and the main checkout is
+# unaffected, because the guard keys on the linked worktree.
+check_in "$LIFE" no-work-on-stale-branch.sh ALLOW 'the main checkout at the stale branch own commit' \
+  'git commit -m "wip"'
+
+echo "--- abstaining when there is no active dev branch to compare against ---"
+# A fresh clone, or the rotation window after the merged dev-NN is deleted and
+# its successor is not yet pushed.
+NODEV="$FIXTURES/nodev"
+git init -q -b main "$NODEV"
+GN="git -C $NODEV -c user.email=checks@example.invalid -c user.name=checks"
+$GN remote add origin "$FIXTURES/unreachable-remote.git"
+$GN commit -q --allow-empty -m base
+NODEV_BASE=$($GN rev-parse HEAD)
+$GN commit -q --allow-empty -m advance
+$GN branch behind-branch "$NODEV_BASE"
+$GN worktree add -q "$NODEV/wt-behind" behind-branch
+$GN branch nodev-gone-branch "$NODEV_BASE"
+$GN config -f "$NODEV/.git/config" branch.nodev-gone-branch.remote origin
+$GN config -f "$NODEV/.git/config" branch.nodev-gone-branch.merge refs/heads/nodev-gone-branch
+$GN worktree add -q "$NODEV/wt-nodev-gone" nodev-gone-branch
+check_in "$NODEV/wt-behind" no-work-on-stale-branch.sh ALLOW 'no origin/dev-* ref, so the fallback abstains' \
+  'git commit -m "wip"'
+# The gone detector reads the remote's existence, not ancestry against a dev
+# branch, so it is not the fallback and does not abstain with it. A branch whose
+# remote half has been pruned away is merged whether or not this clone has ever
+# seen a dev branch.
+check_in "$NODEV/wt-nodev-gone" no-work-on-stale-branch.sh BLOCK 'upstream gone still refuses with no dev ref' \
+  'git commit -m "wip"'
+
+echo "--- the two refusals say different things, because they know different things ---"
+# `upstream: gone` fires only on the genuinely merged case, so it may say
+# merged. The fallback cannot tell a merged branch from one cut before the dev
+# branch moved, so it must not.
+says "$WT_GONE"  no-work-on-stale-branch.sh 'has been merged' \
+  'the gone refusal names the merge' 'git commit -m "wip"'
+says "$WT_STALE" no-work-on-stale-branch.sh 'no work of its own' \
+  'the fallback refusal is about state' 'git commit -m "wip"'
+says_not "$WT_STALE" no-work-on-stale-branch.sh 'merged' \
+  'the fallback refusal does not claim a merge' 'git commit -m "wip"'
+# The deadlock the carve-out exists to avoid is named in the refusal that would
+# otherwise cause it.
+says "$WT_STALE" no-work-on-stale-branch.sh 'git merge origin/dev-05 is permitted' \
+  'the fallback refusal says how to get out' 'git commit -m "wip"'
+
+echo "--- the guard fails closed when the tokeniser is not beside it, and only where it has an opinion ---"
+cp no-work-on-stale-branch.sh "$FIXTURES/nolib/"
+check_in "$WT_STALE" "$FIXTURES/nolib/no-work-on-stale-branch.sh" BLOCK 'no lib/, on a stale branch' \
+  'git status'
+# Failing closed is scoped to a branch this file has an opinion about. A healthy
+# worktree is not refused because a library is missing.
+check_in "$WT_WORK" "$FIXTURES/nolib/no-work-on-stale-branch.sh" ALLOW 'no lib/, on a branch carrying work' \
+  'git commit -m "wip"'
+
+echo "=== the arming properties, asserted as literals ==="
+# A second kind of check: the ones above drive a hook as a process and read its
+# exit code, and these read a file. It is a new seam in this suite and is named
+# as one.
+#
+# It exists because report-stale-branches.sh arms enforcement rather than
+# performing it. Issue #36 leaves `.claude/` unguarded on the grounds that
+# breakage announces itself -- the refusal stops coming -- and that reasoning
+# does not hold for a file whose failure is that two detectors quietly read
+# stale refs. Dropping --prune from that script changes nothing visible, so
+# these say what must be true of it.
+#
+# This announces at the next review rather than on the next push: the repository
+# has no CI, so the suite runs when someone runs it. That is how every check
+# above already behaves.
+armed 'the report fetches with an explicit prune' \
+  "$HOOKS/report-stale-branches.sh" 'git fetch --prune --quiet origin'
+armed 'the fetch is bounded, so an offline session still starts' \
+  "$HOOKS/report-stale-branches.sh" 'timeout "$FETCH_TIMEOUT" git fetch'
+armed 'a failed fetch says so, because neither detector is armed after one' \
+  "$HOOKS/report-stale-branches.sh" 'FAILED or timed out'
+# Read-only by name and by content. The name is checked by being the path above;
+# the content is checked here.
+unarmed 'the report removes no worktree' \
+  "$HOOKS/report-stale-branches.sh" 'worktree remove'
+unarmed 'the report deletes no branch' \
+  "$HOOKS/report-stale-branches.sh" 'branch -d'
+unarmed 'the report force-deletes no branch' \
+  "$HOOKS/report-stale-branches.sh" 'branch -D'
+unarmed 'the report deletes nothing on the remote' \
+  "$HOOKS/report-stale-branches.sh" 'push origin --delete'
+
+# settings.json is what actually runs either file, so a hook present in the tree
+# and absent from the configuration is a hook that does nothing. jq reads it;
+# the expectation is a literal.
+SETTINGS="$HOOKS/../settings.json"
+tok 'settings.json runs the report at SessionStart' \
+    '"$CLAUDE_PROJECT_DIR"/.claude/hooks/report-stale-branches.sh' \
+    "$(jq -r '.hooks.SessionStart[]?.hooks[]?.command' "$SETTINGS" 2>/dev/null | grep report-stale-branches)"
+tok 'settings.json runs the guard on every Bash command' \
+    '"$CLAUDE_PROJECT_DIR"/.claude/hooks/no-work-on-stale-branch.sh' \
+    "$(jq -r '.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[]?.command' "$SETTINGS" 2>/dev/null | grep no-work-on-stale-branch)"
+# The report's timeout must outlast the fetch it waits on, or the hook is killed
+# before it can say that the fetch failed.
+tok 'the report hook outlasts its own fetch' \
+    '30' \
+    "$(jq -r '.hooks.SessionStart[]?.hooks[]? | select(.command | contains("report-stale-branches")) | .timeout' "$SETTINGS" 2>/dev/null)"
 
 echo
 if [ $FAILED -eq 0 ]; then echo "ALL CHECKS PASSED"; else echo "SOME CHECKS FAILED"; fi

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -978,6 +978,32 @@ check_in "$WT_GONE" no-work-on-stale-branch.sh ALLOW 'merge --abort' \
   'git merge --abort'
 check_in "$WT_GONE" no-work-on-stale-branch.sh ALLOW 'cherry-pick --skip' \
   'git cherry-pick --skip'
+# A commit message is the one argument on this path that carries arbitrary
+# prose, and the arguments are stripped of their quotes before the continuation
+# flags are looked for. So the text of a message read as an option, and
+# `git commit -m "permit rebase --continue"` -- the shape of a message written
+# while working on this very hook -- permitted a commit on a merged branch.
+# Silent, and in the permitting direction. Found by review, not by this suite:
+# every continuation check here drove the bare flag, which is exactly the case
+# that already worked.
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'a commit message naming a continuation flag' \
+  'git commit -m "permit rebase --continue"'
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'a commit message naming --skip' \
+  'git commit -m "handle --skip in the guard"'
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'a merge message naming a continuation flag' \
+  'git merge -m "wip --continue" some-other-branch'
+# An unterminated quote is argument text past the point this can read, and
+# reading argument text as a flag is what permits here, so the ambiguous case
+# must not.
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'an unterminated quote before a continuation flag' \
+  'git commit -m "wip --continue'
+# A continuation flag anywhere but the first argument is not a continuation.
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'a continuation flag trailing a real commit' \
+  'git commit -m "wip" --skip'
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'a continuation flag trailing a cherry-pick' \
+  'git cherry-pick 1234abc --continue'
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'a continuation flag behind an option' \
+  'git rebase --quiet --continue'
 check_in "$WT_GONE" no-work-on-stale-branch.sh ALLOW 'a read is not work' \
   'git log --oneline -5'
 check_in "$WT_GONE" no-work-on-stale-branch.sh ALLOW 'a command with no git in it at all' \
@@ -1042,6 +1068,10 @@ check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'a permitted merge followe
   'git merge origin/dev-05 && git commit -m "wip"'
 check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'rebase --continue' \
   'git rebase --continue'
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'a commit message naming a continuation flag' \
+  'git commit -m "permit rebase --continue"'
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'a merge message naming a continuation flag' \
+  'git merge -m "wip --continue" some-other-branch'
 check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'a read is not work' \
   'git status'
 
@@ -1103,6 +1133,20 @@ check_in "$WT_STALE" "$FIXTURES/nolib/no-work-on-stale-branch.sh" BLOCK 'no lib/
 # worktree is not refused because a library is missing.
 check_in "$WT_WORK" "$FIXTURES/nolib/no-work-on-stale-branch.sh" ALLOW 'no lib/, on a branch carrying work' \
   'git commit -m "wip"'
+# A library that is present but incomplete. cs_git_args is the function whose
+# absence would be silent and permitting: `RAW=$(cs_git_args "$VERB") ||
+# continue` cannot tell "not this verb" from "no such function", so probing
+# cs_split alone left every verb permitted through the check written to stop
+# exactly that. Found by review, not by this suite.
+mkdir -p "$FIXTURES/halflib/lib"
+cp no-work-on-stale-branch.sh "$FIXTURES/halflib/"
+sed 's/^cs_git_args()/cs_renamed_away()/' lib/command-scan.sh > "$FIXTURES/halflib/lib/command-scan.sh"
+grep -q '^cs_renamed_away()' "$FIXTURES/halflib/lib/command-scan.sh" || {
+  echo "the half-library fixture did not rename cs_git_args; the check below proves nothing" >&2
+  exit 1
+}
+check_in "$WT_STALE" "$FIXTURES/halflib/no-work-on-stale-branch.sh" BLOCK 'a library missing only cs_git_args' \
+  'git commit -m "wip"'
 
 echo "=== the arming properties, asserted as literals ==="
 # A second kind of check: the ones above drive a hook as a process and read its
@@ -1135,6 +1179,21 @@ unarmed 'the report force-deletes no branch' \
   "$HOOKS/report-stale-branches.sh" 'branch -D'
 unarmed 'the report deletes nothing on the remote' \
   "$HOOKS/report-stale-branches.sh" 'push origin --delete'
+
+# The active dev branch is derived in both files, and the copies are identical
+# by hand. lib/command-scan.sh's own header names this failure mode -- the same
+# question answered differently in a different place -- and the library is right
+# there, so the duplication is a decision and not an oversight: the guard must
+# read its state before it may depend on lib/ at all. That is what lets it fail
+# closed only on a branch it has an opinion about, rather than refusing every
+# command in every worktree whenever a library is missing. The cost of that
+# ordering is two copies, so the copies are pinned instead of shared. A
+# divergence here silently unarms the guard or misreports the branch.
+DEV_DERIVATION="| grep -E '^origin/dev-[0-9]+\$' | sort -V | tail -1)"
+armed 'the guard derives the active dev branch this way' \
+  "$HOOKS/no-work-on-stale-branch.sh" "$DEV_DERIVATION"
+armed 'and the report derives it identically' \
+  "$HOOKS/report-stale-branches.sh" "$DEV_DERIVATION"
 
 # settings.json is what actually runs either file, so a hook present in the tree
 # and absent from the configuration is a hook that does nothing. jq reads it;

--- a/.claude/hooks/no-work-on-stale-branch.sh
+++ b/.claude/hooks/no-work-on-stale-branch.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+# A worktree branch exists for one pull request. When that pull request merges,
+# the branch has served its purpose: remotely `delete_branch_on_merge` removes
+# it, locally Bertan's sweep does. Nothing stopped work continuing on it in the
+# meantime, and that failure has fired twice -- the probe->check rename was
+# committed onto hooks-push-and-pr-guards after PR #35 had already merged it,
+# and research/non-openrouter-response-bodies sat one commit ahead and nineteen
+# behind with no pull request, loaded to revert nineteen commits the moment
+# anyone proposed it.
+#
+# Keyed on running in a linked worktree, the same keying no-git-push.sh uses and
+# deliberately not on the branch's name. CONTEXT.md's *worktree branch* entry
+# says why at length: worktrees are made two ways here and only one of them
+# prefixes the branch, and a branch in the main checkout can be given whatever
+# name a rule looks for.
+#
+# TWO DETECTORS, EACH COVERING THE OTHER'S BLIND SPOT.
+#
+# *The upstream is gone.* With delete_branch_on_merge on, a merged worktree
+# branch is exactly a branch whose upstream has been pruned away. This reads the
+# remote's existence rather than the commits' ancestry, so no merge style
+# defeats it. `%(upstream:track)` reports `[gone]` for precisely that state --
+# upstream configured, remote-tracking ref absent -- and `%(upstream)` does not,
+# because it keeps naming the ref after the ref is gone. Measured on a fixture.
+#
+# *ahead == 0 && behind > 0* against the active dev branch, as the fallback for
+# when nobody has pruned yet. This one rests on *merged implies ancestor*, which
+# is a property of merge style rather than of git: a squash or a rebase merge
+# rewrites the commits and leaves the branch no ancestor of anything. So
+# allow_squash_merge and allow_rebase_merge are disabled on the repository,
+# making the assumption true by configuration rather than by habit. An
+# assumption a repository setting can silently break is not an assumption; it is
+# a bug with a delay.
+#
+# THE ACTIVE DEV BRANCH is the highest-numbered refs/remotes/origin/dev-*, read
+# with no network because a hook has five seconds. Sorted with `sort -V` and
+# filtered to `^origin/dev-[0-9]+$`, and both halves earn their place: a lexical
+# sort makes dev-09 beat dev-10, and an unfiltered glob lets origin/dev-foo win
+# outright. The branch-hygiene skill mandates two-digit zero-padding, so a
+# lexical sort would be correct today and wrong at dev-10; the version sort does
+# not depend on that mandate holding.
+#
+# When no such ref exists -- a fresh clone, or the rotation window after the
+# merged dev-NN is deleted and its successor is not yet pushed -- the guard
+# ABSTAINS rather than refuses. These stop mistakes, not adversaries.
+#
+# THE MESSAGES STATE WHAT THE HOOK CAN SEE. `upstream: gone` fires only on the
+# genuinely merged case, so that message says "merged" and means it. The
+# fallback cannot distinguish a merged branch from a brand-new worktree branch
+# that has not committed while dev-NN moved on -- the two are topologically
+# identical and only a network call would separate them -- so its message is
+# about state: this branch has no work of its own and the active dev branch has
+# moved past it. check-hooks.sh pins both messages, because a change routing
+# both states through one wording would leave the verdicts green and the claim
+# false.
+#
+# WHICH COMMANDS. Any command that adds a commit makes ahead > 0 and retires the
+# fallback for that branch permanently, so the test is not "would an agent
+# plausibly write this" but "would this silently disable the rule". That is
+# commit, cherry-pick, revert, merge and `am`. cherry-pick is not marginal -- it
+# is the command in this repository's own recovery procedure. rebase is here
+# too, not because it is in that list but because the carve-out below has to
+# answer for it: a rebase onto anything but the active dev branch writes new
+# commits onto this branch exactly as a merge would.
+#
+# Mid-operation continuations -- --continue, --abort, --skip, --quit -- are
+# excluded, and the reason belongs here: a refusal mid-rebase strands state the
+# agent cannot exit, and a guard that leaves the repository in a condition only
+# a human can clear is worse than the mistake it prevents.
+#
+# THE ONE CARVE-OUT. Under the fallback, ahead == 0 means the branch is a strict
+# ancestor of the active dev branch, so merging or rebasing onto that branch is
+# a fast-forward: it creates no commit and masks nothing. Merge was in the set
+# for a hazard unreachable in that exact state, and refusing it there deadlocks
+# the branch -- no commit, no catch-up, and removing a worktree is a reserved
+# act, so a timing race becomes a hand-off to a human. So under the fallback a
+# merge or rebase naming the active dev branch is permitted, and one naming
+# anything else is refused, because that one would create a real commit and
+# would mask. Under `upstream: gone` both are refused: merging into a branch
+# that no longer exists on the remote is meaningless.
+#
+# The carve-out is the only permitting path in a refused state, so it is a
+# whitelist rather than a blacklist. Every token has to be either the active dev
+# branch under one of its four spellings or an option from a short list that
+# takes no value and creates no commit. --no-ff is not on that list and never
+# will be: it is the spelling whose whole purpose is to write a merge commit
+# where a fast-forward would do.
+#
+# ARMED BY report-stale-branches.sh. Both detectors read remote-tracking refs
+# and are exactly as fresh as the last fetch -- the fallback no less than the
+# gone test, since origin/dev-NN is a remote-tracking ref too. A hook cannot
+# fetch, so a SessionStart hook does it, with an explicit --prune. Two soft
+# edges follow and both are deliberate. The fetch fails open, so an offline or
+# slow session proceeds with neither detector armed; that is announced by the
+# report, which says the fetch failed. And permitting the catch-up merge means a
+# genuinely merged branch can be fast-forwarded to the tip, after which both
+# detectors read clean -- a window lasting only a session, in which a merge
+# lands after that session's fetch, closed at the next session start.
+#
+# NOT COVERED, AND DELIBERATELY. `git pull` is fetch plus merge and can write a
+# merge commit; it is not matched here. On a gone branch it fails of its own
+# accord, and on the fallback it is the catch-up the carve-out exists to permit.
+# `git stash pop`, `git apply` and `git checkout -- .` change the working tree
+# and write no commit, so they do not move ahead and do not disable the rule.
+# `git reset` and `git branch -f` can move the branch and are not matched: they
+# are the shapes of a recovery, not of work continuing by mistake.
+#
+# STOPPING RULE, inherited from no-git-push.sh. A newly found evasion earns a
+# fix only if it is a shape an agent would plausibly write, not one it would
+# have to construct. A wrapper's payload sits in quotes where no command
+# position exists, so wrappers are refused outright rather than parsed.
+#
+# This stops mistakes, not adversaries.
+
+set -f
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+
+# Every command this file refuses is a git subcommand, so text with no `git` in
+# it anywhere cannot hold one -- a wrapped payload included, since the payload
+# still carries the word. This bail runs before the library is needed and before
+# any git process is started, so `ls` in a stale worktree costs one grep.
+echo "$COMMAND" | grep -q 'git' || exit 0
+
+# The exception is keyed on where the command runs, not on what the branch is
+# called: in a linked worktree --git-dir is .git/worktrees/<name> while
+# --git-common-dir is .git; in the main checkout the two are equal. The main
+# checkout is unaffected by this file.
+GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null)
+GIT_COMMON_PATH=$(git rev-parse --git-common-dir 2>/dev/null)
+[ -n "$GIT_DIR_PATH" ] || exit 0
+[ "$GIT_DIR_PATH" = "$GIT_COMMON_PATH" ] && exit 0
+
+CURRENT=$(git branch --show-current 2>/dev/null)
+# A detached HEAD has no branch, so neither detector has anything to read.
+[ -n "$CURRENT" ] || exit 0
+
+# The active dev branch. See the header for why the filter and the version sort
+# are both load-bearing.
+DEV=$(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/dev-*' 2>/dev/null \
+      | grep -E '^origin/dev-[0-9]+$' | sort -V | tail -1)
+
+TRACK=$(git for-each-ref --format='%(upstream:track)' "refs/heads/$CURRENT" 2>/dev/null)
+
+STATE=CLEAR
+BEHIND=0
+if [ "$TRACK" = "[gone]" ]; then
+  STATE=GONE
+elif [ -n "$DEV" ] && [ "origin/$CURRENT" != "$DEV" ]; then
+  COUNTS=$(git rev-list --left-right --count "$DEV...refs/heads/$CURRENT" 2>/dev/null)
+  BEHIND=$(printf '%s' "$COUNTS" | cut -f1)
+  AHEAD=$(printf '%s' "$COUNTS" | cut -f2)
+  # An unreadable count is not a stale branch. Abstaining is the same answer
+  # this file gives when there is no dev ref at all.
+  if [ -n "$AHEAD" ] && [ "$AHEAD" -eq 0 ] && [ "$BEHIND" -gt 0 ]; then
+    STATE=STALE
+  fi
+fi
+
+# A branch carrying work of its own, a fresh branch at the dev tip, and every
+# branch in a repository with no origin/dev-* ref at all leave here without an
+# opinion. That is most sessions, and it costs four git reads.
+[ "$STATE" = "CLEAR" ] && exit 0
+
+GONE_REFUSE="Blocked: this worktree branch has been merged. Its branch on the remote is gone, which is what delete_branch_on_merge does when a pull request lands, so work added here now sits on a branch nothing will merge again. Make a new worktree from ${DEV:-the active dev branch} and move the work there."
+STALE_REFUSE="Blocked: this worktree branch has no work of its own and ${DEV:-the active dev branch} is $BEHIND commit(s) ahead of it. A commit here would be the first thing on a branch the active dev branch has already moved past. Catch up first -- git merge ${DEV:-the active dev branch} is permitted from here -- or make a new worktree."
+
+refuse() {
+  if [ "$STATE" = "GONE" ]; then echo "$GONE_REFUSE $1" >&2; else echo "$STALE_REFUSE $1" >&2; fi
+  exit 2
+}
+
+# The branch is stale or gone, so from here the file has an opinion and must be
+# able to read the command to hold it. Without the tokeniser it cannot find a
+# command word at all, and every commit on a merged branch would be permitted.
+# A guard's own breakage refuses; it does not wave things through. Tested for
+# before it is sourced and the functions after: a missing file makes `.` end the
+# shell where an `if` around it never runs, so the guard would have been a
+# comment.
+LIB="$(dirname "$0")/lib/command-scan.sh"
+[ -r "$LIB" ] && . "$LIB"
+if ! command -v cs_split >/dev/null 2>&1; then
+  refuse "(This hook could not load lib/command-scan.sh, so it cannot read what this command does. Refusing rather than permitting.)"
+fi
+
+SCAN=$(printf '%s\n' "$COMMAND" | cs_normalise)
+CMDS=$(printf '%s\n' "$SCAN" | cs_split)
+
+VERBS="commit cherry-pick revert merge am rebase"
+
+# A wrapper's payload sits in quotes, where no command position exists and the
+# tokeniser finds nothing -- so this runs on the raw text and before the search
+# for a command word, exactly as the three sibling hooks do. Ordering it the
+# other way would let every wrapped commit through.
+if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))' \
+   && echo "$COMMAND" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?(commit|cherry-pick|revert|merge|am|rebase)([^-A-Za-z0-9_]|$)'; then
+  refuse "(That command is wrapped in a shell, so what it would write cannot be read through a quoted payload. Run it plainly.)"
+fi
+
+# Whether the carve-out may be taken at all. Everything here moves git somewhere
+# else, or moves the branch under it, so the state read above would not be the
+# state the command runs against -- and the carve-out is the one path out of a
+# refused state. Refusing rather than assessing is what makes the read sound;
+# it is the answer issue #43 gave in no-commit-to-main.sh, and this file is
+# blocked on that one for exactly this reason. The environment spellings come
+# from the un-split text, because cs_split removes assignments to find the
+# command word behind them.
+CARVE=1
+if printf '%s\n' "$CMDS" | grep -qE '^(cd|pushd|popd)([^-A-Za-z0-9_]|$)'; then CARVE=; fi
+if echo "$SCAN" | grep -qE '(GIT_DIR|GIT_WORK_TREE|GIT_COMMON_DIR)='; then CARVE=; fi
+if printf '%s\n' "$CMDS" | grep -qE '^git[[:space:]]+([^[:space:]]+[[:space:]]+)*(-C|--git-dir|--work-tree)([[:space:]]|=)'; then CARVE=; fi
+while IFS= read -r CMD; do
+  if cs_git_args checkout <<<"$CMD" >/dev/null || cs_git_args switch <<<"$CMD" >/dev/null; then
+    CARVE=
+    break
+  fi
+done <<CMDLIST
+$CMDS
+CMDLIST
+
+# The four spellings of the active dev branch. DEV is origin/dev-NN; the local
+# branch of the same name, and both branches' full ref paths, name the same
+# commit for the purpose of a fast-forward.
+DEV_SHORT=${DEV#origin/}
+names_dev() {
+  case "$1" in
+    "$DEV"|"$DEV_SHORT"|"refs/remotes/$DEV"|"refs/heads/$DEV_SHORT") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# A merge or rebase that is a fast-forward onto the active dev branch and
+# nothing else. A whitelist: every token must be one of a short list of options
+# that take no value and create no commit, or a name of that branch, and at
+# least one name must be present. A bare `git merge` takes its argument from
+# configuration and names nothing, so it is refused with the rest.
+is_catch_up() {
+  local ARGS="$1" TOK NAMED=
+  for TOK in $ARGS; do
+    case "$TOK" in
+      --ff|--ff-only|-q|--quiet|-v|--verbose|--stat|--no-stat|--progress|--no-progress|--no-edit) continue ;;
+      -*) return 1 ;;
+    esac
+    names_dev "$TOK" || return 1
+    NAMED=1
+  done
+  [ -n "$NAMED" ]
+}
+
+# Every command, not the first: `git merge dev-05 && git commit -m x` is refused
+# on its second half. Scoping to one occurrence is the fifth defect in
+# lib/command-scan.sh's own list.
+while IFS= read -r CMD; do
+  for VERB in $VERBS; do
+    ARGS=$(cs_git_args "$VERB" <<<"$CMD") || continue
+    ARGS=$(printf '%s' "$ARGS" | tr -d '\042\047')
+
+    # Mid-operation continuations. See the header: a refusal here strands state
+    # the agent cannot exit.
+    if printf ' %s ' "$ARGS" | grep -qE '[[:space:]]--(continue|abort|skip|quit)([[:space:]]|$)'; then
+      continue
+    fi
+
+    if [ "$STATE" = "STALE" ] && { [ "$VERB" = "merge" ] || [ "$VERB" = "rebase" ]; }; then
+      if [ -n "$CARVE" ] && is_catch_up "$ARGS"; then
+        continue
+      fi
+      refuse "(A $VERB naming $DEV would be a fast-forward and is permitted; this one is not that.)"
+    fi
+
+    refuse "(Refused command: git $VERB.)"
+  done
+done <<CMDLIST
+$CMDS
+CMDLIST
+
+exit 0

--- a/.claude/hooks/no-work-on-stale-branch.sh
+++ b/.claude/hooks/no-work-on-stale-branch.sh
@@ -26,11 +26,20 @@
 # *ahead == 0 && behind > 0* against the active dev branch, as the fallback for
 # when nobody has pruned yet. This one rests on *merged implies ancestor*, which
 # is a property of merge style rather than of git: a squash or a rebase merge
-# rewrites the commits and leaves the branch no ancestor of anything. So
-# allow_squash_merge and allow_rebase_merge are disabled on the repository,
-# making the assumption true by configuration rather than by habit. An
-# assumption a repository setting can silently break is not an assumption; it is
-# a bug with a delay.
+# rewrites the commits and leaves the branch no ancestor of anything.
+#
+# So the fallback REQUIRES allow_squash_merge and allow_rebase_merge to be
+# disabled on the repository, which makes the assumption true by configuration
+# rather than by habit. An assumption a repository setting can silently break is
+# not an assumption; it is a bug with a delay.
+#
+# That is a repository setting and not something this file can assert. At the
+# time of writing it is NOT yet applied -- both are still enabled -- and issue
+# #44 carries it as an acceptance criterion for Bertan, because changing a
+# repository setting is not an act an agent takes. Until it is applied, a branch
+# merged by squash or by rebase defeats this detector: its commits are rewritten
+# on the dev branch, so it is no ancestor and reads as ahead > 0. The gone
+# detector still catches that branch, which is the point of having two.
 #
 # THE ACTIVE DEV BRANCH is the highest-numbered refs/remotes/origin/dev-*, read
 # with no network because a hook has five seconds. Sorted with `sort -V` and
@@ -180,7 +189,15 @@ refuse() {
 # comment.
 LIB="$(dirname "$0")/lib/command-scan.sh"
 [ -r "$LIB" ] && . "$LIB"
-if ! command -v cs_split >/dev/null 2>&1; then
+#
+# All three functions are probed, not one. cs_git_args is the one whose absence
+# would be silent and permitting: `RAW=$(cs_git_args "$VERB") || continue`
+# cannot tell "not this verb" from "no such function", so a library holding
+# cs_split but not cs_git_args would leave every verb permitted through the very
+# check written to stop that.
+if ! command -v cs_split >/dev/null 2>&1 \
+   || ! command -v cs_normalise >/dev/null 2>&1 \
+   || ! command -v cs_git_args >/dev/null 2>&1; then
   refuse "(This hook could not load lib/command-scan.sh, so it cannot read what this command does. Refusing rather than permitting.)"
 fi
 
@@ -253,13 +270,28 @@ is_catch_up() {
 # lib/command-scan.sh's own list.
 while IFS= read -r CMD; do
   for VERB in $VERBS; do
-    ARGS=$(cs_git_args "$VERB" <<<"$CMD") || continue
-    ARGS=$(printf '%s' "$ARGS" | tr -d '\042\047')
+    RAW=$(cs_git_args "$VERB" <<<"$CMD") || continue
+    ARGS=$(printf '%s' "$RAW" | tr -d '\042\047')
 
     # Mid-operation continuations. See the header: a refusal here strands state
     # the agent cannot exit.
-    if printf ' %s ' "$ARGS" | grep -qE '[[:space:]]--(continue|abort|skip|quit)([[:space:]]|$)'; then
-      continue
+    #
+    # Matched as the first argument and nowhere else, and never for commit,
+    # which has no continuation at all. Scanning the whole argument list for the
+    # flag is what the first version did, and it read the text of a commit
+    # message as an option: `git commit -m "permit rebase --continue"` -- the
+    # shape of a message written while working on this very hook -- permitted a
+    # commit on a merged branch. Silent, and in the permitting direction. The
+    # quotes have already been stripped by then, so there is no quoting left to
+    # look at; the answer is the position instead.
+    #
+    # A real continuation is the sole argument of the command, so this costs
+    # `git rebase --quiet --continue`, which is refused. Visible, and one edit
+    # away.
+    if [ "$VERB" != "commit" ]; then
+      case "${RAW%%[[:space:]]*}" in
+        --continue|--abort|--skip|--quit) continue ;;
+      esac
     fi
 
     if [ "$STATE" = "STALE" ] && { [ "$VERB" = "merge" ] || [ "$VERB" = "rebase" ]; }; then

--- a/.claude/hooks/report-stale-branches.sh
+++ b/.claude/hooks/report-stale-branches.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# The read-only half of the branch-hygiene sweep, run at SessionStart -- and the
+# thing that arms no-work-on-stale-branch.sh.
+#
+# That guard has two detectors and both read remote-tracking refs: a branch
+# whose upstream is gone, and a branch at ahead == 0 behind > 0 against
+# origin/dev-NN. Remote-tracking refs are exactly as fresh as the last fetch,
+# and a PreToolUse hook has five seconds and cannot fetch. So the fetch happens
+# here, once, before the session starts: the read-only half of the sweep is what
+# arms the enforcing half.
+#
+# It prunes explicitly rather than relying on fetch.prune, because a guard whose
+# soundness depends on per-clone configuration is no-git-push.sh's own objection
+# pointed inward -- and per-clone configuration is missing on exactly the clone
+# where it matters. Without --prune the remote-tracking ref of a merged branch
+# survives its deletion on the remote, `[gone]` never appears, and the first
+# detector silently never fires.
+#
+# READ-ONLY, by name and by content. Removing a worktree or a branch is Bertan's
+# -- a reserved act in CONTEXT.md, and issue #41 declined to carve a hook
+# exception for the sweep. The name is report- and never sweep- because the
+# filename is where that constraint survives the next reader. The only thing
+# here that writes anything is `git fetch --prune`, which writes
+# remote-tracking refs and nothing else: no local branch, no worktree, no
+# checkout.
+#
+# THE ARMING PROPERTY IS NOT SELF-ANNOUNCING. Issue #36 leaves `.claude/`
+# unguarded on the grounds that an agent does not *mistakenly* rewrite the hook
+# that just refused it -- breakage announces itself, because the refusal stops
+# coming. This file breaks that reasoning: it arms enforcement rather than
+# performing it, so dropping --prune from the line below changes nothing
+# visible. The exclusion is not reopened; it is re-argued. Anything in
+# `.claude/` that arms enforcement rather than performing it carries a check
+# asserting its arming property, and check-hooks.sh asserts as a literal that
+# this file's fetch prunes and that settings.json still runs it. That check
+# announces at the next review rather than on the next push, because this
+# repository has no CI: there is no .github/workflows/, so the suite runs when
+# someone runs it. That is how all the existing checks already behave.
+#
+# FAILS OPEN, WITH A TIMEOUT. An offline or slow session must start. When the
+# fetch fails or times out the report says so in as many words, because the
+# consequence is not cosmetic: neither detector is armed for that session, and
+# the guard will read whatever the last successful fetch left behind.
+#
+# Exits 0 always. A SessionStart hook that fails is a session that does not
+# start, and nothing here is worth that.
+FETCH_TIMEOUT=15
+
+cd "$(dirname "$0")/../.." || exit 0
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+echo "== branch lifecycle =="
+
+if ! git remote | grep -qxF origin; then
+  echo "fetch: SKIPPED -- this repository has no remote named origin, so neither"
+  echo "       staleness detector in no-work-on-stale-branch.sh is armed."
+  FETCHED=
+else
+  # --prune written out rather than left to fetch.prune. See the header: this is
+  # the arming property, and check-hooks.sh asserts this line as a literal.
+  if timeout "$FETCH_TIMEOUT" git fetch --prune --quiet origin 2>/dev/null; then
+    echo "fetch: pruned origin"
+    FETCHED=1
+  else
+    echo "fetch: FAILED or timed out after ${FETCH_TIMEOUT}s -- remote-tracking refs are"
+    echo "       as stale as the last successful fetch, so no-work-on-stale-branch.sh"
+    echo "       is not armed for this session."
+    FETCHED=
+  fi
+fi
+
+# The active dev branch: the highest-numbered refs/remotes/origin/dev-*. Sorted
+# with sort -V rather than lexically, and filtered to digits, because both parts
+# matter: a lexical sort makes dev-09 beat dev-10, and an unfiltered glob lets
+# origin/dev-foo -- or origin/dev-05-backup -- win outright. Both were measured
+# on a fixture rather than assumed.
+DEV=$(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/dev-*' 2>/dev/null \
+      | grep -E '^origin/dev-[0-9]+$' | sort -V | tail -1)
+if [ -n "$DEV" ]; then
+  echo "active dev branch: $DEV"
+else
+  echo "active dev branch: none -- no refs/remotes/origin/dev-* exists, so"
+  echo "       no-work-on-stale-branch.sh abstains rather than refusing."
+fi
+
+# Which branch is checked out in which worktree, so a stale branch can be
+# reported with the directory somebody is standing in.
+WT=$(git worktree list --porcelain 2>/dev/null | awk '
+  /^worktree /  { path = substr($0, 10) }
+  /^branch /    { ref = substr($0, 8); sub(/^refs\/heads\//, "", ref); print ref "\t" path }')
+
+STALE=0
+UNCLASSIFIED=0
+CLEAR=0
+REPORT=
+
+while IFS=$'\t' read -r BRANCH TRACK; do
+  [ -n "$BRANCH" ] || continue
+  case "$BRANCH" in main) CLEAR=$((CLEAR + 1)); continue ;; esac
+
+  HERE=$(printf '%s\n' "$WT" | awk -F'\t' -v b="$BRANCH" '$1 == b { print $2 }')
+  [ -n "$HERE" ] && HERE="   [worktree: $HERE]"
+
+  # A dev-NN that is not the active one has been rotated past. That is the
+  # branch-hygiene skill's own definition of stale, not this file's.
+  if printf '%s' "$BRANCH" | grep -qE '^dev-[0-9]+$'; then
+    if [ "origin/$BRANCH" != "$DEV" ]; then
+      REPORT="$REPORT
+  $BRANCH -- rotated past; the active dev branch is ${DEV:-unknown}$HERE"
+      STALE=$((STALE + 1))
+    else
+      CLEAR=$((CLEAR + 1))
+    fi
+    continue
+  fi
+
+  if [ "$TRACK" = "[gone]" ]; then
+    REPORT="$REPORT
+  $BRANCH -- merged: its branch on the remote is gone$HERE"
+    STALE=$((STALE + 1))
+    continue
+  fi
+
+  if [ -z "$DEV" ]; then
+    CLEAR=$((CLEAR + 1))
+    continue
+  fi
+
+  COUNTS=$(git rev-list --left-right --count "$DEV...refs/heads/$BRANCH" 2>/dev/null)
+  BEHIND=$(printf '%s' "$COUNTS" | cut -f1)
+  AHEAD=$(printf '%s' "$COUNTS" | cut -f2)
+  if [ -z "$AHEAD" ]; then
+    CLEAR=$((CLEAR + 1))
+    continue
+  fi
+
+  if [ "$AHEAD" -eq 0 ] && [ "$BEHIND" -gt 0 ]; then
+    # The branch-hygiene skill is explicit that ahead/behind cannot tell a
+    # merged branch from one freshly cut before the dev branch moved. Reported
+    # as state, and called unclassified rather than stale, for that reason.
+    REPORT="$REPORT
+  $BRANCH -- no work of its own; $DEV is $BEHIND ahead of it (unclassified: merged, or cut and not yet worked)$HERE"
+    UNCLASSIFIED=$((UNCLASSIFIED + 1))
+  else
+    CLEAR=$((CLEAR + 1))
+  fi
+done <<BRANCHES
+$(git for-each-ref --format='%(refname:short)%09%(upstream:track)' refs/heads/ 2>/dev/null)
+BRANCHES
+
+if [ -n "$REPORT" ]; then
+  echo "branches whose work may be over:$REPORT"
+else
+  echo "branches whose work may be over: none"
+fi
+echo "$CLEAR other branch(es) are clear; $STALE stale, $UNCLASSIFIED unclassified."
+
+if [ -n "$FETCHED" ]; then
+  echo "Nothing was removed. Deleting a branch or a worktree is a reserved act --"
+  echo "report it and stop; see the branch-hygiene skill."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/no-pr-decisions.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/no-work-on-stale-branch.sh",
+            "timeout": 5
           }
         ]
       },
@@ -46,6 +51,17 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/append-only-docs-edit.sh",
             "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/report-stale-branches.sh",
+            "timeout": 30
           }
         ]
       }

--- a/.claude/skills/branch-hygiene/SKILL.md
+++ b/.claude/skills/branch-hygiene/SKILL.md
@@ -48,6 +48,19 @@ closed-without-merge pull request would discard the work.
 
 ### 2. Report what is stale
 
+Part of this now runs on its own. `.claude/hooks/report-stale-branches.sh` is a
+`SessionStart` hook that does the pruning fetch and reports stale branches and
+the worktrees standing on them — the read-only half of this step, and nothing
+else: it removes nothing, which is why it is named `report-` and not `sweep-`.
+Its output is already in the session; read it before running the commands below,
+and run them for what it does not cover — the pull request state, which needs
+`gh`, and the last commit dates.
+
+That fetch is also what arms `.claude/hooks/no-work-on-stale-branch.sh`, which
+refuses a commit on a branch whose work is over. Both read remote-tracking refs,
+so both are exactly as fresh as that fetch; when the report says the fetch
+failed, neither detector is armed for that session.
+
 ```bash
 git fetch --prune
 git branch -a


### PR DESCRIPTION
Closes #44.

A worktree branch exists for one pull request. When that pull request merges the
branch has served its purpose, and nothing stopped work continuing on it — a
failure that has fired twice here. This adds the guard that refuses it and the
SessionStart script that arms the guard.

## What is here

**`.claude/hooks/no-work-on-stale-branch.sh`** — two detectors, each covering
the other's blind spot. *The upstream is gone*, which with
`delete_branch_on_merge` is exactly what a merged worktree branch looks like,
and which reads the remote's existence rather than the commits' ancestry, so no
merge style defeats it. And *`ahead == 0 && behind > 0`* against the active dev
branch, as the fallback for when nobody has pruned yet. Keyed on running in a
linked worktree, the same keying `no-git-push.sh` uses and deliberately not on
the branch's name.

Refused: `commit`, `cherry-pick`, `revert`, `merge`, `am`, `rebase`.
Mid-operation continuations are permitted — a refusal mid-rebase strands state
the agent cannot exit. Under the fallback a merge or rebase **naming the active
dev branch** is permitted, because at `ahead == 0` that is a fast-forward: it
creates no commit and masks nothing, and refusing it would deadlock the branch.
One naming anything else is refused, and under `upstream: gone` both are.

**`.claude/hooks/report-stale-branches.sh`** — the read-only half of the
branch-hygiene sweep, run at `SessionStart`. Both detectors read
remote-tracking refs and are only as fresh as the last fetch, and a hook cannot
fetch, so this does it with an explicit `--prune` rather than trusting
`fetch.prune`. It fails open with a timeout and says so when it does. Run once
before its checks were written — per the ticket's internal order — it found two
merged worktrees still on disk.

**`check-hooks.sh`** — 347 checks, up from 207. Includes a second kind of check
the ticket names: assertions about a *file* rather than a process, because
`report-stale-branches.sh` arms enforcement rather than performing it, so
dropping its `--prune` would change nothing visible.

## Verification

- `bash .claude/hooks/check-hooks.sh` — ALL CHECKS PASSED (347).
- **Mutation-checked: 24 deliberate breaks, every one turning its own checks
  red.** Each detector, the version sort, the digit filter, the carve-out, the
  worktree keying, the wrapper refusal, the fail-closed path, both `settings.json`
  entries and both arming properties.
- `make test` — 572 passed, 5 xfailed.
- End-to-end against real repository state: the guard refuses a commit in a
  genuinely merged worktree, and is silent in this one and in the main checkout.

## Review found two permitting holes, both fixed in d840e57

Both silent, both in the permitting direction, and the suite was green over
both — the tenth such round on these files.

1. Continuation flags were matched anywhere in a command's arguments, after the
   quotes had been stripped, so `git commit -m "permit rebase --continue"`
   permitted a commit on a merged branch. Matched as the first argument now, and
   never for `commit`. The trade: `git rebase --quiet --continue` is refused.
2. The library probe asked for `cs_split` while the file calls three functions.
   `RAW=$(cs_git_args "$VERB") || continue` cannot tell "not this verb" from "no
   such function", so a half-loaded library permitted every verb through the
   check written to stop exactly that.

## Two things for Bertan

**One acceptance criterion is not met, and cannot be met by an agent.**
`allow_squash_merge` and `allow_rebase_merge` are still enabled on the
repository. The fallback detector rests on *merged implies ancestor*, which is a
property of merge style, so it is unsound until they are disabled: a
squash-merged branch is no ancestor and reads as `ahead > 0`. The gone detector
still catches that branch, which is the point of having two. Changing a
repository setting is not an act an agent takes, so it is left here rather than
done. The header states the dependency and that it is not yet satisfied.

**One interpretation worth a ruling.** The criterion says the guard abstains
when no `refs/remotes/origin/dev-*` exists. That sentence sits in the *active
dev branch* paragraph, so this reads it as governing the ahead/behind fallback
only: the gone detector reads the remote's existence rather than ancestry
against a dev branch, and still refuses in a clone with no dev ref. A branch
whose remote half has been pruned away is merged whether or not this clone has
ever seen a dev branch. Pinned by a check either way, so reversing it is one
edit and one literal.

https://claude.ai/code/session_017GdTHeFNSzxJiZNixD8pFf
