### PR TITLE
Resolve the catch-up ref before permitting it

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -197,8 +197,16 @@ says_not() {  # says_not <dir> <script> <fragment> <label> <cmd>
 # A property of a file rather than of a process. See the arming section at the
 # foot of this suite for why one file in .claude/ needs this and the others do
 # not. Fixed strings, not patterns: the expectation is the line as written.
+# Comments are stripped before the search, and that is the whole point rather
+# than a detail: `grep -qF` over raw file text matches a literal that has been
+# commented OUT, so every one of these stayed green while the line it names did
+# nothing. Found by review of PR #64, not by this suite. Comment-out-and-leave
+# is how a shell script ordinarily gets edited, not a constructed evasion, so
+# this is the permitting-direction defect these checks exist to catch, in the
+# checks themselves. None of the literals below contains a `#`, so stripping
+# from the first one is safe for them.
 armed() {  # armed <label> <file> <literal>
-  if grep -qF -- "$3" "$2" 2>/dev/null; then
+  if sed 's/[[:space:]]*#.*$//' "$2" 2>/dev/null | grep -qF -- "$3"; then
     printf '  ok   armed %s\n' "$1"
   else
     printf '  FAIL %s\n         expected %s to contain |%s|\n' "$1" "$2" "$3"
@@ -1732,7 +1740,53 @@ check_in "$WT_NOLOC" no-work-on-stale-branch.sh BLOCK 'no local dev-05: the shor
 check_in "$WT_NOLOC" no-work-on-stale-branch.sh BLOCK 'no local dev-05: refs/heads/dev-05 names nothing either' \
   'git merge refs/heads/dev-05'
 
-# STATE THREE: the dev tip does not resolve to a commit. The hook holds
+# STATE THREE: a local dev-05 merely BEHIND origin/dev-05 -- not forked, just
+# not pulled. THE SECOND HARMLESS CASE THIS FIX GIVES UP, and the one that
+# starts firing as soon as it lands: worktree pull requests merge into dev-05 on
+# GitHub, so origin/dev-05 moves while the local branch sits still, and that is
+# the ordinary state of this repository rather than an edge of it.
+#
+#   root ---- beh-stale, dev-05 ---- origin/dev-05
+#
+# From beh-stale, `git merge dev-05` is `Already up to date.` -- it writes
+# nothing and masks nothing. It is refused anyway, because the test is an
+# identity and the local branch is not origin/dev-05. Separating this case from
+# the forked one means asking about ancestry, and a hook that rev-parses its way
+# to a merge-base decision is a larger claim than this defect needs. Recorded
+# here, in the file header and in the commit message, per the repository's rule
+# that a fix giving up a case says so in all three.
+BEH="$FIXTURES/behind-dev"
+git init -q -b main "$BEH"
+GH_="git -C $BEH -c user.email=checks@example.invalid -c user.name=checks"
+$GH_ remote add origin "$FIXTURES/unreachable-remote.git"
+$GH_ commit -q --allow-empty -m root
+$GH_ commit -q --allow-empty -m "where local dev-05 stopped"
+BEH_LOCAL=$($GH_ rev-parse HEAD)
+$GH_ commit -q --allow-empty -m "where origin/dev-05 went without it"
+$GH_ update-ref refs/remotes/origin/dev-05 "$($GH_ rev-parse HEAD)"
+$GH_ branch dev-05 "$BEH_LOCAL"
+$GH_ branch beh-stale "$BEH_LOCAL"
+$GH_ worktree add -q "$BEH/wt-beh" beh-stale
+WT_BEH="$BEH/wt-beh"
+need_worktree "$WT_BEH" behind-dev
+# Behind, not forked: the worktree branch IS an ancestor of the local branch, so
+# the merge given up here is a no-op rather than a merge commit. That is the
+# difference from STATE ONE, and asserting it is what stops this fixture
+# quietly turning into a copy of that one.
+$GH_ merge-base --is-ancestor refs/heads/beh-stale refs/heads/dev-05 || {
+  echo "beh-stale is not an ancestor of local dev-05, so this is the forked case again; the checks below prove nothing" >&2
+  exit 1
+}
+$GH_ merge-base --is-ancestor refs/heads/dev-05 refs/remotes/origin/dev-05 || {
+  echo "local dev-05 is not behind origin/dev-05; the checks below prove nothing" >&2
+  exit 1
+}
+check_in "$WT_BEH" no-work-on-stale-branch.sh ALLOW 'local dev-05 behind: the remote spelling is the catch-up' \
+  'git merge origin/dev-05'
+check_in "$WT_BEH" no-work-on-stale-branch.sh BLOCK 'local dev-05 behind: a harmless no-op merge, refused, and recorded as given up' \
+  'git merge dev-05'
+
+# STATE FOUR: the dev tip does not resolve to a commit. The hook holds
 # `[ -n "$DEV_OID" ] || return 1` for it, and that line cannot be reached by
 # running the hook: DEV is the short name of the very ref DEV_OID is read from,
 # so a dev tip that will not resolve is one `git rev-list` cannot read either,
@@ -1896,11 +1950,15 @@ armed 'and the report derives it identically' \
 # The carve-out's identity test, pinned as three lines rather than driven as a
 # process. Two of them are driven, by the diverged and no-local fixtures above;
 # the third -- an unresolvable dev tip -- is not reachable by running this hook,
-# because the ancestry read fails first and the file abstains. It is kept
-# because the carve-out is the only permitting path out of a refused state, and
-# a comparison against an empty string is not a comparison at all: drop the
-# line and `TOK_OID` empty would equal `DEV_OID` empty, permitting the merge on
-# exactly the state that could not be read. This says so; nothing above can.
+# because the ancestry read fails first and the file abstains.
+#
+# The guard line is also redundant with the comparison that follows it, and the
+# first version of this suite claimed otherwise -- that dropping it would let an
+# empty TOK_OID equal an empty DEV_OID. That was false: the rev-parse above the
+# comparison returns on failure and prints an OID on success, so TOK_OID is
+# never empty there. What these three lines pin is that the identity test is
+# spelled the way the file says it is; they are not evidence that any one of
+# them decides an outcome, and the middle one does not.
 armed 'the dev tip is resolved to a commit, from the ref the ancestry was read against' \
   "$HOOKS/no-work-on-stale-branch.sh" \
   'DEV_OID=$(git rev-parse --verify --quiet "refs/remotes/$DEV^{commit}" 2>/dev/null)'

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -206,6 +206,17 @@ armed() {  # armed <label> <file> <literal>
   fi
 }
 
+# A fixture guard rather than a check, and it stops the suite rather than
+# failing one line. An unmade worktree makes ( cd "$dir" && hook ) return 1,
+# which reads as ALLOW -- so every ALLOW-expecting check against it would pass
+# without the hook ever running. That is the shape this suite exists to not
+# have, so it is said once here rather than three times below.
+need_worktree() {  # need_worktree <dir> <fixture name>
+  [ -d "$1" ] && return 0
+  echo "the $2 worktree was not created; the checks against it prove nothing" >&2
+  exit 1
+}
+
 unarmed() {  # unarmed <label> <file> <literal>
   if grep -qF -- "$3" "$2" 2>/dev/null; then
     printf '  FAIL %s\n         %s must not contain |%s|\n' "$1" "$2" "$3"
@@ -1452,6 +1463,12 @@ LIFE_TIP=$($GL rev-parse HEAD)
 $GL update-ref refs/remotes/origin/dev-05 "$LIFE_TIP"
 $GL update-ref refs/remotes/origin/dev-foo "$LIFE_BASE"
 $GL update-ref refs/remotes/origin/dev-4 "$LIFE_BASE"
+# A local dev-05 at the same commit, which is the state a checkout-and-pull
+# leaves. Without it the short-spelling and refs/heads/ catch-up checks below
+# were green for the wrong reason: the hook compared two strings against a ref
+# that did not exist here at all, and `git merge dev-05` run for real in this
+# fixture fails in git. The sibling fixtures hold the other two states.
+$GL branch dev-05 "$LIFE_TIP"
 
 # ahead == 0, behind == 1. The fallback detector's case, and nothing else: this
 # branch has no upstream configured, so `[gone]` cannot be what refuses it.
@@ -1569,6 +1586,8 @@ check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'the catch-up merge, short
   'git merge dev-05'
 check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'the catch-up merge, full ref' \
   'git merge refs/remotes/origin/dev-05'
+check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'the catch-up merge, local full ref' \
+  'git merge refs/heads/dev-05'
 check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'the catch-up merge, --ff-only' \
   'git merge --ff-only origin/dev-05'
 check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'the catch-up rebase' \
@@ -1611,6 +1630,148 @@ check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'a merge message naming a 
   'git merge -m "wip --continue" some-other-branch'
 check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'a read is not work' \
   'git status'
+
+echo "--- the catch-up must name the commit the ancestry was read against ---"
+# The whitelist accepts four spellings, and two of them -- dev-NN and
+# refs/heads/dev-NN -- name a local branch, while ahead == 0 was measured
+# against refs/remotes/origin/dev-NN. A pruning fetch moves the second and never
+# the first, so the two disagree as a matter of course here: worktree pull
+# requests merge into dev-NN on GitHub while the local branch sits still.
+#
+# One repository cannot hold the three states, so there are three. Rejected
+# alternative: `git branch -f dev-05 <other>` partway down the list above -- two
+# lines instead of twenty, but it makes check ORDER load-bearing, and an
+# order-dependent suite quietly stops meaning what it says.
+
+# STATE ONE: a local dev-05 that has diverged from origin/dev-05.
+#
+# Diverged means forked, not merely unequal. A local dev-05 sitting one commit
+# AHEAD of origin/dev-05 is unequal and harmless: the worktree branch is an
+# ancestor of both, so the short spelling is still a fast-forward. The harm
+# needs the worktree branch to be an ancestor of origin/dev-05 and of nothing
+# else, which takes a fork:
+#
+#   root ---- div-stale ---- origin/dev-05        (the ancestry the hook reads)
+#     \
+#      ---- dev-05                                (the local branch, forked off)
+#
+# From div-stale, `git merge dev-05` then writes a real merge commit, ahead
+# becomes > 0, and the fallback detector is retired for this branch
+# permanently. A fixture built linearly instead would pass these checks while
+# proving only that two strings differ.
+DIV="$FIXTURES/diverged-dev"
+git init -q -b main "$DIV"
+GD="git -C $DIV -c user.email=checks@example.invalid -c user.name=checks"
+$GD remote add origin "$FIXTURES/unreachable-remote.git"
+$GD commit -q --allow-empty -m root
+DIV_ROOT=$($GD rev-parse HEAD)
+$GD commit -q --allow-empty -m "where the worktree branch was cut"
+DIV_BASE=$($GD rev-parse HEAD)
+$GD commit -q --allow-empty -m advance
+$GD update-ref refs/remotes/origin/dev-05 "$($GD rev-parse HEAD)"
+# The local branch's own commit, written with commit-tree so that building the
+# fork needs no checkout of a second branch.
+DIV_FORK=$($GD commit-tree -p "$DIV_ROOT" -m "local dev-05 forked before the worktree branch was cut" \
+           "$($GD rev-parse "$DIV_ROOT^{tree}")")
+$GD branch dev-05 "$DIV_FORK"
+$GD branch div-stale "$DIV_BASE"
+$GD worktree add -q "$DIV/wt-div" div-stale
+WT_DIV="$DIV/wt-div"
+need_worktree "$WT_DIV" diverged-dev
+# The two halves of the shape drawn above, asserted rather than assumed: the
+# worktree branch is an ancestor of the remote dev tip, and is not an ancestor
+# of the local branch of the same name. The second is what makes the refused
+# merge a real merge commit rather than a fast-forward.
+$GD merge-base --is-ancestor refs/heads/div-stale refs/remotes/origin/dev-05 || {
+  echo "div-stale is not an ancestor of origin/dev-05, so the fallback will not fire; the checks below prove nothing" >&2
+  exit 1
+}
+$GD merge-base --is-ancestor refs/heads/div-stale refs/heads/dev-05 && {
+  echo "div-stale is an ancestor of local dev-05, so the short spelling would be a fast-forward; the checks below prove nothing" >&2
+  exit 1
+}
+check_in "$WT_DIV" no-work-on-stale-branch.sh ALLOW 'diverged local dev-05: the remote spelling is still the fast-forward' \
+  'git merge origin/dev-05'
+check_in "$WT_DIV" no-work-on-stale-branch.sh ALLOW 'diverged local dev-05: and so is its full ref' \
+  'git merge refs/remotes/origin/dev-05'
+check_in "$WT_DIV" no-work-on-stale-branch.sh BLOCK 'diverged local dev-05: the short spelling would write a merge commit' \
+  'git merge dev-05'
+# A rebase writes no merge commit; it replays this branch's commits onto the
+# named branch, which is just as much work on a branch the dev tip has moved
+# past, and it moves ahead the same way.
+check_in "$WT_DIV" no-work-on-stale-branch.sh BLOCK 'diverged local dev-05: a rebase onto its full ref is not the catch-up either' \
+  'git rebase refs/heads/dev-05'
+
+# STATE TWO: no local dev-05 at all, which is what a linked worktree normally
+# sees -- nobody checks out and pulls dev-NN in one. THE TRADE THIS FIX MAKES IS
+# HERE: the short spelling used to be permitted in this state and is now
+# refused. Nothing is lost. Run for real, `git merge dev-05` fails in git
+# anyway, because dev-05 resolves through refs/heads/, refs/tags/ and
+# refs/remotes/<name>/, and a remote-tracking origin/dev-05 is none of those.
+# The refusal names origin/dev-05, which is the spelling that works.
+NOLOC="$FIXTURES/no-local-dev"
+git init -q -b main "$NOLOC"
+GX="git -C $NOLOC -c user.email=checks@example.invalid -c user.name=checks"
+$GX remote add origin "$FIXTURES/unreachable-remote.git"
+$GX commit -q --allow-empty -m base
+NOLOC_BASE=$($GX rev-parse HEAD)
+$GX commit -q --allow-empty -m advance
+$GX update-ref refs/remotes/origin/dev-05 "$($GX rev-parse HEAD)"
+$GX branch noloc-stale "$NOLOC_BASE"
+$GX worktree add -q "$NOLOC/wt-noloc" noloc-stale
+WT_NOLOC="$NOLOC/wt-noloc"
+need_worktree "$WT_NOLOC" no-local-dev
+$GX rev-parse --verify --quiet refs/heads/dev-05 >/dev/null && {
+  echo "a local dev-05 exists in the no-local-dev fixture; the trade check below proves nothing" >&2
+  exit 1
+}
+check_in "$WT_NOLOC" no-work-on-stale-branch.sh ALLOW 'no local dev-05: the remote spelling is the catch-up' \
+  'git merge origin/dev-05'
+check_in "$WT_NOLOC" no-work-on-stale-branch.sh BLOCK 'no local dev-05: the short spelling is refused, and used to be permitted' \
+  'git merge dev-05'
+check_in "$WT_NOLOC" no-work-on-stale-branch.sh BLOCK 'no local dev-05: refs/heads/dev-05 names nothing either' \
+  'git merge refs/heads/dev-05'
+
+# STATE THREE: the dev tip does not resolve to a commit. The hook holds
+# `[ -n "$DEV_OID" ] || return 1` for it, and that line cannot be reached by
+# running the hook: DEV is the short name of the very ref DEV_OID is read from,
+# so a dev tip that will not resolve is one `git rev-list` cannot read either,
+# and the file abstains above before the carve-out is ever considered. So this
+# is checked twice and in two different ways -- the abstention as a process
+# below, and the guard behind it as a property of the file, at the foot of this
+# suite. Saying which is which is the point: a check is evidence about the case
+# it names.
+BADDEV="$FIXTURES/bad-dev-ref"
+git init -q -b main "$BADDEV"
+GB="git -C $BADDEV -c user.email=checks@example.invalid -c user.name=checks"
+$GB remote add origin "$FIXTURES/unreachable-remote.git"
+$GB commit -q --allow-empty -m base
+BAD_BASE=$($GB rev-parse HEAD)
+$GB commit -q --allow-empty -m advance
+$GB branch bad-stale "$BAD_BASE"
+$GB worktree add -q "$BADDEV/wt-bad" bad-stale
+# A ref pointing at a blob: the ref exists, so for-each-ref names it and DEV is
+# set, and nothing it points at is a commit. Written as a loose ref file rather
+# than through update-ref, because update-ref's object-type check is the thing
+# being worked around and its behaviour on refs/remotes/ is a git version
+# detail this fixture should not depend on.
+BAD_BLOB=$(printf 'not a commit' | $GB hash-object -w --stdin)
+mkdir -p "$BADDEV/.git/refs/remotes/origin"
+printf '%s\n' "$BAD_BLOB" > "$BADDEV/.git/refs/remotes/origin/dev-05"
+WT_BAD="$BADDEV/wt-bad"
+need_worktree "$WT_BAD" bad-dev-ref
+[ "$($GB for-each-ref --format='%(refname:short)' 'refs/remotes/origin/dev-*' 2>/dev/null)" = "origin/dev-05" ] || {
+  echo "the bad dev ref is not visible to for-each-ref; the check below proves nothing" >&2
+  exit 1
+}
+$GB rev-parse --verify --quiet 'refs/remotes/origin/dev-05^{commit}' >/dev/null 2>&1 && {
+  echo "the bad dev ref resolves to a commit; the check below proves nothing" >&2
+  exit 1
+}
+# An unreadable count is not a stale branch: the file abstains, which is the
+# same answer it gives when there is no dev ref at all.
+check_in "$WT_BAD" no-work-on-stale-branch.sh ALLOW 'a dev tip that is not a commit: the ancestry is unreadable, so the guard abstains' \
+  'git commit -m "wip"'
 
 echo "--- branches whose life is not over, and the main checkout ---"
 check_in "$WT_WORK"  no-work-on-stale-branch.sh ALLOW 'a branch carrying work of its own, ahead == 1' \
@@ -1731,6 +1892,22 @@ armed 'the guard derives the active dev branch this way' \
   "$HOOKS/no-work-on-stale-branch.sh" "$DEV_DERIVATION"
 armed 'and the report derives it identically' \
   "$HOOKS/report-stale-branches.sh" "$DEV_DERIVATION"
+
+# The carve-out's identity test, pinned as three lines rather than driven as a
+# process. Two of them are driven, by the diverged and no-local fixtures above;
+# the third -- an unresolvable dev tip -- is not reachable by running this hook,
+# because the ancestry read fails first and the file abstains. It is kept
+# because the carve-out is the only permitting path out of a refused state, and
+# a comparison against an empty string is not a comparison at all: drop the
+# line and `TOK_OID` empty would equal `DEV_OID` empty, permitting the merge on
+# exactly the state that could not be read. This says so; nothing above can.
+armed 'the dev tip is resolved to a commit, from the ref the ancestry was read against' \
+  "$HOOKS/no-work-on-stale-branch.sh" \
+  'DEV_OID=$(git rev-parse --verify --quiet "refs/remotes/$DEV^{commit}" 2>/dev/null)'
+armed 'an unresolvable dev tip withdraws the carve-out rather than widening it' \
+  "$HOOKS/no-work-on-stale-branch.sh" '[ -n "$DEV_OID" ] || return 1'
+armed 'and a whitelisted spelling must resolve to that same commit' \
+  "$HOOKS/no-work-on-stale-branch.sh" '[ "$TOK_OID" = "$DEV_OID" ]'
 
 # settings.json is what actually runs either file, so a hook present in the tree
 # and absent from the configuration is a hook that does nothing. jq reads it;

--- a/.claude/hooks/no-work-on-stale-branch.sh
+++ b/.claude/hooks/no-work-on-stale-branch.sh
@@ -112,12 +112,29 @@
 # branch permanently: silent, and in the permitting direction, which is the test
 # for inclusion stated above.
 #
-# THE TRADE THAT MAKES, RECORDED. When no local dev-NN exists at all, the short
-# spelling `git merge dev-NN` is now refused where it used to be permitted.
-# Nothing is lost: run for real in that state the command fails in git anyway,
-# because dev-NN resolves through refs/heads/, refs/tags/ and
-# refs/remotes/<name>/ and a remote-tracking origin/dev-NN is none of those. The
-# refusal message already names origin/dev-NN, which is the spelling that works.
+# THE TRADE THAT MAKES, RECORDED. The test is an identity, so it refuses the
+# short spelling whenever local dev-NN is not exactly origin/dev-NN -- not only
+# when it has forked. TWO HARMLESS CASES ARE GIVEN UP WITH IT, and both are
+# named here rather than left to be discovered:
+#
+# *No local dev-NN at all*, which is what a linked worktree normally sees.
+# `git merge dev-NN` was permitted and is now refused. Nothing is lost: run for
+# real in that state the command fails in git anyway, because dev-NN resolves
+# through refs/heads/, refs/tags/ and refs/remotes/<name>/ and a remote-tracking
+# origin/dev-NN is none of those.
+#
+# *A local dev-NN merely BEHIND origin/dev-NN*, which is the ordinary state here
+# and becomes the common one the moment a pull request lands on GitHub: the
+# remote half moves and the local branch sits still. That merge is a no-op or a
+# fast-forward to a commit this branch is already an ancestor of, so it writes
+# nothing and masks nothing, and it is refused all the same. This is the case
+# the identity test cannot separate from the forked one without asking a
+# question about ancestry that the whitelist exists to not ask -- a hook that
+# rev-parses its way to a merge-base decision is a larger claim than this
+# defect needs.
+#
+# Both refusals cost one edit: the message already names origin/dev-NN, which is
+# the spelling that works in every one of these states.
 #
 # ARMED BY report-stale-branches.sh. Both detectors read remote-tracking refs
 # and are exactly as fresh as the last fetch -- the fallback no less than the
@@ -269,9 +286,11 @@ CMDLIST
 # routinely disagree here, and for the case this now refuses.
 #
 # Resolved here rather than beside DEV because the common path exits above
-# without ever needing it: one rev-parse here, and one more per whitelisted
-# token below, paid only on the carve-out path -- a merge or rebase in an
-# already-refused state, which is rare.
+# without ever needing it. Exactly what that costs, since this placement is the
+# argument for it: one rev-parse here, paid once per command in an
+# already-refused state -- `git status` in a stale worktree pays it too, not
+# only a merge -- and one more per whitelisted token inside names_dev, paid only
+# where the carve-out is actually considered.
 DEV_SHORT=${DEV#origin/}
 DEV_OID=$(git rev-parse --verify --quiet "refs/remotes/$DEV^{commit}" 2>/dev/null)
 names_dev() {
@@ -281,11 +300,21 @@ names_dev() {
     *) return 1 ;;
   esac
   # The whitelist stays the outer gate: this resolves four fixed strings, never
-  # arbitrary command text. An unreadable dev tip is not a licence -- with
-  # nothing to compare against the carve-out is not taken, and the command is
-  # refused with the rest.
+  # arbitrary command text.
+  #
+  # The emptiness test is REDUNDANT WITH THE COMPARISON BELOW and is kept as a
+  # statement of intent, not as a guard that decides anything. Saying so
+  # plainly, because the first version of this file justified it as load-bearing
+  # and that was false: the rev-parse below returns on failure, and on success
+  # prints an OID, so TOK_OID is never empty where the comparison runs, and an
+  # unreadable DEV_OID already fails that comparison. Delete this line and no
+  # outcome changes. An asserted claim about what a guard does is the defect
+  # this whole file was rewritten to stop making.
   [ -n "$DEV_OID" ] || return 1
   TOK_OID=$(git rev-parse --verify --quiet "$1^{commit}" 2>/dev/null) || return 1
+  # This is what refuses an unreadable dev tip: with DEV_OID empty, no resolved
+  # token equals it, so the carve-out is not taken and the command is refused
+  # with the rest.
   [ "$TOK_OID" = "$DEV_OID" ]
 }
 

--- a/.claude/hooks/no-work-on-stale-branch.sh
+++ b/.claude/hooks/no-work-on-stale-branch.sh
@@ -95,6 +95,30 @@
 # will be: it is the spelling whose whole purpose is to write a merge commit
 # where a fast-forward would do.
 #
+# A SPELLING IS NOT A COMMIT. Two of those four -- dev-NN and refs/heads/dev-NN
+# -- name a local branch, while the ancestry above was read against
+# refs/remotes/origin/dev-NN and against that ref alone. Git does not guarantee
+# the two agree, and in this repository they routinely do not: worktree pull
+# requests merge into dev-NN on GitHub, so origin/dev-NN moves while the local
+# branch sits still, and the pruning fetch that report-stale-branches.sh
+# performs updates refs/remotes/origin/* and leaves refs/heads/* exactly where
+# they were. Nobody checks out and pulls dev-NN in a linked worktree. So each
+# whitelisted token is resolved and required to name the commit the ancestry was
+# read against; the equality is a condition this file checks, not a fact it may
+# assert. Left unchecked, `git merge dev-NN` against a local branch that has
+# forked -- not merely run ahead, since a branch ahead of origin/dev-NN still
+# has this one as an ancestor and the merge still fast-forwards -- writes a real
+# merge commit. ahead becomes > 0, and the fallback detector is retired for that
+# branch permanently: silent, and in the permitting direction, which is the test
+# for inclusion stated above.
+#
+# THE TRADE THAT MAKES, RECORDED. When no local dev-NN exists at all, the short
+# spelling `git merge dev-NN` is now refused where it used to be permitted.
+# Nothing is lost: run for real in that state the command fails in git anyway,
+# because dev-NN resolves through refs/heads/, refs/tags/ and
+# refs/remotes/<name>/ and a remote-tracking origin/dev-NN is none of those. The
+# refusal message already names origin/dev-NN, which is the spelling that works.
+#
 # ARMED BY report-stale-branches.sh. Both detectors read remote-tracking refs
 # and are exactly as fresh as the last fetch -- the fallback no less than the
 # gone test, since origin/dev-NN is a remote-tracking ref too. A hook cannot
@@ -236,15 +260,33 @@ done <<CMDLIST
 $CMDS
 CMDLIST
 
-# The four spellings of the active dev branch. DEV is origin/dev-NN; the local
-# branch of the same name, and both branches' full ref paths, name the same
-# commit for the purpose of a fast-forward.
+# The four spellings of the active dev branch, and the commit every one of them
+# has to name. DEV is origin/dev-NN, a remote-tracking ref, and the ancestry
+# above was read against it: ahead == 0 says this branch is a strict ancestor of
+# refs/remotes/origin/dev-NN, and that -- and only that -- is what makes the
+# fast-forward claim true. Two of the four spellings name a local branch
+# instead, which a pruning fetch never moves; see the header for why they
+# routinely disagree here, and for the case this now refuses.
+#
+# Resolved here rather than beside DEV because the common path exits above
+# without ever needing it: one rev-parse here, and one more per whitelisted
+# token below, paid only on the carve-out path -- a merge or rebase in an
+# already-refused state, which is rare.
 DEV_SHORT=${DEV#origin/}
+DEV_OID=$(git rev-parse --verify --quiet "refs/remotes/$DEV^{commit}" 2>/dev/null)
 names_dev() {
+  local TOK_OID
   case "$1" in
-    "$DEV"|"$DEV_SHORT"|"refs/remotes/$DEV"|"refs/heads/$DEV_SHORT") return 0 ;;
+    "$DEV"|"$DEV_SHORT"|"refs/remotes/$DEV"|"refs/heads/$DEV_SHORT") ;;
     *) return 1 ;;
   esac
+  # The whitelist stays the outer gate: this resolves four fixed strings, never
+  # arbitrary command text. An unreadable dev tip is not a licence -- with
+  # nothing to compare against the carve-out is not taken, and the command is
+  # refused with the rest.
+  [ -n "$DEV_OID" ] || return 1
+  TOK_OID=$(git rev-parse --verify --quiet "$1^{commit}" 2>/dev/null) || return 1
+  [ "$TOK_OID" = "$DEV_OID" ]
 }
 
 # A merge or rebase that is a fast-forward onto the active dev branch and


### PR DESCRIPTION
Closes #58.

## What was wrong

The carve-out in `no-work-on-stale-branch.sh` accepted four spellings of the
active dev branch by string comparison. Two of them — `dev-NN` and
`refs/heads/dev-NN` — name a different ref from the one staleness was measured
against. `AHEAD == 0` says this branch is a strict ancestor of
`refs/remotes/origin/dev-NN`, and that alone is what makes the fast-forward
claim true. The header asserted the four name the same commit; git does not
guarantee it, and here they routinely disagree — worktree pull requests merge
into `dev-NN` on GitHub, so `origin/dev-NN` moves while the local branch sits
still, and `report-stale-branches.sh` fetches with `--prune`, which updates
`refs/remotes/origin/*` and leaves `refs/heads/*` exactly where they were.

Against a local `dev-NN` that has forked, `git merge dev-NN` — the shortest
spelling of the command the refusal message itself recommends — writes a real
merge commit. `AHEAD` becomes `> 0`, the branch reads as one carrying work of
its own, and the fallback detector is retired for that branch permanently.
Silent, and in the permitting direction.

## What changed

`names_dev` keeps the four-spelling whitelist as the outer gate and now resolves
the token behind it, requiring it to name `DEV_OID`, the commit the ancestry was
read against. It still rev-parses four fixed strings and never arbitrary command
text — widening the whitelist to any revision resolving to the dev tip was out
of scope and stayed out.

The header paragraph asserting the equality is rewritten to state it as a
condition the hook checks.

## The trade, recorded

Where no local `dev-NN` exists at all, `git merge dev-NN` is now **refused**; it
used to be permitted. Nothing is lost: run for real in that state the command
fails in git anyway, since `dev-NN` resolves through `refs/heads/`, `refs/tags/`
and `refs/remotes/<name>/`, and a remote-tracking `origin/dev-NN` is none of
those. The refusal already names `origin/dev-NN`, which works.

Said in the file header, in the commit message, and in a check of its own.

## Fixtures

The lifecycle fixture had no local `dev-05` at all, so the short-spelling checks
were green for the wrong reason — two strings compared against a ref that did
not exist there, for a command that fails in git if run. It gains a local
`dev-05` at `LIFE_TIP`, and three siblings hold the other states: forked local
`dev-05`, no local `dev-05`, and a dev tip that is not a commit. Separate
repositories rather than `git branch -f` partway down the list, which would make
check **order** load-bearing.

Diverged there means **forked**, not merely ahead: a local branch one commit
ahead of `origin/dev-NN` still has the worktree branch as an ancestor, so the
merge would fast-forward and the fixture would prove only that two strings
differ. The first draft of this branch made exactly that mistake and the review
caught it; the fixture now asserts both halves of the shape it needs.

## Mutation checks

- reverting `names_dev` to the plain string comparison → the four new BLOCK
  checks go red
- dropping the `DEV_OID` emptiness guard → its `armed` line goes red
- removing the local `dev-05` from the lifecycle fixture → the two
  short-spelling ALLOWs go red, which is what shows they now pass for the right
  reason
- rebuilding the forked fixture linearly → the suite stops at its own guard

## Two deviations from the issue, for review

**`DEV_OID` placement.** The issue says "resolved once from `refs/remotes/$DEV`,
beside `DEV`". It is beside `DEV_SHORT` instead, 87 lines later. The issue's own
cost claim — "only on the carve-out path … everything else still exits before
the library is sourced" — and its snippet comment "the ancestry **above**" both
point there, and the common path exits before it. Argued in the file.

**The unresolvable-`DEV_OID` check is reframed, not skipped.** That line cannot
be reached by running the hook: `DEV` is the short name of the very ref
`DEV_OID` is read from, so a dev tip that will not resolve is one `git rev-list`
cannot read either, and the file abstains at `STATE=CLEAR` before the carve-out
is considered. It is checked two ways instead, and the suite says which is
which — the abstention driven as a process, the guard behind it pinned as a
property of the file. The guard is kept because a comparison against an empty
string is not a comparison: drop the line and an empty `TOK_OID` would equal an
empty `DEV_OID`, permitting the merge on exactly the state that could not be
read.

## Verification

`bash .claude/hooks/check-hooks.sh` passes — 562 checks. Both files pass
`bash -n`. No dependency changed, so `make upgrade-safe` has not been run; it is
the floor before this closes.

`make test` is 571 passed / 1 failed on this branch, and that failure is
pre-existing environment drift — `alembic` and `mako` from the `migrations`
group are not installed in `.venv`, repaired with `uv sync --all-groups`. This
diff touches no Python.

https://claude.ai/code/session_019HkmeYcZLfPsF22F4L4Gp8
