### PR TITLE
Name all four boundary hooks in CLAUDE.md, and check that it keeps doing so

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -1770,10 +1770,25 @@ echo "=== CLAUDE.md names every hook that carries the boundary ==="
 # the section is right not to name. Adding a boundary hook and not the sentence
 # turns this red; adding a hook about documents or commands means adding it
 # here, deliberately, with a reason.
+# A third helper, because the two above read a file and this asks about a list
+# this suite has computed. One membership convention, written once: the spaces
+# belong to the pattern, so no literal carries its own.
+present() {  # present <label> <needle> <space-separated haystack>
+  case " $3 " in
+    *" $2 "*) printf '  ok   %s\n' "$1" ;;
+    *) printf '  FAIL %s\n' "$1"; FAILED=1 ;;
+  esac
+}
+
 CLAUDE_MD="$HOOKS/../../CLAUDE.md"
 SECTION="$FIXTURES/boundary-section.md"
-sed -n '/^## What an unattended agent may do to this repository$/,/^## /p' \
-    "$CLAUDE_MD" | sed '$d' > "$SECTION"
+# awk rather than `sed -n '/start/,/^## /p' | sed '$d'`: that pair drops the last
+# line unconditionally, and when the boundary section is the last in the file
+# there is no following heading to drop -- so it would eat a real line of the
+# section, silently, in the permitting direction.
+awk '/^## What an unattended agent may do to this repository$/ {f=1; print; next}
+     f && /^## / {exit}
+     f {print}' "$CLAUDE_MD" > "$SECTION"
 # The extraction is itself a claim about a heading that can be renamed, so it is
 # checked from both ends before anything is asserted against it: the heading is
 # in what came out, and a line from another section is not.
@@ -1782,57 +1797,73 @@ armed 'the extracted section is the boundary section' \
 unarmed 'and it is that section rather than the whole file' \
   "$SECTION" 'Import cost is a design constraint'
 
+# Narrowed again, to the paragraph that says what is enforced. The section's last
+# paragraph is about what is deliberately NOT guarded, and it discusses
+# .claude/ by name; a hook named only there would satisfy a section-wide grep
+# while telling a reader the opposite of what the grep was taken to prove. This
+# is also what CLAUDE.md now claims -- "this paragraph names every hook that
+# carries it" -- and a check that asserted something wider would be the same
+# drift one paragraph along.
+PARAGRAPH="$FIXTURES/boundary-paragraph.md"
+awk -v RS= '/Enforced by/' "$SECTION" > "$PARAGRAPH"
+armed 'and the paragraph taken from it is the one that says what is enforced' \
+  "$PARAGRAPH" 'Enforced by'
+unarmed 'and it stops short of what is deliberately left unguarded' \
+  "$PARAGRAPH" 'Deliberately left open'
+
 # Registered on Bash or at SessionStart, but about documents or commands rather
 # than about what an agent may do to this repository. Each name here is a
-# decision: these are the hooks the section is correct to leave out.
-NOT_THE_BOUNDARY=" append-only-docs.sh alembic-via-uv-group.sh pytest-via-uv-group.sh "
+# decision: these are the hooks the paragraph is correct to leave out.
+NOT_THE_BOUNDARY="append-only-docs.sh alembic-via-uv-group.sh pytest-via-uv-group.sh"
+# Space-separated, because `present` separates on spaces and a newline between
+# two names is not the separator its pattern looks for -- every name but the
+# first would read as absent. The second sed drops anything after the path, so
+# a hook registered with an argument is still named by its file.
 REGISTERED=$(jq -r '
     (.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[]?.command),
     (.hooks.SessionStart[]?.hooks[]?.command)' "$SETTINGS" 2>/dev/null \
-  | sed 's|.*/||' | sort -u | tr '\n' ' ')
-# Space-separated on purpose: the membership tests below are `case " $REGISTERED "`
-# against `*" $hook "*`, and a newline between two names is not the separator
-# that pattern looks for -- every name but the first would read as absent.
+  | sed 's|.*/||; s|[[:space:]].*||' | sort -u | tr '\n' ' ')
+# Every .sh beside this suite, for the other direction below.
+HOOK_FILES=$(ls "$HOOKS"/*.sh "$HOOKS"/lib/*.sh 2>/dev/null | sed 's|.*/||' | sort -u | tr '\n' ' ')
 # An empty derivation would pass every loop below without asking anything.
-[ -n "$REGISTERED" ] || {
-  echo "no hooks were read out of settings.json; the checks below prove nothing" >&2
+[ -n "$REGISTERED" ] && [ -n "$HOOK_FILES" ] || {
+  echo "no hooks were read out of settings.json or off the disk; the checks below prove nothing" >&2
   exit 1
 }
+# Unglobbed: a name is a word here, never a pattern to expand against the tree.
+set -f
 for hook in $REGISTERED; do
-  case "$NOT_THE_BOUNDARY" in *" $hook "*) continue ;; esac
-  armed "the section names $hook, which settings.json runs" "$SECTION" "$hook"
+  case " $NOT_THE_BOUNDARY " in *" $hook "*) continue ;; esac
+  armed "the paragraph names $hook, which settings.json runs" "$PARAGRAPH" "$hook"
 done
 
-# The other direction: a name in the section that nothing runs any more. Every
-# .sh the section names must exist, which catches a rename that updated the tree
-# and left the sentence behind; and every one named as a no-*.sh guard must
-# still be registered, which catches a guard quietly dropped from settings.json
-# while the document goes on promising it.
-for hook in $(grep -oE '[A-Za-z0-9_-]+\.sh' "$SECTION" | sort -u); do
-  if [ -e "$HOOKS/$hook" ] || [ -e "$HOOKS/lib/$hook" ]; then
-    printf '  ok   armed the section names %s, and that file exists\n' "$hook"
-  else
-    printf '  FAIL the section names %s, which is no file in .claude/hooks\n' "$hook"
-    FAILED=1
-  fi
+# The other direction: a name in the paragraph that nothing runs any more. Every
+# .sh it names must exist, which catches a rename that updated the tree and left
+# the sentence behind; and every one named as a no-*.sh guard must still be
+# registered, which catches a guard quietly dropped from settings.json while the
+# document goes on promising it.
+for hook in $(grep -oE '[A-Za-z0-9_-]+\.sh' "$PARAGRAPH" | sort -u); do
+  present "the paragraph names $hook, and that file exists" "$hook" "$HOOK_FILES"
   case "$hook" in
-    no-*.sh)
-      case " $REGISTERED " in
-        *" $hook "*)
-          printf '  ok   armed the section names %s, and settings.json runs it\n' "$hook" ;;
-        *)
-          printf '  FAIL the section names %s, which settings.json does not run\n' "$hook"
-          FAILED=1 ;;
-      esac ;;
+    no-*.sh) present "the paragraph names $hook, and settings.json runs it" \
+                     "$hook" "$REGISTERED" ;;
   esac
 done
+set +f
 
 # The section also makes a claim of count -- "the only Edit|Write hook" -- and a
 # second one would falsify it as quietly as a fourth Bash hook falsified the
-# sentence above. The expectation is the literal 1.
-tok 'settings.json registers the one Edit|Write hook the section claims' \
+# sentence above. The question is how many hooks would run on an Edit, not how
+# many are registered under that one spelling of the matcher: `Edit`, `*` and an
+# absent matcher all reach the Edit tool, and asking for the literal string
+# "Edit|Write" would answer 1 while a second hook guarded edits under any of
+# them. So the matcher is used as what it is, a pattern, and the expectation is
+# the literal 1.
+tok 'one hook runs on an Edit, which is the number the section claims' \
     '1' \
-    "$(jq -r '[.hooks.PreToolUse[]? | select(.matcher == "Edit|Write") | .hooks[]?] | length' "$SETTINGS" 2>/dev/null)"
+    "$(jq -r '[.hooks.PreToolUse[]? | select((.matcher // "*") as $m
+                | $m == "*" or $m == "" or ("Edit" | test($m)))
+              | .hooks[]?] | length' "$SETTINGS" 2>/dev/null)"
 
 echo
 if [ $FAILED -eq 0 ]; then echo "ALL CHECKS PASSED"; else echo "SOME CHECKS FAILED"; fi

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -1748,6 +1748,92 @@ tok 'the report hook outlasts its own fetch' \
     '30' \
     "$(jq -r '.hooks.SessionStart[]?.hooks[]? | select(.command | contains("report-stale-branches")) | .timeout' "$SETTINGS" 2>/dev/null)"
 
+echo "=== CLAUDE.md names every hook that carries the boundary ==="
+# A third kind of check, and the second here that reads a file rather than
+# driving a process: this one asks whether the document agrees with the
+# configuration.
+#
+# CLAUDE.md's boundary section exists so that the boundary can be audited
+# without reading the hooks, which only works while the section names all of
+# them. Issue #63 found it naming two of four: #43 rebuilt no-commit-to-main.sh
+# on lib/command-scan.sh and #44 added no-work-on-stale-branch.sh, and neither
+# revised the section. That is the ordinary way this kind of claim goes stale,
+# and it goes stale in the direction that matters -- a reader who audits the
+# named files has audited less than half of what runs, and cannot tell from the
+# text that they have.
+#
+# The direction of the check matters too. settings.json is the fact, because it
+# is what actually runs a hook; the section is the claim. So the registered
+# hooks are derived and the section is asserted against them, rather than one
+# list of names being written out here a second time. The single literal is the
+# opposite list: the registered hooks whose subject is not the boundary, which
+# the section is right not to name. Adding a boundary hook and not the sentence
+# turns this red; adding a hook about documents or commands means adding it
+# here, deliberately, with a reason.
+CLAUDE_MD="$HOOKS/../../CLAUDE.md"
+SECTION="$FIXTURES/boundary-section.md"
+sed -n '/^## What an unattended agent may do to this repository$/,/^## /p' \
+    "$CLAUDE_MD" | sed '$d' > "$SECTION"
+# The extraction is itself a claim about a heading that can be renamed, so it is
+# checked from both ends before anything is asserted against it: the heading is
+# in what came out, and a line from another section is not.
+armed 'the extracted section is the boundary section' \
+  "$SECTION" 'What an unattended agent may do to this repository'
+unarmed 'and it is that section rather than the whole file' \
+  "$SECTION" 'Import cost is a design constraint'
+
+# Registered on Bash or at SessionStart, but about documents or commands rather
+# than about what an agent may do to this repository. Each name here is a
+# decision: these are the hooks the section is correct to leave out.
+NOT_THE_BOUNDARY=" append-only-docs.sh alembic-via-uv-group.sh pytest-via-uv-group.sh "
+REGISTERED=$(jq -r '
+    (.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[]?.command),
+    (.hooks.SessionStart[]?.hooks[]?.command)' "$SETTINGS" 2>/dev/null \
+  | sed 's|.*/||' | sort -u | tr '\n' ' ')
+# Space-separated on purpose: the membership tests below are `case " $REGISTERED "`
+# against `*" $hook "*`, and a newline between two names is not the separator
+# that pattern looks for -- every name but the first would read as absent.
+# An empty derivation would pass every loop below without asking anything.
+[ -n "$REGISTERED" ] || {
+  echo "no hooks were read out of settings.json; the checks below prove nothing" >&2
+  exit 1
+}
+for hook in $REGISTERED; do
+  case "$NOT_THE_BOUNDARY" in *" $hook "*) continue ;; esac
+  armed "the section names $hook, which settings.json runs" "$SECTION" "$hook"
+done
+
+# The other direction: a name in the section that nothing runs any more. Every
+# .sh the section names must exist, which catches a rename that updated the tree
+# and left the sentence behind; and every one named as a no-*.sh guard must
+# still be registered, which catches a guard quietly dropped from settings.json
+# while the document goes on promising it.
+for hook in $(grep -oE '[A-Za-z0-9_-]+\.sh' "$SECTION" | sort -u); do
+  if [ -e "$HOOKS/$hook" ] || [ -e "$HOOKS/lib/$hook" ]; then
+    printf '  ok   armed the section names %s, and that file exists\n' "$hook"
+  else
+    printf '  FAIL the section names %s, which is no file in .claude/hooks\n' "$hook"
+    FAILED=1
+  fi
+  case "$hook" in
+    no-*.sh)
+      case " $REGISTERED " in
+        *" $hook "*)
+          printf '  ok   armed the section names %s, and settings.json runs it\n' "$hook" ;;
+        *)
+          printf '  FAIL the section names %s, which settings.json does not run\n' "$hook"
+          FAILED=1 ;;
+      esac ;;
+  esac
+done
+
+# The section also makes a claim of count -- "the only Edit|Write hook" -- and a
+# second one would falsify it as quietly as a fourth Bash hook falsified the
+# sentence above. The expectation is the literal 1.
+tok 'settings.json registers the one Edit|Write hook the section claims' \
+    '1' \
+    "$(jq -r '[.hooks.PreToolUse[]? | select(.matcher == "Edit|Write") | .hooks[]?] | length' "$SETTINGS" 2>/dev/null)"
+
 echo
 if [ $FAILED -eq 0 ]; then echo "ALL CHECKS PASSED"; else echo "SOME CHECKS FAILED"; fi
 exit $FAILED

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 # Where a command starts, where its arguments end, and how many commands a
-# string holds. Sourced by no-git-push.sh, no-pr-decisions.sh and, since issue
-# #43, no-commit-to-main.sh -- which is every hook that reads a command.
+# string holds. Sourced by no-git-push.sh, no-pr-decisions.sh, and since issue
+# #43 no-commit-to-main.sh and since #44 no-work-on-stale-branch.sh -- which is
+# every hook that reads a command. Issue #63 found this line naming three of the
+# four, the same way it found CLAUDE.md's boundary section naming two of them: a
+# hook is added, and the sentence saying which hooks there are is not revised
+# with it.
 #
 # This exists because of what the defects in PR #35 turned out to have in
 # common. Every one of them, found by Bertan or by the assistant, was the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,18 +217,16 @@ spellings is used, `gh pr edit --base` and the two `gh api` forms included. It
 may comment on one, edit one without moving its base, and read one, through
 `gh pr view` or through a `gh api` request that does not write. It may not merge
 one, review one with a verdict, close or reopen one, or create or delete a
-release. A worktree branch lives as long as its pull request: once that has
-merged the branch is finished, and the next piece of work starts on a new one.
-`main` and `dev-NN` are Bertan's to push; `main` is additionally protected
-server-side by the `main-branch-protection` ruleset, which requires a pull
-request. Enforced by `.claude/hooks/no-git-push.sh`, `no-pr-decisions.sh` and
-`no-commit-to-main.sh`, all three built on `.claude/hooks/lib/command-scan.sh`,
-and by `no-work-on-stale-branch.sh`, which refuses work in a worktree whose
-branch has outlived its pull request, reading refs that
-`report-stale-branches.sh` prunes for it at the start of every session.
+release. A worktree branch lives as long as its pull request, and work moves to
+a new one once that has merged. `main` and `dev-NN` are Bertan's to push; `main`
+is additionally protected server-side by the `main-branch-protection` ruleset,
+which requires a pull request. Enforced by `.claude/hooks/no-git-push.sh`,
+`no-pr-decisions.sh`, `no-commit-to-main.sh` and `no-work-on-stale-branch.sh`,
+all four built on `.claude/hooks/lib/command-scan.sh`, the last of them reading
+refs that `report-stale-branches.sh` prunes for it each session;
 `bash .claude/hooks/check-hooks.sh` checks the boundary in both directions, and
-checks that this paragraph names every hook that carries it. Hooks see only the
-Bash tool, so Bertan's own terminal is not subject to any of this.
+that this paragraph names every hook that carries it. Hooks see only the Bash
+tool, so Bertan's own terminal is not subject to any of this.
 
 `dev-NN` rests on those hooks *because* an agent currently acts with Bertan's
 credentials, so no server-side rule can tell the two apart. That is a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,13 +217,18 @@ spellings is used, `gh pr edit --base` and the two `gh api` forms included. It
 may comment on one, edit one without moving its base, and read one, through
 `gh pr view` or through a `gh api` request that does not write. It may not merge
 one, review one with a verdict, close or reopen one, or create or delete a
-release. `main` and
-`dev-NN` are Bertan's to push; `main` is additionally protected server-side by
-the `main-branch-protection` ruleset, which requires a pull request. Enforced by
-`.claude/hooks/no-git-push.sh` and `no-pr-decisions.sh`, both built on
-`.claude/hooks/lib/command-scan.sh`; `bash .claude/hooks/check-hooks.sh` checks
-the boundary in both directions. Hooks see only the Bash tool, so Bertan's own
-terminal is not subject to any of this.
+release. A worktree branch lives as long as its pull request: once that has
+merged the branch is finished, and the next piece of work starts on a new one.
+`main` and `dev-NN` are Bertan's to push; `main` is additionally protected
+server-side by the `main-branch-protection` ruleset, which requires a pull
+request. Enforced by `.claude/hooks/no-git-push.sh`, `no-pr-decisions.sh` and
+`no-commit-to-main.sh`, all three built on `.claude/hooks/lib/command-scan.sh`,
+and by `no-work-on-stale-branch.sh`, which refuses work in a worktree whose
+branch has outlived its pull request, reading refs that
+`report-stale-branches.sh` prunes for it at the start of every session.
+`bash .claude/hooks/check-hooks.sh` checks the boundary in both directions, and
+checks that this paragraph names every hook that carries it. Hooks see only the
+Bash tool, so Bertan's own terminal is not subject to any of this.
 
 `dev-NN` rests on those hooks *because* an agent currently acts with Bertan's
 credentials, so no server-side rule can tell the two apart. That is a


### PR DESCRIPTION
## What

CLAUDE.md's boundary section named `no-git-push.sh` and `no-pr-decisions.sh`. `.claude/settings.json` registers four hooks that carry the boundary: #43 rebuilt `no-commit-to-main.sh` on `lib/command-scan.sh` and #44 added `no-work-on-stale-branch.sh` with `report-stale-branches.sh` arming it, and neither revised the section. A reader auditing the two named files had audited less than half of what runs, with nothing in the text to say so — and the section exists so that the boundary can be audited without reading the hooks.

The enforcement sentence now names all four, says they share the tokeniser, names the arming script, and states the branch-lifecycle rule the fourth enforces, which the section did not carry at all. The operative paragraph is 354 words against 307 before.

`lib/command-scan.sh`'s own header said it was sourced by three hooks, "which is every hook that reads a command" — stale since #44 in the same way, and quoted in the issue as evidence. Corrected here, with a line saying how it went stale.

## The check

`settings.json` is the fact, because it is what actually runs a hook; the paragraph is the claim. So the registered hooks are derived and the paragraph is asserted against them, rather than one list of names being written into the suite a second time. The single literal is the opposite list — the three registered hooks whose subject is documents or commands. Adding a boundary hook and not the sentence turns it red. Both reverse directions are checked too: a `.sh` the paragraph names must exist, and one named as a `no-*.sh` guard must still be registered.

That is the strong form the issue preferred over the count assertion, "the one that actually fails when a hook is added and the document is not".

## What the review changed

Both axes ran against the first commit, and the second commit is their findings. The sentence itself was wrong — it grouped `no-work-on-stale-branch.sh` outside "built on `lib/command-scan.sh`", and `no-work-on-stale-branch.sh:190` sources the library and refuses when its functions are missing. That is the defect this issue is about, committed again in the fix for it; it came in through the issue's suggested wording, which came from the stale library header.

Three defects in the check, each now mutation-checked:

- it grepped the whole section, and the section's last paragraph is about what is deliberately *not* guarded — a hook named only there passed. It now reads the paragraph that says what is enforced, which is what CLAUDE.md claims.
- `sed -n '/start/,/^## /p' | sed '$d'` eats a real line when the boundary section is last in the file. Replaced with `awk`; demonstrated on a copy.
- the `Edit|Write` count matched the literal matcher string, so a second hook under `Edit`, `Write` or `*` left it at 1. The matcher is now used as the pattern it is.

## Evidence

- `bash .claude/hooks/check-hooks.sh` — 571 ok, ALL CHECKS PASSED. Red before the CLAUDE.md revision on exactly the three missing names.
- Mutation-checked on a copy of the tree, four ways: a hook registered and not named turns it red; a boundary hook named only in the "deliberately left open" paragraph turns it red (the first version passed); a second hook under matcher `Edit` turns the count red (the first version said 1); with the section last in the file the extraction keeps its final line.
- `make test` — 571 passed, 5 xfailed. `test_installed_packages_match_uv_lock` fails on pre-existing venv drift (`alembic` and `mako` from the `migrations` group are not installed); no commit here touches Python or `uv.lock`.
- `make upgrade-safe` not run: no dependency changed. It remains the gate before this closes.

No dev-log entry: these worktree-issue branches have not carried one, and the log is per session.

https://claude.ai/code/session_017f3ZtRkR11cervrB1sft3p
