### PR TITLE
Give docs/research/ a job, and a test that catches the next unnamed directory

### DIFF
--- a/.claude/hooks/append-only-docs-edit.sh
+++ b/.claude/hooks/append-only-docs-edit.sh
@@ -12,8 +12,11 @@
 # exist is allowed. Touching a file that is already there is what rewrites
 # history, and that is blocked for both tools.
 #
-# docs/design/ is deliberately absent from the guarded set — CLAUDE.md's own
-# table marks it "revised in place".
+# docs/design/ and docs/research/ are deliberately absent from the guarded set —
+# CLAUDE.md's own table marks both "revised in place". For research/ the
+# omission is load-bearing rather than incidental: a research document carries
+# [NEEDS OBSERVATION] markers, and clearing one as the observation is made is
+# the edit the directory exists to allow.
 INPUT=$(cat)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 

--- a/.claude/hooks/append-only-docs.sh
+++ b/.claude/hooks/append-only-docs.sh
@@ -5,6 +5,12 @@
 #
 # Adding a new entry file is the normal case and stays allowed; so does a >>
 # append. What is blocked is destroying or rewriting what is already recorded.
+#
+# docs/research/ was considered for this set and deliberately left out (issue
+# #61). A research document carries [NEEDS OBSERVATION] markers, and clearing
+# one as the observation is made is the edit the directory exists to allow;
+# CLAUDE.md's table marks it "revised in place" for that reason. The same is
+# true of docs/design/. See the companion note in append-only-docs-edit.sh.
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -1685,6 +1685,62 @@ grep -q '^cs_renamed_away()' "$FIXTURES/halflib/lib/command-scan.sh" || {
 check_in "$WT_STALE" "$FIXTURES/halflib/no-work-on-stale-branch.sh" BLOCK 'a library missing only cs_git_args' \
   'git commit -m "wip"'
 
+echo "=== append-only: which docs directories are guarded, and which are not ==="
+# First coverage for append-only-docs.sh and its Edit/Write companion. It was
+# added with issue #61, which put a comment in both files saying docs/research/
+# is deliberately outside the guarded set -- and a comment is not evidence. The
+# refusing direction is checked alongside it, because an ALLOW for research/
+# that came from the guard having stopped working altogether would look
+# identical to the one intended.
+check append-only-docs.sh BLOCK 'sed -i over a dev-log entry' \
+  "sed -i 's/a/b/' docs/dev-log/devlog_2026-08-25_session-2.md"
+check append-only-docs.sh BLOCK 'rm of an eval report' \
+  'rm docs/eval-reports/some-report.md'
+check append-only-docs.sh BLOCK 'truncating redirect into a lessons-learned entry' \
+  'echo x > docs/lessons-learned/some-lesson.md'
+check append-only-docs.sh ALLOW 'appending to a dev-log entry' \
+  'echo x >> docs/dev-log/devlog_2026-08-25_session-2.md'
+check append-only-docs.sh ALLOW 'sed -i over a research document' \
+  "sed -i 's/a/b/' docs/research/non-openrouter-response-bodies.md"
+check append-only-docs.sh ALLOW 'sed -i over a design document' \
+  "sed -i 's/a/b/' docs/design/llm-call-log.md"
+
+# The Edit/Write companion reads tool_input.file_path rather than .command, and
+# its verdict turns on whether the file already exists -- so it is asked about
+# real paths in this repository, with CLAUDE_PROJECT_DIR naming the root it
+# anchors to. A new seam in this suite, named as one.
+REPO_ROOT=$(cd "$HOOKS/../.." && pwd)
+check_file() {  # check_file <script> <want> <label> <path relative to the repo>
+  local script="$1" want="$2" label="$3" path="$4" got rc
+  printf '%s' "$path" | jq -Rs '{tool_name:"Edit",tool_input:{file_path:.}}' \
+    | CLAUDE_PROJECT_DIR="$REPO_ROOT" ./"$script" >/dev/null 2>&1
+  rc=$?
+  if [ $rc -eq 2 ]; then got=BLOCK; else got=ALLOW; fi
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %-5s %s\n' "$got" "$label"
+  else
+    printf '  FAIL want=%s got=%s  %s\n' "$want" "$got" "$label"
+    FAILED=1
+  fi
+}
+# An ALLOW that came from the path simply not being there would say nothing
+# about docs/research/, and a BLOCK-expecting case needs its file present for
+# the same reason. Both are asserted rather than assumed.
+[ -e "$REPO_ROOT/docs/dev-log/devlog_2026-08-25_session-2.md" ] \
+  && [ -e "$REPO_ROOT/docs/dev-log/README.md" ] \
+  && [ -e "$REPO_ROOT/docs/research/non-openrouter-response-bodies.md" ] || {
+  echo "the append-only Edit cases name files that are not there; they would prove nothing" >&2
+  exit 1
+}
+check_file append-only-docs-edit.sh BLOCK 'Edit of an existing dev-log entry' \
+  'docs/dev-log/devlog_2026-08-25_session-2.md'
+check_file append-only-docs-edit.sh ALLOW 'Write of a dev-log entry not yet there' \
+  'docs/dev-log/devlog_2099-01-01_session-1.md'
+check_file append-only-docs-edit.sh ALLOW 'Edit of a dev-log README that does exist' \
+  'docs/dev-log/README.md'
+check_file append-only-docs-edit.sh ALLOW 'Edit of an existing research document' \
+  'docs/research/non-openrouter-response-bodies.md'
+
 echo "=== the arming properties, asserted as literals ==="
 # A second kind of check: the ones above drive a hook as a process and read its
 # exit code, and these read a file. It is a new seam in this suite and is named

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,8 +170,9 @@ nothing else.
 
 ## Documentation
 
-Five directories with different jobs; the distinction erodes easily
-(`docs/design/README.md` states the first four in full):
+Six directories with different jobs; the distinction erodes easily
+(`docs/design/README.md` draws the record-vs-current-state split in full, and
+the line between `docs/design/` and `docs/research/`):
 
 | directory | answers | dated? |
 |---|---|---|
@@ -180,10 +181,21 @@ Five directories with different jobs; the distinction erodes easily
 | `docs/eval-reports/` | what the numbers were at a point in time | yes, **append-only** |
 | `docs/design/` | how a mechanism works **today** | no, revised in place |
 | `docs/adr/` | why a decision was taken, and what was rejected | no, superseded rather than revised |
+| `docs/research/` | what is true **outside** this repository — a provider, a library, a spec | no, revised in place; claims carry their source |
 
 `docs/todo.md` is the backlog; `docs/evaluation-plan.md` is what the framework
 *should* become, not evidence about what exists. Append-only means old entries
 are history — corrections go in the newest entry, never backwards.
+
+`docs/research/` holds the output of a `wayfinder:research` ticket: a question
+answered against primary sources, every claim attributed, and anything not
+actually observed marked `[NEEDS OBSERVATION]` so a later session can grep the
+file and get a checklist. It is outside the append-only guard deliberately —
+clearing a marker *is* the point, and freezing the file would make the
+checklist unworkable; git holds the history. What it must not become is a
+second `docs/design/`: a research document describes something this repository
+does not control, and stops before the decision it unblocks.
+`docs/research/README.md` states the conventions.
 
 **Dev-log voice.** Sessions are worked jointly by Bertan and an AI assistant.
 Never write a bare "I": name the agent ("the assistant", "Bertan"). Passive is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,13 @@ the line between `docs/design/` and `docs/research/`):
 *should* become, not evidence about what exists. Append-only means old entries
 are history — corrections go in the newest entry, never backwards.
 
+`ls docs/` returns seven directories, not six. `docs/agents/` is the seventh and
+is deliberately not in the table: it holds agent configuration — the issue
+tracker's conventions, the triage label mapping, the domain glossary — rather
+than documentation of the system, and is described under **Agent skills** below.
+It is counted here so that the next reader does not have to wonder whether it
+was forgotten.
+
 `docs/research/` holds the output of a `wayfinder:research` ticket: a question
 answered against primary sources, every claim attributed, and anything not
 actually observed marked `[NEEDS OBSERVATION]` so a later session can grep the

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -18,11 +18,32 @@ easy to erode:
 | `lessons-learned/` | how a specific failure happened | yes, append-only |
 | `eval-reports/` | what the numbers were at a point in time | yes, append-only |
 | **`design/`** | **how a mechanism works today** | **no, revised in place** |
+| `adr/` | why a decision was taken, and what was rejected | no, superseded |
+| `research/` | what is true outside this repository | no, revised in place |
 
 Everything above `design/` is a **record**: written once, never edited, because
 editing history destroys its value. A design document is the opposite — it is
 **current state**, and when the mechanism changes the document is rewritten to
 match. Its history lives in git, not in the filename.
+
+The two below it are current state as well, which makes them the neighbours
+this directory is most easily confused with:
+
+- `adr/` answers *why*, once, for a decision. A design document answers *how*,
+  continuously, for a mechanism. When an ADR's decision is reversed the ADR is
+  superseded by a new one rather than rewritten; a design document is rewritten
+  in place, because there is only ever one current answer to "how does this
+  work".
+- `research/` is the closer call, because it is also undated and also revised
+  in place. The line is which side of the repository boundary the subject sits
+  on. A design document describes a mechanism **here** and carries a "Verified
+  against" commit, because the code is the thing it can be checked against. A
+  research document describes something this repository does not control — a
+  provider's response body, a library's behaviour, a specification — and
+  carries the date its sources were read, because there is no commit to check
+  it against. A research finding that changes how a mechanism here is built
+  stays in `research/`; the design document cites it and states the decision
+  taken.
 
 Two documents this is also not:
 

--- a/docs/design/llm-call-log.md
+++ b/docs/design/llm-call-log.md
@@ -991,6 +991,18 @@ filter the sweep would query `/api/v1/generation` forever for ids that were neve
 OpenRouter's, and trap 4 would then mark them swept-and-empty — true, and
 useless.
 
+What those bodies do carry, column by column, was read out of each provider's
+own documentation in
+[`docs/research/non-openrouter-response-bodies.md`](../research/non-openrouter-response-bodies.md)
+(issue #10). Its first finding bears on the path filter described above:
+`ai_common.llm.get_llm` builds a different client per server, and three of the
+five do not use `/chat/completions` at all, so a filter on that path would see
+almost none of this project's non-OpenRouter traffic as it is wired today. That
+is a reading of the installed package and of published documentation, not an
+observation of the wire — the research document marks which claims are which,
+and nothing in this design is revised on the strength of it until the
+observations it lists have been made.
+
 ### The enrichment sweep
 
 A row is written immediately with everything the socket saw, and completed

--- a/docs/design/llm-call-log.md
+++ b/docs/design/llm-call-log.md
@@ -996,8 +996,11 @@ own documentation in
 [`docs/research/non-openrouter-response-bodies.md`](../research/non-openrouter-response-bodies.md)
 (issue #10). Its first finding bears on the path filter described above:
 `ai_common.llm.get_llm` builds a different client per server, and three of the
-five do not use `/chat/completions` at all, so a filter on that path would see
-almost none of this project's non-OpenRouter traffic as it is wired today. That
+five it charts — OpenAI, Ollama and Anthropic, leaving Groq and vLLM — do not
+use `/chat/completions` at all, so a filter on that path would see almost none
+of this project's non-OpenRouter traffic as it is wired today. Five, not the
+enum's seven: `OPENROUTER` is the baseline the others are measured against, and
+`GOOGLE` was outside that ticket's scope and is uncharted. That
 is a reading of the installed package and of published documentation, not an
 observation of the wire — the research document marks which claims are which,
 and nothing in this design is revised on the strength of it until the

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -24,12 +24,13 @@ The boundary is ownership, not subject matter:
 | `adr/` | why a decision was taken, and what was rejected | no, superseded |
 | `eval-reports/` | what the numbers were at a point in time | yes, append-only |
 
-- **Against `design/`.** A design document describes code this repository owns
-  and carries a **"Verified against"** commit, because the code is what it can
-  be checked against. A research document has no commit to check against, so it
-  carries the date its sources were read instead. When a finding here changes
-  how a mechanism is built, the finding stays here and the design document
-  cites it — copying it across leaves two claims that drift apart.
+- **Against `design/`.** The boundary is ownership: a design document describes
+  code this repository owns, a research document describes something it does
+  not. `docs/design/README.md` draws the line in full, including what each kind
+  can be checked against; it is stated once, there. What matters at this end:
+  when a finding here changes how a mechanism is built, the finding stays here
+  and the design document cites it — copying it across leaves two claims that
+  drift apart.
 - **Against `adr/`.** Research establishes what is true; an ADR records what
   was decided in the light of it. A research document that ends in a
   recommendation has stopped being research.
@@ -38,7 +39,7 @@ The boundary is ownership, not subject matter:
   produces a new report, not an edit to the old one. A research document is not
   a measurement of this system and is not frozen; see below.
 
-## Dated, and why this directory is not append-only
+## Undated, and not append-only
 
 Filenames are **undated** and a document is **revised in place**.
 
@@ -75,8 +76,11 @@ force, because the subject is someone else's system:
 - **Separate what was read from what was seen.** A quotation from a provider's
   documentation and a response body captured from that provider are different
   kinds of evidence. Mark the first; do not present it as the second. Reading
-  library source produced a wrong claim twice on 2026-08-25, which is why the
-  markers are not optional.
+  library source produced a wrong claim twice on 2026-08-25 — that
+  `response_metadata["provider"]` was available for free, asserted from
+  `langchain_openrouter/chat_models.py:870` and absent when measured
+  (`docs/dev-log/devlog_2026-08-25_session-2.md`, "The served provider does not
+  reach the message"). That is why the markers are not optional.
 - **Attribute at the point of the claim**, not in a bibliography at the end —
   a reader checking one row should not have to guess which source it came from.
   Name the version, revision or read date of what was read.
@@ -101,9 +105,11 @@ force, because the subject is someone else's system:
 ## Documents
 
 - [What a non-OpenRouter completions body actually contains](non-openrouter-response-bodies.md)
-  — for each server in `ai_common.enums.LlmServers`, what the response body
-  carries: cost, identifier, usage shape, and whether anything names the
-  machine that served it. Read against each provider's documentation on
+  — for five of the seven servers in `ai_common.enums.LlmServers` (`OPENROUTER`
+  is the baseline the others are measured against; `GOOGLE` was outside the
+  ticket's scope), what the response body carries: cost, identifier, usage
+  shape, and whether anything names the machine that served it. Read against
+  each provider's documentation on
   2026-09-04; **no live API call was made**, and every claim is marked
   accordingly. Feeds `docs/design/llm-call-log.md`, whose socket patch filters
   on the completions path — the document's first finding is that three of the

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,110 @@
+# Research
+
+What is true **outside** this repository: a provider's response body, a
+library's behaviour, a specification's wording. One document per question,
+answered against primary sources, with every claim attributed to the source it
+came from.
+
+These are the answer to *"before we build this, what does the thing we do not
+control actually do?"* — the reading legwork that would otherwise be redone by
+each person who needs it, or, worse, guessed at once and then quoted forever.
+
+A document here is the output of a `wayfinder:research` ticket. The ticket asks
+a question and forbids answering the decision it unblocks; the document keeps
+that separation.
+
+## What belongs here, and what does not
+
+The boundary is ownership, not subject matter:
+
+| directory | question it answers | dated? |
+|---|---|---|
+| **`research/`** | **what is true outside this repository** | **no, revised in place** |
+| `design/` | how a mechanism **here** works today | no, revised in place |
+| `adr/` | why a decision was taken, and what was rejected | no, superseded |
+| `eval-reports/` | what the numbers were at a point in time | yes, append-only |
+
+- **Against `design/`.** A design document describes code this repository owns
+  and carries a **"Verified against"** commit, because the code is what it can
+  be checked against. A research document has no commit to check against, so it
+  carries the date its sources were read instead. When a finding here changes
+  how a mechanism is built, the finding stays here and the design document
+  cites it — copying it across leaves two claims that drift apart.
+- **Against `adr/`.** Research establishes what is true; an ADR records what
+  was decided in the light of it. A research document that ends in a
+  recommendation has stopped being research.
+- **Against `eval-reports/`.** An eval report is a measurement of *this*
+  system, taken once, and is append-only for that reason — re-running the eval
+  produces a new report, not an edit to the old one. A research document is not
+  a measurement of this system and is not frozen; see below.
+
+## Dated, and why this directory is not append-only
+
+Filenames are **undated** and a document is **revised in place**.
+
+That is a deliberate exception to the rule that evidence gathered at a point in
+time is append-only, and the reason is the marker convention. A research
+document marks every claim it has not actually observed:
+
+- **`[NEEDS OBSERVATION]`** — documented, or inferred from documentation, but
+  not seen.
+- **`[DOCS SILENT]`** — the source does not answer the question. A gap recorded
+  as a gap, which is not the same as the field being absent.
+
+The markers exist so a later session can grep the file and get a checklist.
+Clearing one *is* the intended edit. Freezing the document would make the
+checklist unworkable, and would leave the repository quoting a provider's
+documentation from a date at which it has since changed. The history lives in
+git, which is where a rewritten document's history belongs.
+
+The cost of that choice, stated because it is real: a reader cannot tell from
+the file alone what it said last month. If a claim's *former* wording is what
+matters — because a decision was taken on it and later went wrong — that
+belongs in `dev-log/` or `lessons-learned/`, which are append-only precisely so
+they can be quoted.
+
+## Register
+
+**This directory is public and is read by people evaluating the work.** The
+standing rule this project applies to its own gates applies here with more
+force, because the subject is someone else's system:
+
+> A claim about a layer's behaviour is worth nothing until the layer has been
+> observed doing it.
+
+- **Separate what was read from what was seen.** A quotation from a provider's
+  documentation and a response body captured from that provider are different
+  kinds of evidence. Mark the first; do not present it as the second. Reading
+  library source produced a wrong claim twice on 2026-08-25, which is why the
+  markers are not optional.
+- **Attribute at the point of the claim**, not in a bibliography at the end —
+  a reader checking one row should not have to guess which source it came from.
+  Name the version, revision or read date of what was read.
+- **Record a gap as a gap.** "The documentation does not say" is a finding.
+  Silently omitting the question is not.
+- **Decide nothing.** State what the decision would turn on, and stop.
+
+## Conventions
+
+- File name: kebab-case, **undated**, e.g. `non-openrouter-response-bodies.md`.
+- Open with the ticket the research answers, the date the sources were read,
+  and what kind of evidence the document contains — in particular, whether
+  anything was observed rather than read.
+- State the marker convention in the document itself, so it is readable without
+  this README.
+- Close with **What would need to be observed** — the `[NEEDS OBSERVATION]`
+  markers gathered into a checklist — and **Sources**.
+- Prefer a comparison table where the question is "which of these does what".
+  It makes an omission visible as an empty cell rather than an absent
+  paragraph.
+
+## Documents
+
+- [What a non-OpenRouter completions body actually contains](non-openrouter-response-bodies.md)
+  — for each server in `ai_common.enums.LlmServers`, what the response body
+  carries: cost, identifier, usage shape, and whether anything names the
+  machine that served it. Read against each provider's documentation on
+  2026-09-04; **no live API call was made**, and every claim is marked
+  accordingly. Feeds `docs/design/llm-call-log.md`, whose socket patch filters
+  on the completions path — the document's first finding is that three of the
+  five servers do not use that path at all.

--- a/tests/test_docs_directory_naming.py
+++ b/tests/test_docs_directory_naming.py
@@ -50,6 +50,11 @@ NAMING_FORM = "docs/{name}/"
 
 def _documentation_section() -> list[str]:
     lines = CLAUDE_MD.read_text(encoding="utf-8").splitlines()
+    assert SECTION_HEADING in lines, (
+        f"CLAUDE.md has no {SECTION_HEADING!r} heading. If the section was "
+        "renamed, rename SECTION_HEADING with it — these tests are about that "
+        "section and silently measure nothing without it."
+    )
     start = lines.index(SECTION_HEADING)
     for offset, line in enumerate(lines[start + 1 :], start=start + 1):
         if line.startswith("## "):
@@ -96,4 +101,24 @@ def test_the_stated_directory_count_matches_the_table():
         f"CLAUDE.md says '{stated_word}' directories but the table has "
         f"{len(counted)} rows. The count and the table were revised in the "
         "same window once already and disagreed; see issue #61."
+    )
+
+
+def test_every_table_row_names_a_directory_that_exists():
+    # The inverse of the first test, and the reason it is here: the first one
+    # asks whether each directory is named *somewhere* in CLAUDE.md, and
+    # `docs/research/` is now named in the prose as well as the table. So a
+    # typo in the table row alone — `docs/researchX/` — left both other tests
+    # green when it was tried. This one reads the rows and asks the filesystem.
+    rows = [
+        line for line in _documentation_section() if line.startswith("| `docs/")
+    ]
+    assert rows, "no `docs/...` rows found under the documentation heading"
+
+    named = [line.split("`")[1].removeprefix("docs/").removesuffix("/") for line in rows]
+    missing = [name for name in named if not (DOCS / name).is_dir()]
+    assert not missing, (
+        f"CLAUDE.md's documentation table names directories that do not "
+        f"exist: {missing}. A row describing nothing is worse than no row — "
+        "it reads as a rule someone is already following."
     )

--- a/tests/test_docs_directory_naming.py
+++ b/tests/test_docs_directory_naming.py
@@ -1,0 +1,99 @@
+"""Every directory under `docs/` must be named in CLAUDE.md.
+
+CLAUDE.md's documentation section opens by naming its own failure mode — "the
+distinction erodes easily" — and then eroded: `docs/research/` was created on
+`dev-05`, held one file, and was named by no table, no README and no other file
+in the repository (issue #61). The same branch revised the count in that
+sentence from four directories to five while adding `docs/adr/`, and did not
+count the sixth.
+
+The cost of an unnamed directory is not the directory. It is that the next
+document of its kind has no rule saying where it goes, and the one after that
+has a precedent instead of a rule.
+
+**Scope limit, stated because it is the interesting half.** These tests catch a
+directory that is *unnamed* and a count that is *stale*. They cannot catch a
+directory that is named in the wrong place, described wrongly, or given a job
+that overlaps its neighbour's — that judgement is what review is for. A green
+run here is evidence about the two cases below and about nothing else.
+"""
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CLAUDE_MD = PROJECT_ROOT / "CLAUDE.md"
+DOCS = PROJECT_ROOT / "docs"
+
+# The heading the documentation table lives under. Written as a literal:
+# reading it back out of the file would make the test agree with whatever the
+# file happens to say.
+SECTION_HEADING = "## Documentation"
+
+# Number words this project would plausibly reach for. A count outside this
+# range means the section grew past what the sentence form can carry, which is
+# worth a failure rather than a silent skip.
+NUMBER_WORDS = {
+    "Three": 3,
+    "Four": 4,
+    "Five": 5,
+    "Six": 6,
+    "Seven": 7,
+    "Eight": 8,
+}
+
+# `docs/agents/` carries agent configuration, not a kind of documentation, so
+# it is named in CLAUDE.md's prose rather than in the table. The invariant is
+# that a directory is named *somewhere*, which is the weakest form of the rule
+# that still catches issue #61.
+NAMING_FORM = "docs/{name}/"
+
+
+def _documentation_section() -> list[str]:
+    lines = CLAUDE_MD.read_text(encoding="utf-8").splitlines()
+    start = lines.index(SECTION_HEADING)
+    for offset, line in enumerate(lines[start + 1 :], start=start + 1):
+        if line.startswith("## "):
+            return lines[start + 1 : offset]
+    return lines[start + 1 :]
+
+
+def test_every_docs_directory_is_named_in_claude_md():
+    text = CLAUDE_MD.read_text(encoding="utf-8")
+    directories = sorted(p.name for p in DOCS.iterdir() if p.is_dir())
+    assert directories, "docs/ has no subdirectories; the glob is wrong"
+
+    unnamed = [
+        name for name in directories if NAMING_FORM.format(name=name) not in text
+    ]
+    assert not unnamed, (
+        f"docs/ subdirectories named nowhere in CLAUDE.md: {unnamed}. "
+        "Give each one a job in the documentation table, or fold its contents "
+        "into a directory that already has one."
+    )
+
+
+def test_the_stated_directory_count_matches_the_table():
+    section = _documentation_section()
+
+    counted = [
+        line for line in section if line.startswith("| `docs/") and line.endswith("|")
+    ]
+    assert counted, "no `docs/...` rows found under the documentation heading"
+
+    sentences = [line for line in section if "directories with different jobs" in line]
+    assert len(sentences) == 1, (
+        f"expected exactly one 'N directories with different jobs' sentence, "
+        f"found {len(sentences)}"
+    )
+
+    stated_word = sentences[0].split(" ", 1)[0]
+    assert stated_word in NUMBER_WORDS, (
+        f"'{stated_word}' is not a number word this test knows; "
+        f"expected one of {sorted(NUMBER_WORDS)}"
+    )
+
+    assert NUMBER_WORDS[stated_word] == len(counted), (
+        f"CLAUDE.md says '{stated_word}' directories but the table has "
+        f"{len(counted)} rows. The count and the table were revised in the "
+        "same window once already and disagreed; see issue #61."
+    )


### PR DESCRIPTION
Closes #61.

## The decision

Issue #61 offers two outcomes and says either closes it. This takes **option 1, name it**, on the evidence that research findings recur as their own kind of document: `wayfinder:research` is a standing role in this tracker — one of five `wayfinder:*` labels — and the document at the centre of the issue is the output of such a ticket (#10).

Option 2 would have folded a survey of what five providers *document* into `docs/eval-reports/`, whose stated job is "what the numbers were at a point in time". That trades erosion of the table for erosion of the row it landed in.

## What `docs/research/` is

| | |
|---|---|
| **answers** | what is true **outside** this repository — a provider, a library, a spec |
| **dated** | no; undated filenames, revised in place |
| **append-only** | no, deliberately |

The append-only exception is the part worth reading. A research document marks every claim it has not observed with `[NEEDS OBSERVATION]`, so that a later session can grep the file and get a checklist. Clearing a marker *is* the intended edit. Freezing the file would make the checklist unworkable and would leave the repository quoting a provider's documentation from a date at which it has since changed. Git holds the history.

The line that will erode next is `design/` against `research/`, since both are undated and both are revised in place. `docs/design/README.md` draws it once: which side of the repository boundary the subject sits on. A design document describes a mechanism here and carries a "Verified against" commit; a research document describes something this repository does not control and carries the date its sources were read, because there is no commit to check it against.

## Changed

- **`CLAUDE.md`** — table row, the count, and a paragraph giving the directory its job. Also reconciles the six-vs-seven gap: `ls docs/` returns seven, and `docs/agents/` is now explicitly counted out as agent configuration rather than documentation.
- **`docs/research/README.md`** (new) — the directory's job, register, and conventions, plus the Documents entry that ends "referenced nowhere".
- **`docs/design/README.md`** — the `research/` and `adr/` rows its table was missing, and the contrast paragraphs. Leaving `adr/` out while adding `research/` would have reproduced the defect being fixed.
- **`docs/design/llm-call-log.md`** — cites the research document at the passage that prompted it. The design doc asserted only that non-OpenRouter bodies "return no `gen-…` id and often no cost either"; the research answers the rest of that sentence.
- **`.claude/hooks/append-only-docs.sh`, `append-only-docs-edit.sh`** — comments recording that `docs/research/` was considered for the guarded set and left out on purpose. No behaviour change.

## Evidence

`make test` — **575 passed, 5 xfailed** (the pre-existing chunker xfails). `bash .claude/hooks/check-hooks.sh` — **ALL CHECKS PASSED**.

Three new tests in `tests/test_docs_directory_naming.py`, each observed failing for its own reason rather than assumed to work:

| test | seen red on |
|---|---|
| every `docs/` subdirectory is named in CLAUDE.md | `['research']`, before this change |
| the stated count matches the table | a temporary `Six` → `Seven` |
| every table row names a directory that exists | a temporary `docs/researchX/` row |

Ten new cases in `check-hooks.sh` — the first coverage of either append-only hook, in both directions. Mutation-checked: adding `research` to either hook's pattern turns exactly the two intended cases red. The Edit/Write companion needed a second helper, since it reads `file_path` rather than `command` and its verdict turns on whether the file exists; it asserts its fixture paths are present, because an ALLOW from a missing file would prove nothing.

The tests' own scope limit is in their docstring: they catch a directory that is *unnamed* and a count that is *stale*. They cannot catch a directory named in the wrong place or given a job that overlaps its neighbour's.

## Reviewed

Two-axis review (standards + spec) ran against `996ad8c`; all six findings were taken, and `13a8271` is the response. The substantive ones: the count was still wrong in the way #61 names; the guard-code comment was an unchecked claim in a file whose header records nine defects found by review rather than by the suite; the hook file the issue actually cites was the one left unannotated; and "three of the five" read as the size of an enum that has seven members.

## Not addressed

`make audit` is red on `accelerate 1.14.0` (PYSEC-2026-3804, no fixed version). Pre-existing and inherited from `dev-05` — this branch does not touch `uv.lock`. It is the advisory Dependabot flags on the default branch.

https://claude.ai/code/session_01FFUpD1P5VFZ88bZYMF2Ziu
