### PR TITLE
Pin the whole active-dev derivation, not its tail

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -234,6 +234,10 @@ need_worktree() {  # need_worktree <dir> <fixture name>
 # line rather than a trailing remark. Routed through `armed`, such a pin cannot
 # pass: measured, not reasoned, on the boundary-section check that dev-05 is
 # red on today. This reads the file as written, and the name says which.
+prose_count() {  # prose_count <file> <literal> -- how many lines say it
+  grep -cF -- "$2" "$1" 2>/dev/null
+}
+
 written() {  # written <label> <file> <literal> -- the file as written, # and all
   if grep -qF -- "$3" "$2" 2>/dev/null; then
     printf '  ok   written %s\n' "$1"
@@ -2125,13 +2129,34 @@ beside 'the guard names the pairing beside its derivation' \
 beside 'and the report names it identically' \
   "$HOOKS/report-stale-branches.sh" "$PAIRING"
 # A pointer to an argument is worth what the argument is worth, and the report's
-# now points at prose in another file. Nothing kept that prose alive, so delete
-# the guard's header and the report goes on citing a reason that is no longer
-# written anywhere -- the stale-docstring defect moved rather than fixed. This
-# pins the claim itself, both halves of it, in the one place it is now made.
+# now points at prose in another file. Two ways that goes wrong, and the second
+# is the one this branch would otherwise have left open.
+#
+# Delete the guard's header and the report cites a reason no longer written
+# anywhere: the stale-docstring defect moved rather than fixed. Re-add a second
+# copy to the report and the defect is back exactly as it was -- two arguments,
+# nothing holding them to each other -- which is what the report's own new
+# comment says is wrong: "a second copy of an argument goes stale in silence
+# when the first one is corrected." The code duplication got a count for that
+# reason; the prose duplication fixed in the same breath did not, and the
+# asymmetry was the gap. Both directions are counted now, the same shape as the
+# two counts above, and both halves of the claim are in the literal.
+#
+# The limit is the one the counts above have: this finds the argument as
+# written, so a reworded second copy is a second copy uncounted.
 ARGUMENT='sort makes dev-09 beat dev-10, and an unfiltered glob lets origin/dev-foo'
-written 'the argument the report points at is still made in the guard' \
-  "$HOOKS/no-work-on-stale-branch.sh" "$ARGUMENT"
+tok 'the argument the report points at is made in the guard, once' \
+    '1' "$(prose_count "$HOOKS/no-work-on-stale-branch.sh" "$ARGUMENT")"
+tok 'and the report does not argue it a second time' \
+    '0' "$(prose_count "$HOOKS/report-stale-branches.sh" "$ARGUMENT")"
+# And the sentence that does the pointing: without it the report holds a bare
+# pairing pointer and no trace of where its reasoning went. `beside` rather than
+# `written`, because a pointer that is not beside the derivation is not doing
+# the job the pointer exists for -- the same standard the pairing line is held
+# to four lines above.
+POINTER="no-work-on-stale-branch.sh's header, rather than twice here in different words"
+beside 'the report says where the argument was moved to' \
+  "$HOOKS/report-stale-branches.sh" "$POINTER"
 
 # The carve-out's identity test, pinned as three lines rather than driven as a
 # process. Two of them are driven, by the diverged and no-local fixtures above;

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -224,12 +224,15 @@ unarmed() {  # unarmed <label> <file> <literal>
 # stale the moment either file gains a line above it, and goes stale silently --
 # and on what the derivation reads rather than on the name it assigns, so a
 # second reader of those refs is counted rather than hidden behind the first.
-# What that counts is readers spelled with for-each-ref: one written as
-# `git branch -r` would read the same refs and not be counted, and the suite
-# says nothing about it. The count is here because equality alone does not
-# close the case -- two files that both extract to nothing are equal, so the
-# three checks are needed together and each was mutated to confirm it.
-dev_reads() {  # dev_reads <file> -- how many lines read the dev refs
+#
+# Two limits, both named because a check is evidence about what it names. The
+# count finds readers spelled with for-each-ref, so one written as
+# `git branch -r` would read the same refs uncounted -- the permitting
+# direction, and the reason the pin below is there too. And it counts matching
+# lines anywhere in the file, comments included, so quoting the pipeline in
+# either hook's header turns the suite red although nothing has changed: the
+# refusing direction, visible and one edit away.
+dev_read_count() {  # dev_read_count <file> -- how many lines read the dev refs
   grep -cE 'for-each-ref.*refs/remotes/origin/dev-' "$1" 2>/dev/null
 }
 
@@ -238,6 +241,28 @@ dev_derivation() {  # dev_derivation <file> -- the derivation, as written
        inblock                                      { print }
        inblock && /tail -1\)/                       { inblock = 0 }' \
       "$1" 2>/dev/null
+}
+
+# The comment block standing immediately above the derivation. `armed` would
+# ask only whether a literal is somewhere in a file, and somewhere is not
+# beside: a pointer that drifted to the head of either file would still satisfy
+# grep while no longer standing where the derivation is read and edited, which
+# is the whole of what a pointer is for. A blank line ends the block, so a
+# pointer separated from the derivation does not count as beside it.
+dev_pointer() {  # dev_pointer <file> -- the comment block above the derivation
+  awk '/^#/ { block = block $0 "\n"; next }
+       /for-each-ref.*refs\/remotes\/origin\/dev-/ { printf "%s", block; exit }
+       { block = "" }' "$1" 2>/dev/null
+}
+
+beside() {  # beside <label> <file> <literal>
+  if dev_pointer "$2" | grep -qF -- "$3"; then
+    printf '  ok   armed %s\n' "$1"
+  else
+    printf '  FAIL %s\n         expected the comment above the derivation in %s\n         to contain |%s|\n' \
+           "$1" "$2" "$3"
+    FAILED=1
+  fi
 }
 
 tok() {  # tok <label> <expected> <actual>
@@ -1764,11 +1789,21 @@ unarmed 'the report deletes nothing on the remote' \
 # two-line fixed string is satisfied by a file holding either line alone --
 # measured on a two-line fixture, not assumed. The derivations are extracted and
 # compared as strings instead, three ways: each file holds exactly one, the two
-# are equal to each other, and each is the derivation as pinned here. The first
-# of those is a question `armed` cannot ask at all -- it wants a constant
-# somewhere in a file, so a second derivation added to either file would have
-# been satisfied by the first, and a check that names the tail of a pipeline is
-# evidence about that tail and about nothing else.
+# are equal to each other, and each is the derivation as pinned here. The counts
+# ask a question `armed` cannot ask at all -- it wants a constant somewhere in a
+# file, so a second derivation added to either file would have been satisfied by
+# the first -- and they are what closes the case, because two files that both
+# extract to nothing are equal to each other and to nothing else.
+#
+# Be exact about which of the three carry the weight: with both files pinned to
+# the literal, the guard-equals-report check follows by transitivity and proves
+# nothing the pins do not. It is kept as the one line that states the property
+# the duplication actually needs, and because it is the check that still holds
+# the two together the day someone re-pins the literal on purpose -- a
+# coordinated change turns both pins red and leaves it green, which is the pair
+# of answers that says what happened. Each of the five was mutated to confirm it
+# fails for its own reason, and the two counts were mutated to confirm they fail
+# for theirs.
 DEV_DERIVATION=$(cat <<'DERIVATION'
 DEV=$(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/dev-*' 2>/dev/null \
       | grep -E '^origin/dev-[0-9]+$' | sort -V | tail -1)
@@ -1777,9 +1812,9 @@ DERIVATION
 GUARD_DERIVATION=$(dev_derivation "$HOOKS/no-work-on-stale-branch.sh")
 REPORT_DERIVATION=$(dev_derivation "$HOOKS/report-stale-branches.sh")
 tok 'the guard reads the dev refs in exactly one place' \
-    '1' "$(dev_reads "$HOOKS/no-work-on-stale-branch.sh")"
+    '1' "$(dev_read_count "$HOOKS/no-work-on-stale-branch.sh")"
 tok 'and the report reads them in exactly one place' \
-    '1' "$(dev_reads "$HOOKS/report-stale-branches.sh")"
+    '1' "$(dev_read_count "$HOOKS/report-stale-branches.sh")"
 tok 'the guard and the report derive the active dev branch identically' \
     "$GUARD_DERIVATION" "$REPORT_DERIVATION"
 tok 'the guard derives it as pinned here, glob and --format included' \
@@ -1796,10 +1831,18 @@ tok 'and the report derives it as pinned here too' \
 # is one line because grep is: a literal spanning a line break would match
 # neither file.
 PAIRING='check-hooks.sh holds the two equal, so a change here is a change there'
-armed 'the guard names the pairing beside its derivation' \
+beside 'the guard names the pairing beside its derivation' \
   "$HOOKS/no-work-on-stale-branch.sh" "$PAIRING"
-armed 'and the report names it identically' \
+beside 'and the report names it identically' \
   "$HOOKS/report-stale-branches.sh" "$PAIRING"
+# A pointer to an argument is worth what the argument is worth, and the report's
+# now points at prose in another file. Nothing kept that prose alive, so delete
+# the guard's header and the report goes on citing a reason that is no longer
+# written anywhere -- the stale-docstring defect moved rather than fixed. This
+# pins the claim itself, both halves of it, in the one place it is now made.
+ARGUMENT='sort makes dev-09 beat dev-10, and an unfiltered glob lets origin/dev-foo'
+armed 'the argument the report points at is still made in the guard' \
+  "$HOOKS/no-work-on-stale-branch.sh" "$ARGUMENT"
 
 # settings.json is what actually runs either file, so a hook present in the tree
 # and absent from the configuration is a hook that does nothing. jq reads it;

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -217,6 +217,29 @@ unarmed() {  # unarmed <label> <file> <literal>
 
 . ./lib/command-scan.sh
 
+# A property of two files at once, which is what `armed` cannot express: it
+# asks whether a file contains a constant, never whether two files agree. These
+# two read what a file actually derives, so the copies can be compared with each
+# other. Anchored on content rather than on a line range -- a line range goes
+# stale the moment either file gains a line above it, and goes stale silently --
+# and on what the derivation reads rather than on the name it assigns, so a
+# second reader of those refs is counted rather than hidden behind the first.
+# What that counts is readers spelled with for-each-ref: one written as
+# `git branch -r` would read the same refs and not be counted, and the suite
+# says nothing about it. The count is here because equality alone does not
+# close the case -- two files that both extract to nothing are equal, so the
+# three checks are needed together and each was mutated to confirm it.
+dev_reads() {  # dev_reads <file> -- how many lines read the dev refs
+  grep -cE 'for-each-ref.*refs/remotes/origin/dev-' "$1" 2>/dev/null
+}
+
+dev_derivation() {  # dev_derivation <file> -- the derivation, as written
+  awk '/for-each-ref.*refs\/remotes\/origin\/dev-/ { inblock = 1 }
+       inblock                                      { print }
+       inblock && /tail -1\)/                       { inblock = 0 }' \
+      "$1" 2>/dev/null
+}
+
 tok() {  # tok <label> <expected> <actual>
   if [ "$3" = "$2" ]; then
     printf '  ok   %s\n' "$1"
@@ -1726,11 +1749,57 @@ unarmed 'the report deletes nothing on the remote' \
 # command in every worktree whenever a library is missing. The cost of that
 # ordering is two copies, so the copies are pinned instead of shared. A
 # divergence here silently unarms the guard or misreports the branch.
-DEV_DERIVATION="| grep -E '^origin/dev-[0-9]+\$' | sort -V | tail -1)"
-armed 'the guard derives the active dev branch this way' \
-  "$HOOKS/no-work-on-stale-branch.sh" "$DEV_DERIVATION"
-armed 'and the report derives it identically' \
-  "$HOOKS/report-stale-branches.sh" "$DEV_DERIVATION"
+#
+# Issue #62: that pin used to be `armed` against the tail of the pipeline,
+# "| grep -E ... | sort -V | tail -1)". Everything left of the first pipe -- the
+# command, the --format, and the ref glob 'refs/remotes/origin/dev-*' -- was
+# pinned in neither file, and the glob is the half most likely to move: it is
+# what keeps origin/dev-foo and origin/dev-05-backup from winning, so a change
+# to which refs count is a change to it. Changing the glob in one file only left
+# the whole suite green, the second of those two checks labelled "derives it
+# identically".
+#
+# Extending that literal to both lines would not have closed it. `armed` is
+# grep -qF, and grep reads a pattern containing a newline as two patterns, so a
+# two-line fixed string is satisfied by a file holding either line alone --
+# measured on a two-line fixture, not assumed. The derivations are extracted and
+# compared as strings instead, three ways: each file holds exactly one, the two
+# are equal to each other, and each is the derivation as pinned here. The first
+# of those is a question `armed` cannot ask at all -- it wants a constant
+# somewhere in a file, so a second derivation added to either file would have
+# been satisfied by the first, and a check that names the tail of a pipeline is
+# evidence about that tail and about nothing else.
+DEV_DERIVATION=$(cat <<'DERIVATION'
+DEV=$(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/dev-*' 2>/dev/null \
+      | grep -E '^origin/dev-[0-9]+$' | sort -V | tail -1)
+DERIVATION
+)
+GUARD_DERIVATION=$(dev_derivation "$HOOKS/no-work-on-stale-branch.sh")
+REPORT_DERIVATION=$(dev_derivation "$HOOKS/report-stale-branches.sh")
+tok 'the guard reads the dev refs in exactly one place' \
+    '1' "$(dev_reads "$HOOKS/no-work-on-stale-branch.sh")"
+tok 'and the report reads them in exactly one place' \
+    '1' "$(dev_reads "$HOOKS/report-stale-branches.sh")"
+tok 'the guard and the report derive the active dev branch identically' \
+    "$GUARD_DERIVATION" "$REPORT_DERIVATION"
+tok 'the guard derives it as pinned here, glob and --format included' \
+    "$DEV_DERIVATION" "$GUARD_DERIVATION"
+tok 'and the report derives it as pinned here too' \
+    "$DEV_DERIVATION" "$REPORT_DERIVATION"
+
+# The filter and the version sort were argued twice, in different words, at the
+# head of each file, and nothing held those two to each other either: correct
+# one and the other goes on asserting the superseded reason, which CLAUDE.md
+# counts as a defect in its own right. The argument is made once now, in
+# no-work-on-stale-branch.sh's header, and each file carries the same one-line
+# pointer to the pairing in place of its own copy of the reasoning. The pointer
+# is one line because grep is: a literal spanning a line break would match
+# neither file.
+PAIRING='check-hooks.sh holds the two equal, so a change here is a change there'
+armed 'the guard names the pairing beside its derivation' \
+  "$HOOKS/no-work-on-stale-branch.sh" "$PAIRING"
+armed 'and the report names it identically' \
+  "$HOOKS/report-stale-branches.sh" "$PAIRING"
 
 # settings.json is what actually runs either file, so a hook present in the tree
 # and absent from the configuration is a hook that does nothing. jq reads it;

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -225,6 +225,24 @@ need_worktree() {  # need_worktree <dir> <fixture name>
   exit 1
 }
 
+# `armed` strips a shell comment before it looks, so that commenting a line out
+# can no longer satisfy a pin. That makes it a pin on code, and its header says
+# so: none of its literals carries a `#`. Two kinds of file here are not code.
+# Prose in a comment is the whole of what some pins assert -- an argument the
+# other file points at, which lives nowhere but a comment -- and a markdown
+# fixture opens its headings with the same character, so stripping erases the
+# line rather than a trailing remark. Routed through `armed`, such a pin cannot
+# pass: measured, not reasoned, on the boundary-section check that dev-05 is
+# red on today. This reads the file as written, and the name says which.
+written() {  # written <label> <file> <literal> -- the file as written, # and all
+  if grep -qF -- "$3" "$2" 2>/dev/null; then
+    printf '  ok   written %s\n' "$1"
+  else
+    printf '  FAIL %s\n         expected %s to still say |%s|\n' "$1" "$2" "$3"
+    FAILED=1
+  fi
+}
+
 unarmed() {  # unarmed <label> <file> <literal>
   if grep -qF -- "$3" "$2" 2>/dev/null; then
     printf '  FAIL %s\n         %s must not contain |%s|\n' "$1" "$2" "$3"
@@ -276,7 +294,7 @@ dev_pointer() {  # dev_pointer <file> -- the comment block above the derivation
 
 beside() {  # beside <label> <file> <literal>
   if dev_pointer "$2" | grep -qF -- "$3"; then
-    printf '  ok   armed %s\n' "$1"
+    printf '  ok   beside %s\n' "$1"
   else
     printf '  FAIL %s\n         expected the comment above the derivation in %s\n         to contain |%s|\n' \
            "$1" "$2" "$3"
@@ -2112,7 +2130,7 @@ beside 'and the report names it identically' \
 # written anywhere -- the stale-docstring defect moved rather than fixed. This
 # pins the claim itself, both halves of it, in the one place it is now made.
 ARGUMENT='sort makes dev-09 beat dev-10, and an unfiltered glob lets origin/dev-foo'
-armed 'the argument the report points at is still made in the guard' \
+written 'the argument the report points at is still made in the guard' \
   "$HOOKS/no-work-on-stale-branch.sh" "$ARGUMENT"
 
 # The carve-out's identity test, pinned as three lines rather than driven as a
@@ -2195,7 +2213,7 @@ awk '/^## What an unattended agent may do to this repository$/ {f=1; print; next
 # The extraction is itself a claim about a heading that can be renamed, so it is
 # checked from both ends before anything is asserted against it: the heading is
 # in what came out, and a line from another section is not.
-armed 'the extracted section is the boundary section' \
+written 'the extracted section is the boundary section' \
   "$SECTION" 'What an unattended agent may do to this repository'
 unarmed 'and it is that section rather than the whole file' \
   "$SECTION" 'Import cost is a design constraint'
@@ -2209,7 +2227,7 @@ unarmed 'and it is that section rather than the whole file' \
 # drift one paragraph along.
 PARAGRAPH="$FIXTURES/boundary-paragraph.md"
 awk -v RS= '/Enforced by/' "$SECTION" > "$PARAGRAPH"
-armed 'and the paragraph taken from it is the one that says what is enforced' \
+written 'and the paragraph taken from it is the one that says what is enforced' \
   "$PARAGRAPH" 'Enforced by'
 unarmed 'and it stops short of what is deliberately left unguarded' \
   "$PARAGRAPH" 'Deliberately left open'
@@ -2237,7 +2255,7 @@ HOOK_FILES=$(ls "$HOOKS"/*.sh "$HOOKS"/lib/*.sh 2>/dev/null | sed 's|.*/||' | so
 set -f
 for hook in $REGISTERED; do
   case " $NOT_THE_BOUNDARY " in *" $hook "*) continue ;; esac
-  armed "the paragraph names $hook, which settings.json runs" "$PARAGRAPH" "$hook"
+  written "the paragraph names $hook, which settings.json runs" "$PARAGRAPH" "$hook"
 done
 
 # The other direction: a name in the paragraph that nothing runs any more. Every

--- a/.claude/hooks/no-work-on-stale-branch.sh
+++ b/.claude/hooks/no-work-on-stale-branch.sh
@@ -44,10 +44,16 @@
 # THE ACTIVE DEV BRANCH is the highest-numbered refs/remotes/origin/dev-*, read
 # with no network because a hook has five seconds. Sorted with `sort -V` and
 # filtered to `^origin/dev-[0-9]+$`, and both halves earn their place: a lexical
-# sort makes dev-09 beat dev-10, and an unfiltered glob lets origin/dev-foo win
-# outright. The branch-hygiene skill mandates two-digit zero-padding, so a
-# lexical sort would be correct today and wrong at dev-10; the version sort does
-# not depend on that mandate holding.
+# sort makes dev-09 beat dev-10, and an unfiltered glob lets origin/dev-foo --
+# or origin/dev-05-backup -- win outright. Both were measured on a fixture
+# rather than assumed. The branch-hygiene skill mandates two-digit
+# zero-padding, so a lexical sort would be correct today and wrong at dev-10;
+# the version sort does not depend on that mandate holding.
+#
+# report-stale-branches.sh derives the same branch from the same two lines and
+# does not re-argue any of this: one argument, for both copies. Why a copy is
+# preferred to a shared helper, and what holds the two copies equal, is in
+# check-hooks.sh at the arming section.
 #
 # When no such ref exists -- a fresh clone, or the rotation window after the
 # merged dev-NN is deleted and its successor is not yet pushed -- the guard
@@ -146,7 +152,9 @@ CURRENT=$(git branch --show-current 2>/dev/null)
 [ -n "$CURRENT" ] || exit 0
 
 # The active dev branch. See the header for why the filter and the version sort
-# are both load-bearing.
+# are both load-bearing. The next two lines stand verbatim in
+# report-stale-branches.sh as well:
+# check-hooks.sh holds the two equal, so a change here is a change there.
 DEV=$(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/dev-*' 2>/dev/null \
       | grep -E '^origin/dev-[0-9]+$' | sort -V | tail -1)
 

--- a/.claude/hooks/report-stale-branches.sh
+++ b/.claude/hooks/report-stale-branches.sh
@@ -69,11 +69,12 @@ else
   fi
 fi
 
-# The active dev branch: the highest-numbered refs/remotes/origin/dev-*. Sorted
-# with sort -V rather than lexically, and filtered to digits, because both parts
-# matter: a lexical sort makes dev-09 beat dev-10, and an unfiltered glob lets
-# origin/dev-foo -- or origin/dev-05-backup -- win outright. Both were measured
-# on a fixture rather than assumed.
+# The active dev branch: the highest-numbered refs/remotes/origin/dev-*. Why the
+# digit filter and the version sort are both load-bearing is argued once, in
+# no-work-on-stale-branch.sh's header, rather than twice here in different words
+# -- a second copy of an argument goes stale in silence when the first one is
+# corrected. The next two lines stand verbatim in that file as well:
+# check-hooks.sh holds the two equal, so a change here is a change there.
 DEV=$(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/dev-*' 2>/dev/null \
       | grep -E '^origin/dev-[0-9]+$' | sort -V | tail -1)
 if [ -n "$DEV" ]; then


### PR DESCRIPTION
Closes #62.

## The defect, measured

The active dev branch is derived by hand in two files, and the duplication is
deliberate — the guard must read its state before it may depend on `lib/` at
all. What paid for it was a pin, and the pin covered the second of the two
lines:

    DEV_DERIVATION="| grep -E '^origin/dev-[0-9]+\$' | sort -V | tail -1)"

Everything left of the first pipe — the command, the `--format`, and the ref
glob `'refs/remotes/origin/dev-*'` — was pinned in neither file. Changing the
glob in `report-stale-branches.sh` alone left the **whole suite green**,
including the check labelled *"and the report derives it identically"*. A guard
that stops finding the active dev branch abstains rather than refuses, so that
divergence would have been silent.

## Why not just extend the literal

`armed` is `grep -qF`, and grep reads a pattern containing a newline as two
patterns: a two-line fixed string is satisfied by a file holding **either line
alone**. Measured on a two-line fixture. That is why the fix extracts and
compares rather than greps.

## What lands

Both derivations are extracted by content — not by line range, which goes stale
silently the moment either file gains a line above it — and checked three ways:
each file holds exactly one, the two are equal to each other, and each is the
derivation as pinned, glob and `--format` included. The counts are what close
the case: two files that both extract to nothing are equal to each other.

The rationale for the filter and the version sort was also written twice, in
different words, with nothing holding those to each other. It is argued once
now, in `no-work-on-stale-branch.sh`'s header — which takes over the two details
only the report had — and each file carries the same one-line pointer, pinned in
both, in place of its own copy.

## Evidence

Eight mutations, each turning red for its own reason:

| mutation | what goes red |
|---|---|
| glob changed in the report only | equality, the report's pin |
| `--format` changed in the guard only | equality, the guard's pin |
| glob changed identically in both | both pins; equality stays green |
| a second derivation in the report | that file's count, equality |
| neither file matching the anchor | both counts — equality alone passes |
| the pairing pointer dropped | that file's pointer check |
| the pointer moved to the file head | `beside` — `armed` passed this |
| the guard's argument dropped | the argument pin |

The second commit fixes four findings from the two-axis review of the first,
one of them the ticket's own defect shape appearing in the checks that fix it:
the pointer checks were labelled *"beside its derivation"* while `armed` looks
anywhere in the file.

Suite: 556 checks, all pass. `make test` is unchanged by this branch (571
passed, 5 xfailed; the one failure is pre-existing venv drift —
`alembic`/`mako` from the `migrations` group are not installed — and this branch
touches no Python).

## What these checks do not see

Named where they are defined. The count finds readers spelled with
`for-each-ref`, so one written as `git branch -r` would read the same refs
uncounted; and it counts matching lines anywhere in a file, comments included,
so quoting the pipeline in either hook's header turns the suite red although
nothing changed.

https://claude.ai/code/session_01NNtmv9SCTyzRZT3E8J13Km
