### PR TITLE
Stop cutting a command on a separator that is inside quotes

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -32,6 +32,16 @@
 # the workaround is to drop the redirect -- and was filed anyway, because the
 # question it gets wrong is the one lib/command-scan.sh exists to answer once.
 #
+# The quoted-separator checks come from a fifth review, of dev-05, and are the
+# second group to name a defect in the refusing direction. They are also the
+# first whose cost lands on the work of editing these files: cs_split cut on a
+# separator inside quotes, so an ordinary `sed -i` substitution written with |
+# as its delimiter yielded a push that does not exist, and it fired twice in a
+# live session against that session's own edits. The pairs matter more than the
+# individual verdicts there -- the anchored and unanchored spellings of one
+# substitution are pinned side by side, because it was the anchor that decided
+# the verdict and that is the part that reads as arbitrary.
+#
 # So the number below is not a measure of the boundary. A check suite is
 # evidence about the cases it names and about nothing else, and every case here
 # was named by someone who went looking for one it had missed.
@@ -461,6 +471,101 @@ git push --mirror origin' \
 tok 'control word removed, brace group' \
     'git push --mirror origin' \
     "$(printf '{ git push --mirror origin; }\n' | cs_split)"
+# Issue #68. The separator pass cut with a plain character class that knew
+# nothing about quoting, so a | inside a quoted argument was a fragment
+# boundary like any other and the second fragment of a sed substitution was a
+# push standing at the head of its own line. Each of these is one fragment now.
+#
+# The firing and the non-firing spellings are pinned side by side because the
+# pair is the evidence: the fragment had to BEGIN with the command word, so a ^
+# in the pattern saved the command by accident and a leading space did not.
+# Two commands doing the same job, one refused and one not, on a difference
+# that has nothing to do with what either would run.
+tok 'a sed delimiter is not a separator' \
+    "sed -i 's|git push --all origin|X|' f.sh" \
+    "$(printf "sed -i 's|git push --all origin|X|' f.sh\n" | cs_split)"
+tok 'the anchored spelling is the same one fragment' \
+    "sed -i 's|^git push --all origin|X|' f.sh" \
+    "$(printf "sed -i 's|^git push --all origin|X|' f.sh\n" | cs_split)"
+tok 'and so is the leading-space spelling that used to fire' \
+    "sed -i 's| git push --all origin|X|' f.sh" \
+    "$(printf "sed -i 's| git push --all origin|X|' f.sh\n" | cs_split)"
+tok 'a grep alternation is not a separator' \
+    "grep -rn 'git push --all|git push -f' .claude/" \
+    "$(printf "grep -rn 'git push --all|git push -f' .claude/\n" | cs_split)"
+tok 'the commit spelling of the same shape' \
+    "sed -i 's|git commit -m x|X|' f.sh" \
+    "$(printf "sed -i 's|git commit -m x|X|' f.sh\n" | cs_split)"
+tok 'the anchored commit spelling, likewise one fragment' \
+    "sed -i 's|^git commit -m x|X|' f.sh" \
+    "$(printf "sed -i 's|^git commit -m x|X|' f.sh\n" | cs_split)"
+tok 'the forced-push spelling' \
+    "sed -i 's|git push -f origin main|X|' f.sh" \
+    "$(printf "sed -i 's|git push -f origin main|X|' f.sh\n" | cs_split)"
+tok 'the bare-push spelling' \
+    "sed -i 's|git push|X|' f.sh" \
+    "$(printf "sed -i 's|git push|X|' f.sh\n" | cs_split)"
+tok 'the grep alternation over a commit and a push' \
+    "grep -n 'git commit|git push origin main' *.sh" \
+    "$(printf "grep -n 'git commit|git push origin main' *.sh\n" | cs_split)"
+# Double quotes protect a delimiter too. They protect only the separators,
+# never a substitution -- see the two below.
+tok 'a delimiter written with double quotes' \
+    'sed -i "s|git push --all origin|X|" f.sh' \
+    "$(printf 'sed -i "s|git push --all origin|X|" f.sh\n' | cs_split)"
+# A closed quote restores the separator. A tracker that treated everything
+# after the first quote as quoted would convert issue #68 into a real hole.
+tok 'a closed quote reopens the separator' \
+    'echo "a"
+git push --all origin' \
+    "$(printf 'echo "a" | git push --all origin\n' | cs_split)"
+# The two fallbacks, both of which split exactly as the plain character class
+# did. Unbalanced quoting is text this cannot read.
+tok 'unbalanced quoting falls back to the old splitting' \
+    "echo 'unclosed
+git push --all origin" \
+    "$(printf "echo 'unclosed | git push --all origin\n" | cs_split)"
+# And a double-quoted span is not inert: a command substitution inside one RUNS,
+# so a line carrying one goes to the same fallback rather than being protected.
+# Getting this wrong would have hidden every command written that way, silently
+# and in the permitting direction.
+tok 'a substitution in double quotes still splits out' \
+    'echo "$
+gh pr merge 5
+"' \
+    "$(printf 'echo "$(gh pr merge 5)"\n' | cs_split)"
+tok 'a backticked span in double quotes still splits out' \
+    'echo "
+git push --all origin
+"' \
+    "$(printf 'echo "`git push --all origin`"\n' | cs_split)"
+# Single quotes need no such exception -- bash runs nothing inside them -- and
+# an escaped substitution in double quotes is text, which is why the backslash
+# is read before the substitution is looked for.
+tok 'a substitution inside single quotes is text' \
+    "grep -n 'git push|\$(x)' ." \
+    "$(printf "grep -n 'git push|\$(x)' .\n" | cs_split)"
+tok 'an escaped substitution in double quotes is text' \
+    'git commit -m "release \$(date) notes"' \
+    "$(printf 'git commit -m "release \\$(date) notes"\n' | cs_split)"
+# The backslash is read for that one purpose. An escaped separator outside
+# quotes still cuts, exactly as it did before, which is the refusing direction.
+tok 'an escaped separator outside quotes still cuts' \
+    'echo a \
+git push --all origin' \
+    "$(printf 'echo a \\| git push --all origin\n' | cs_split)"
+# The other arm of that branch, which the check above does not reach: an escaped
+# quote outside quotes must not OPEN one. Without this the sed argument that
+# follows sits inside a double quote that never closes, the line is unbalanced,
+# and the fallback splits it into a bare push -- so this pair is the check that
+# fails without the escape branch. Every other escape shape tried gave the same
+# answer with the branch and without it, because the fallback agrees with the
+# protected split whenever the quoting is simple.
+tok 'an escaped quote outside quotes does not open one' \
+    'sed -e s/\"/Q/ -e '"'"'s|git push|X|'"'"' f.sh' \
+    "$(printf 'sed -e s/\\"/Q/ -e %ss|git push|X|%s f.sh\n' "'" "'" | cs_split)"
+check no-git-push.sh ALLOW 'and the same command is not a push' \
+         'sed -e s/\"/Q/ -e '"'"'s|git push|X|'"'"' f.sh'
 tok 'git args, plain' 'origin main' "$(printf 'git push origin main\n' | cs_git_args push)"
 tok 'git args, global option with a separate value' \
     '--all' "$(printf 'git -C /x push --all\n' | cs_git_args push)"
@@ -598,10 +703,124 @@ echo "=== ACCEPTED false positive: quoted multi-line string, not a heredoc ==="
 # knowingly, not a bug fix.
 check no-git-push.sh     BLOCK 'multi-line -b string continuing with a push' $'gh issue comment 27 -b "to release:\n  git push origin main"'
 check no-pr-decisions.sh BLOCK 'multi-line -b string continuing with a merge' $'gh issue comment 27 -b "to land it:\n  gh pr merge 35"'
-# And the price of removing control words: a quoted string holding a separator
-# and then one of them reads as a command. Same trade, same reason.
-check no-git-push.sh     BLOCK 'quoted "; then" before a push'  'git commit -m "wait; then git push --all origin"'
-check no-pr-decisions.sh BLOCK 'quoted "; then" before a merge' 'git commit -m "wait; then gh pr merge 35"'
+# The single-line half of that trade is no longer paid, and the two checks that
+# used to sit here now sit in the issue #68 section below -- an `ALLOW (was
+# BLOCK)` is neither accepted nor a false positive, and leaving them under this
+# heading would have made the heading a lie. The multi-line pair above stays,
+# and stays accepted: quote state is per line, so an unbalanced line falls back
+# to the old splitting and the continuation still reads as a command position.
+
+echo "=== REGRESSION: issue #68, a quoted separator refused ordinary sed and grep ==="
+# The six measured over-refusals from the ticket, now ALLOW. Every one is a
+# command that edits or searches text; none of them pushes or commits anything.
+# It fired twice in a live session against that session's own edits to these
+# hooks, which is what makes it worth a suite entry rather than a note: editing
+# the hooks is exactly the work that trips it.
+check no-git-push.sh ALLOW 'sed over a push --all (was BLOCK)'  "sed -i 's|git push --all origin|X|' f.sh"
+check no-git-push.sh ALLOW 'sed over a forced push (was BLOCK)' "sed -i 's|git push -f origin main|X|' f.sh"
+check no-git-push.sh ALLOW 'sed over a bare push (was BLOCK)'   "sed -i 's|git push|X|' f.sh"
+check no-git-push.sh ALLOW 'grep alternation over pushes (was BLOCK)' "grep -rn 'git push --all|git push -f' .claude/"
+check_in "$ON_MAIN" no-commit-to-main.sh ALLOW 'sed over a commit, on main (was BLOCK)' \
+         "sed -i 's|git commit -m x|X|' f.sh"
+check_in "$ON_MAIN" no-commit-to-main.sh ALLOW 'grep alternation over commit and push, on main (was BLOCK)' \
+         "grep -n 'git commit|git push origin main' *.sh"
+# The four above run wherever this suite runs, which is the linked worktree the
+# ticket measured them in. Asked again from the main checkout, where every real
+# push is refused before the worktree exception is reached: an ALLOW there says
+# no push was seen at all, rather than that one was seen and permitted. Both
+# contexts, because the whole complaint is that the verdict turned on something
+# irrelevant to what the command runs.
+check_in "$ON_MAIN" no-git-push.sh ALLOW 'sed over a push --all, from main (was BLOCK)' \
+         "sed -i 's|git push --all origin|X|' f.sh"
+check_in "$ON_MAIN" no-git-push.sh ALLOW 'sed over a forced push, from main (was BLOCK)' \
+         "sed -i 's|git push -f origin main|X|' f.sh"
+check_in "$ON_MAIN" no-git-push.sh ALLOW 'sed over a bare push, from main (was BLOCK)' \
+         "sed -i 's|git push|X|' f.sh"
+check_in "$ON_MAIN" no-git-push.sh ALLOW 'grep alternation over pushes, from main (was BLOCK)' \
+         "grep -rn 'git push --all|git push -f' .claude/"
+# Two more verdicts the fix changed, found by sweeping a corpus of commands
+# against both versions of cs_split rather than by this suite -- which is the
+# reason to write them down here: a check suite is evidence about the cases it
+# names, and neither of these was named. The delimiter spelled with double
+# quotes is the same defect as the six above; a substitution in single quotes
+# runs nothing, because bash expands nothing inside them.
+check no-git-push.sh ALLOW 'sed over a push, double-quoted delimiter (was BLOCK)' \
+         'sed -i "s|git push --all origin|X|" f.sh'
+check no-pr-decisions.sh ALLOW 'a merge quoted in single quotes is inert (was BLOCK)' \
+         "echo '\$(gh pr merge 5)'"
+# And its control, one character different: in double quotes that substitution
+# RUNS, so the line goes to the fallback and the merge is found. This pair is
+# what the substitution fallback exists for, and it is asked as a verdict rather
+# than only as a fragment list -- pinning the split alone would let a hook stop
+# refusing these without anything going red.
+check no-pr-decisions.sh BLOCK 'the same substitution in double quotes' \
+         'echo "$(gh pr merge 5)"'
+check no-git-push.sh BLOCK 'a push substituted inside double quotes' \
+         'echo "$(git push --all origin)"'
+check no-git-push.sh BLOCK 'a push backticked inside double quotes' \
+         'echo "`git push --all origin`"'
+check_in "$ON_MAIN" no-commit-to-main.sh BLOCK 'a commit substituted inside double quotes' \
+         'echo "$(git commit -m x)"'
+# The trade above cs_split, partly repaid. A quoted string holding a separator
+# and then a control word in front of a refused command used to read as that
+# command; on one line it is text again. These were written as accepted false
+# positives in the section above and are moved here with the verdict they now
+# return, because that is where the reason for the change is written down.
+check no-git-push.sh     ALLOW 'quoted "; then" before a push (was BLOCK)'  'git commit -m "wait; then git push --all origin"'
+check no-pr-decisions.sh ALLOW 'quoted "; then" before a merge (was BLOCK)' 'git commit -m "wait; then gh pr merge 35"'
+# What did not flip with them, and the reason: the multi-line spelling of the
+# same string leaves a quote open at the newline, so each line falls back and
+# the continuation reads as a command position. Pinned here beside the flip so
+# the two are read together rather than as a contradiction.
+check no-git-push.sh     BLOCK 'the multi-line spelling still refused' \
+         $'gh issue comment 27 -b "to release:\n  git push origin main"'
+# The intermittency, which is the part that reads as arbitrary from inside a
+# session: the anchored spelling was permitted all along and the spelling with a
+# leading space was refused, on a difference that decides nothing about what
+# either command runs. They agree now, and the pair is pinned so that a
+# regression shows up as the disagreement rather than as one lost verdict.
+check no-git-push.sh ALLOW 'the anchored spelling, permitted before and after' \
+         "sed -i 's|^git push --all origin|X|' f.sh"
+check no-git-push.sh ALLOW 'the leading-space spelling (was BLOCK)' \
+         "sed -i 's| git push --all origin|X|' f.sh"
+# The controls. A quote-aware split must not have cost a single real refusal,
+# and these are the three commands the six above only ever mentioned.
+check no-git-push.sh BLOCK 'the control: a real push --all'   'git push --all origin'
+check no-git-push.sh BLOCK 'the control: a real forced push'  'git push -f origin main'
+check_in "$ON_MAIN" no-commit-to-main.sh BLOCK 'the control: a real commit on main' 'git commit -m x'
+check_in "$ON_MAIN" no-commit-to-main.sh BLOCK 'the control: a real push --all on main' 'git push --all origin'
+# The wrapper detections read the RAW command text, before the split and not
+# from it, and that ordering is load-bearing here: quote-aware splitting means a
+# single-quoted payload is now one fragment with no command position in it at
+# all, so nothing but the raw match can still see these. A BLOCK is therefore
+# evidence about where the rule reads from, which is what makes them checks
+# about issue #68 rather than repeats of the wrapper checks above.
+check no-git-push.sh BLOCK 'wrapped push, invisible to the split' "bash -c 'git push --all origin'"
+check no-pr-decisions.sh BLOCK 'wrapped merge, invisible to the split' "eval 'gh pr merge 5'"
+# On a dev branch, not main, so that the refusal cannot be the branch answering
+# for the wrapper rule.
+check_in "$ON_DEV" no-commit-to-main.sh BLOCK 'wrapped commit, invisible to the split' \
+         "sh -c 'git commit -m x'"
+# And the same claim asserted as a property of the files rather than inferred
+# from three verdicts. WRAPRE is the distinctive head of the wrapper regex, so
+# each literal below pins both which rule it is and what that rule is handed.
+WRAPRE='(^[[:space:]]*|[;&|(`][[:space:]]*)'
+armed 'no-git-push.sh matches its wrapper rule on the raw command' \
+      no-git-push.sh "if echo \"\$COMMAND\" | grep -qE '$WRAPRE"
+armed 'no-commit-to-main.sh matches its wrapper rule on the raw command' \
+      no-commit-to-main.sh "if echo \"\$COMMAND\" | grep -qE '$WRAPRE"
+# no-pr-decisions.sh joins continuations first and matches on that, which is the
+# half of cs_normalise its wrapper rules do want; both halves are pinned.
+armed 'no-pr-decisions.sh derives its wrapper text from the raw command' \
+      no-pr-decisions.sh "WRAPTEXT=\$(printf '%s\\n' \"\$COMMAND\" | cs_join)"
+armed 'no-pr-decisions.sh matches its wrapper rule on that text' \
+      no-pr-decisions.sh "if echo \"\$WRAPTEXT\" | grep -qE '$WRAPRE"
+unarmed 'no-git-push.sh does not match its wrapper rule on the fragments' \
+        no-git-push.sh "echo \"\$CMDS\" | grep -qE '$WRAPRE"
+unarmed 'no-commit-to-main.sh does not match its wrapper rule on the fragments' \
+        no-commit-to-main.sh "echo \"\$CMDS\" | grep -qE '$WRAPRE"
+unarmed 'no-pr-decisions.sh does not match its wrapper rule on the fragments' \
+        no-pr-decisions.sh "echo \"\$CMDS\" | grep -qE '$WRAPRE"
 
 echo "=== REGRESSION: PR #35 review, a command after a control word ==="
 # A separator is not the only thing a command can follow. Splitting on ; left

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -508,6 +508,16 @@ tok 'the bare-push spelling' \
 tok 'the grep alternation over a commit and a push' \
     "grep -n 'git commit|git push origin main' *.sh" \
     "$(printf "grep -n 'git commit|git push origin main' *.sh\n" | cs_split)"
+# The checks above exercise | ; ( and ). The other two separators were right and
+# unpinned, and both have a real spelling: & is a legal sed delimiter, and a
+# backtick inside SINGLE quotes is text to bash, where inside double quotes it
+# would run. Found by review of this change.
+tok 'an ampersand inside quotes is not a separator' \
+    "sed -i 's&git push --all origin&X&' f.sh" \
+    "$(printf "sed -i 's&git push --all origin&X&' f.sh\n" | cs_split)"
+tok 'a backtick inside single quotes is not a separator' \
+    "grep -rn '\`git push --all origin\`' docs/" \
+    "$(printf "grep -rn '\`git push --all origin\`' docs/\n" | cs_split)"
 # Double quotes protect a delimiter too. They protect only the separators,
 # never a substitution -- see the two below.
 tok 'a delimiter written with double quotes' \
@@ -746,6 +756,11 @@ check_in "$ON_MAIN" no-git-push.sh ALLOW 'grep alternation over pushes, from mai
 # runs nothing, because bash expands nothing inside them.
 check no-git-push.sh ALLOW 'sed over a push, double-quoted delimiter (was BLOCK)' \
          'sed -i "s|git push --all origin|X|" f.sh'
+# The other two separators, as verdicts rather than only as fragment lists.
+check no-git-push.sh ALLOW 'sed with & as its delimiter (was BLOCK)' \
+         "sed -i 's&git push --all origin&X&' f.sh"
+check no-git-push.sh ALLOW 'grep for a backticked push in prose (was BLOCK)' \
+         "grep -rn '\`git push --all origin\`' docs/"
 check no-pr-decisions.sh ALLOW 'a merge quoted in single quotes is inert (was BLOCK)' \
          "echo '\$(gh pr merge 5)'"
 # And its control, one character different: in double quotes that substitution
@@ -821,6 +836,16 @@ unarmed 'no-commit-to-main.sh does not match its wrapper rule on the fragments' 
         no-commit-to-main.sh "echo \"\$CMDS\" | grep -qE '$WRAPRE"
 unarmed 'no-pr-decisions.sh does not match its wrapper rule on the fragments' \
         no-pr-decisions.sh "echo \"\$CMDS\" | grep -qE '$WRAPRE"
+# The fourth consumer. It was covered behaviourally by the stale-branch section
+# below and not by a literal, which left "each wrapper detection" met in
+# substance and not in letter -- and this is the one hook where a lost fragment
+# retains a carve-out instead of dropping a refusal, so it is the last one that
+# should rest on an argument rather than a pin. See the header of
+# lib/command-scan.sh for why that shape is still safe.
+armed 'no-work-on-stale-branch.sh matches its wrapper rule on the raw command' \
+      no-work-on-stale-branch.sh "if echo \"\$COMMAND\" | grep -qE '$WRAPRE"
+unarmed 'no-work-on-stale-branch.sh does not match its wrapper rule on the fragments' \
+        no-work-on-stale-branch.sh "echo \"\$CMDS\" | grep -qE '$WRAPRE"
 
 echo "=== REGRESSION: PR #35 review, a command after a control word ==="
 # A separator is not the only thing a command can follow. Splitting on ; left
@@ -1846,6 +1871,29 @@ check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'the catch-up merge after 
   'git checkout fresh-branch && git merge origin/dev-05'
 check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'the catch-up merge with git pointed elsewhere' \
   'git --git-dir /elsewhere/.git merge origin/dev-05'
+# Issue #68 reaches this file here, and this is the one place in the boundary
+# where a lost fragment RETAINS an exception rather than dropping a refusal --
+# the three tests above set CARVE= from the fragment list. The merge itself
+# carries no free-text argument that could hold a quoted cd, because -m
+# withdraws the carve-out on its own; the shape that reaches it is a quoted
+# separator in a SIBLING command on the same line, which used to produce a
+# fragment headed by cd and refuse the catch-up merge on the strength of a
+# directory change bash would never have made. Measured on this fixture, old
+# split against new.
+#
+# The unquoted control below is what says the withdrawal itself still works.
+# See the header of lib/command-scan.sh for why this direction is safe: not
+# because a cut can only refuse more -- that argument does not hold in this
+# file -- but because the fallback catches every line the tracker cannot read,
+# so a cd bash would actually run is still cut out.
+check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'a cd quoted in a sibling command (was BLOCK)' \
+  "git merge origin/dev-05 && echo 'x; cd /tmp'"
+check_in "$WT_STALE" no-work-on-stale-branch.sh ALLOW 'a checkout quoted in a sibling command (was BLOCK)' \
+  "git merge origin/dev-05 && echo 'x; git checkout main'"
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'an unquoted cd still withdraws the carve-out' \
+  'cd /tmp && git merge origin/dev-05'
+check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'an unquoted checkout still withdraws it' \
+  'git checkout main && git merge origin/dev-05'
 # Every command, not the first: the permitted half does not license the second.
 check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'a permitted merge followed by a commit' \
   'git merge origin/dev-05 && git commit -m "wip"'

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -80,6 +80,33 @@
 # -f, --delete -- that cannot sit behind a quoted free-text argument, because
 # `git push` has no -m-style slot to put one in.
 #
+# That argument is about the hooks whose fragments TRIGGER a refusal, and it was
+# written as though those were all of them. no-work-on-stale-branch.sh is the
+# fourth consumer and the exception: its fragment tests withdraw a carve-out
+# rather than raise a refusal -- `^(cd|pushd|popd)`, the git directory options,
+# and a checkout or switch each set CARVE= -- so there, losing a fragment head
+# RETAINS an exception instead of dropping a refusal, and "a cut can only refuse
+# more" does not transfer to it as written. Found by review of this change, not
+# by the suite.
+#
+# It is nonetheless safe, for a reason that belongs here rather than in that
+# file. A fragment that quote-awareness removes is one bash would never have run
+# as a command, so a carve-out retained past it is retained for a command that
+# does not change directory. The converse -- a real cd that the tracker now
+# hides -- has nowhere to happen: a cd bash would run sits either outside quotes,
+# where it is still cut, or inside a substitution, which sends the whole line to
+# the fallback. The fail-safe is what carries this case, exactly as it carries
+# the others; the difference is only that here it is load-bearing rather than
+# belt-and-braces.
+#
+# One verdict there did change, and it is worth naming because the shape is not
+# the obvious one. The catch-up merge carries no free-text argument that could
+# hold a quoted cd -- -m withdraws the carve-out by itself -- so what reaches
+# this is a quoted separator in a SIBLING command on the same line:
+# `git merge origin/dev-05 && echo 'x; cd /tmp'` was refused for a directory
+# change bash would never have made, and is permitted now. An unquoted cd still
+# withdraws the carve-out. Both are checks.
+#
 # One soft spot, named rather than closed. no-git-push.sh:153 records that "an
 # empty argument list is the permitted case", so a push whose arguments were
 # lost past a cut would read as a bare push. Probed with `git push "|--all

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -54,6 +54,40 @@
 # would yields extra command candidates, which can only refuse more; it never
 # hides one. That is the safe direction for a guard whose failure mode, twice
 # now, has been to report the permitted answer.
+#
+# A fifth review, of dev-05, found the first defect here that costs only
+# refusals -- and it costs them on the work of editing these files. cs_split cut
+# on separators with a plain character class that knew nothing about quoting, so
+# a | inside a quoted argument was a fragment boundary like any other. `sed -i
+# 's|git push --all origin|X|' f.sh` yielded four fragments, the second of which
+# is a push standing at the head of its own line, and both no-git-push.sh and
+# no-commit-to-main.sh refused it. Six ordinary sed and grep commands were
+# refused this way, and it fired twice in a live session against that session's
+# own edits to these hooks. Worse than the refusal is that it reads as
+# arbitrary: the fragment has to BEGIN with the command word, so `s|^git push|`
+# is permitted and `s|git push|` is not, on a difference that has nothing to do
+# with what either command would run. Issue #68 made the pass quote-aware; the
+# reasoning, and the three ways that fix could itself have become a hole, are in
+# the comment inside cs_split.
+#
+# The permitting direction was swept before that fix and not found, and the
+# structural reason is worth writing down so it is not re-derived. Splitting
+# never deletes text, it only inserts boundaries, so every "is X present in any
+# fragment" test still sees every character it saw before. The only way a cut
+# can hide evidence is by truncating a verb's argument list, and neither hook
+# judges a verb that way: no-commit-to-main.sh refuses `git commit` on main
+# whatever the arguments, and no-git-push.sh refuses on flags -- --all, --mirror,
+# -f, --delete -- that cannot sit behind a quoted free-text argument, because
+# `git push` has no -m-style slot to put one in.
+#
+# One soft spot, named rather than closed. no-git-push.sh:153 records that "an
+# empty argument list is the permitted case", so a push whose arguments were
+# lost past a cut would read as a bare push. Probed with `git push "|--all
+# origin"` and `git push "x|--all" origin`: both still blocked. It holds --
+# but it holds because of a property of git push's own CLI, not because of
+# anything this library does, so the honest phrasing is SWEPT AND NOT FOUND,
+# never "cannot happen". Any future hook that judges a verb by a free-text
+# argument reopens the question.
 
 # Reduce a raw command to lines that can be scanned: heredoc bodies dropped,
 # line continuations joined, redirections dropped -- in that order, so that
@@ -266,7 +300,9 @@ cs_join() {
 #
 # Separators are ; && || | ( ) and a backtick. The backtick is there because
 # $( ) was closed by the paren and its twin was not -- the same asymmetry
-# GIT_DIR= had against --git-dir.
+# GIT_DIR= had against --git-dir. Since issue #68 a separator inside quotes is
+# not one, which is where the exceptions and the fallbacks are; the comment
+# inside the function is where that is argued.
 #
 # Removed prefixes: environment assignments, the shell's own control words, and
 # the wrapper words that run another command with their own options. A caller
@@ -279,13 +315,130 @@ cs_join() {
 # saw a push at all; `do`, `else`, `elif`, `{` and `!` each did the same. They
 # are removed rather than matched around, so every caller keeps anchoring at ^.
 #
-# The trade, taken knowingly and checked as such: a quoted string holding a
-# separator and then one of these words in front of a refused command now reads
-# as that command, so `git commit -m "wait; then git push --all origin"` is
-# refused. That is the direction this file has taken throughout -- a blocked
-# comment is visible and one edit away, a silently permitted push is neither.
+# The trade that used to be recorded here -- a quoted string holding a separator
+# and then a control word in front of a refused command read as that command, so
+# `git commit -m "wait; then git push --all origin"` was refused -- was paid by
+# the separator pass not knowing what a quote is. Issue #68 made it know, so on
+# one line that string is text again and the commit is permitted. Two checks in
+# check-hooks.sh carry the flip as `(was BLOCK)`.
+#
+# What is left of the trade is the multi-line spelling, and it is left on
+# purpose: quote state is per line, so a string left open at a newline sends
+# that line to the fallback and the continuation reads as a command position.
+# CLAUDE.md names that one as deliberately open, and it is the direction this
+# file has taken throughout -- a blocked comment is visible and one edit away, a
+# silently permitted push is neither.
 cs_split() {
-  sed -e 's/&&/\n/g' -e 's/||/\n/g' -e 's/[;&|()`]/\n/g' \
+  awk '
+    # The separator pass, quote-aware. Issue #68: it was a character class with
+    # no idea what a quote is, so a sed substitution written with | as its
+    # delimiter cut into four fragments, the second of which is a push that
+    # does not exist, and every hook refused it. See the header of this file.
+    #
+    # No apostrophe appears in these comments: the program is a single-quoted
+    # shell word, so one would end it. That is why the shapes are named in
+    # words rather than quoted.
+    #
+    # Three things it must not become. It must not stop cutting after the first
+    # quote -- `echo "a" | git push --all origin` is two commands and the pipe
+    # is real, so a closed quote reopens the separator. It must not guess: a
+    # line whose quoting does not balance is text this cannot read, and it is
+    # split exactly as it was before quotes were tracked at all. Over-refusing
+    # is what this ticket complains about and is still the right answer where
+    # the text cannot be read.
+    #
+    # And -- the one that would have turned this fix into a hole -- double
+    # quotes do not make text inert. `"$(gh pr merge 5)"` and a backticked span
+    # inside them RUN, so protecting a double-quoted span outright would hide
+    # every command written that way, silently and in the permitting direction,
+    # which is the shape of nine of the defects this file has already had. A
+    # line carrying either one in double quotes goes to the same fallback as
+    # unbalanced quoting: split as before, and let the substitution be cut out
+    # of it as it always was. That is chosen over tracking where a substitution
+    # ends, which is the shell parser the stopping rule in these files refuses
+    # to write -- a nested `)` would decide the verdict.
+    #
+    # Single quotes need no such exception: bash runs nothing inside them, so a
+    # `$(` or a backtick there is text, and the fallback is not triggered by
+    # one. That is what keeps the two reported shapes -- a sed substitution and
+    # a grep alternation, both single-quoted -- protected.
+    #
+    # The fallback is this same walk with quote tracking switched off, not a
+    # second encoding of the separator set. It was written as a pair of gsub
+    # calls first, and that is the shape the header of this file names as the
+    # reason the file exists: the same question answered in two places, so a
+    # separator added to one and not the other is a defect nobody sees. With
+    # `respect` off the walk reproduces the old character class exactly, and
+    # the two cannot drift apart because there is only one of them.
+    #
+    # qopen and dq_substitution are deliberately NOT locals: they are what the
+    # walk reports back about the line it just read.
+    function cut(line, respect,    n, i, c, nx, out) {
+      n = length(line)
+      out = ""
+      qopen = ""
+      dq_substitution = 0
+      i = 1
+      while (i <= n) {
+        c = substr(line, i, 1)
+        if (respect) {
+          if (qopen != "") {
+            # Only double quotes take a backslash escape; inside single quotes a
+            # backslash is a character. Same answer as cs_normalise gives, for
+            # the same reason -- it is what bash does. It is read before the
+            # substitution test below, so an escaped dollar-paren and an escaped
+            # backtick are the text they are and do not send the line to the
+            # fallback.
+            if (qopen == "\042" && c == "\\") { out = out c substr(line, i + 1, 1); i += 2; continue }
+            if (qopen == "\042" && (c == "`" || (c == "$" && substr(line, i + 1, 1) == "("))) dq_substitution = 1
+            out = out c
+            if (c == qopen) qopen = ""
+            i++
+            continue
+          }
+          # A backslash outside quotes is read so that an escaped quote does not
+          # open one that never closes and send the whole line to the fallback.
+          # An escaped separator still cuts, exactly as before.
+          #
+          # It reads one backslash at a time, so a doubled backslash in front of
+          # a quote -- which in bash is a literal backslash and then a quote that
+          # DOES open -- is read here as an escaped quote and no quote opens.
+          # That leaves the rest of the line unprotected and splits it more, so
+          # it is in the refusing direction; it is named because the sentence
+          # above would otherwise read as a claim that it cannot happen.
+          if (c == "\\") {
+            nx = substr(line, i + 1, 1)
+            if (nx == "\042" || nx == "\047") { out = out c nx; i += 2; continue }
+            out = out c
+            i++
+            continue
+          }
+          if (c == "\042" || c == "\047") { qopen = c; out = out c; i++; continue }
+        }
+        if (c == "&" && substr(line, i + 1, 1) == "&") { out = out "\n"; i += 2; continue }
+        if (c == "|" && substr(line, i + 1, 1) == "|") { out = out "\n"; i += 2; continue }
+        if (index(";&|()`", c) > 0) { out = out "\n"; i++; continue }
+        out = out c
+        i++
+      }
+      return out
+    }
+    {
+      out = cut($0, 1)
+      # Quote state is per line, as it is in cs_normalise, so a string left open
+      # at a newline sends that line and no other to the fallback. That is what
+      # keeps the multi-line quoted string CLAUDE.md names as deliberately
+      # refused still refused.
+      #
+      # The fallback is per line too, and so is coarser than it could be: one
+      # substitution in double quotes anywhere on a line takes the whole line
+      # back to the old splitting, and a sed delimiter on that same line loses
+      # the fix. That is the refusing direction, and narrowing it to the span
+      # would mean finding where the substitution ends, which is the parser this
+      # is written to avoid.
+      if (qopen != "" || dq_substitution) out = cut($0, 0)
+      print out
+    }' \
   | awk '
     {
       line = $0


### PR DESCRIPTION
Closes #68.

`cs_split` cut on separators with a plain character class that knew nothing
about quoting, so a `|` inside a quoted argument was a fragment boundary like
any other. An ordinary sed substitution written with `|` as its delimiter
yielded a push standing at the head of its own line, and every hook refused it:

```
sed -i 's|git push --all origin|X|' f.sh        was refused as a push
grep -rn 'git push --all|git push -f' .claude/  was refused as a push
sed -i 's|git commit -m x|X|' f.sh              was refused as a commit
```

Six such commands, measured in the ticket, and it fired twice in a live session
against that session's own edits — editing these hooks is exactly the work that
trips it. The part that reads as arbitrary from inside a session is that the
fragment has to *begin* with the command word, so an anchor in the pattern saved
the command by accident and a leading space did not: `s|^git push|` was
permitted and `s|git push|` was not. Both spellings are now pinned side by side.

## The permitting direction: swept, and not found

Splitting never deletes text, it only inserts boundaries, so every "is X present
in any fragment" test still saw every character. The only way a cut can hide
evidence is by truncating a verb's argument list, and neither hook judges a verb
that way: `no-commit-to-main.sh` refuses `git commit` on `main` whatever the
arguments, and `no-git-push.sh` refuses on flags that cannot sit behind a quoted
free-text argument.

`no-git-push.sh:153` — "an empty argument list is the permitted case" — is the
one soft spot. Probed both ways; both still blocked. It holds because of a
property of `git push`'s own CLI, not because of anything this library does, so
the header says **swept and not found** rather than "cannot happen".

## Three ways this fix could itself have become a hole

- A tracker treating everything after the first quote as quoted converts the
  ticket into a real hole. A closed quote reopens the separator, and
  `echo "a" | git push --all origin` still splits at the pipe.
- Unbalanced quoting is text this cannot read, and falls back to splitting
  exactly as the character class did. Quote state is per line, which is what
  leaves the multi-line quoted string CLAUDE.md names still refused.
- **Double quotes do not make text inert.** A command substitution inside them
  runs, so protecting a double-quoted span outright would have hidden every
  command written that way — silently and in the permitting direction, the shape
  of nine of the defects these files have already had. A line carrying one goes
  to the same fallback.

That last is a deliberate deviation from the ticket's first checkbox as
literally written. It is argued in the code, in the file header and in the
commit message, and pinned by a check pair. All six measured over-refusals are
single-quoted, so no listed acceptance case is left unmet.

The fallback is that same walk with quote tracking switched off, not a second
encoding of the separator set — which is the shape this file's header names as
the reason the file exists.

## What flipped, and what did not

`git commit -m "wait; then git push --all origin"` on one line is text again and
is permitted. The two checks carrying that flip moved out of the
accepted-false-positive section, where the heading no longer described them, and
sit beside the multi-line spelling that did *not* flip with them.

## Evidence

616 checks, all passing, 54 of them new. Four mutations:

| mutation | red |
|---|---|
| `cs_split` back to the plain character class | 29, all new, the flips among them |
| the substitution fallback removed | 7 — 6 new, plus the accepted false positive about a base written after a substitution |
| the escaped-quote branch removed | 2, both new — without them that branch had no check that failed without it |
| `no-git-push.sh`'s wrapper rule removed | 6 — 2 new, plus the 4 that already covered it |

That last is the check that the wrapper detections still read the raw command
text rather than the fragments, which quote-aware splitting makes load-bearing:
a single-quoted payload is now one fragment with no command position in it.

Two further verdict changes were found by sweeping a corpus of 57 commands
against both versions in two contexts, rather than by the suite — the delimiter
spelled with double quotes, and a substitution inside single quotes, which runs
nothing. Both now have checks. Across that sweep every change was BLOCK to
ALLOW, and every one on a command that manipulates text.

https://claude.ai/code/session_01DPSwjEyZBXrJ5UETM9kk9x
