### PR TITLE
Bound the reported Hit@k cutoffs by the retrieved depth

### DIFF
--- a/scripts/score_retrieval.py
+++ b/scripts/score_retrieval.py
@@ -27,6 +27,7 @@ from src.eval.dataset import load_gdpr_articles, load_tier1
 from src.eval.retrieval import (
     DEFAULT_K,
     cutoffs_for_depth,
+    gap_cutoff,
     retrieve_all,
     score_article_level,
     score_chunk_level,
@@ -66,6 +67,8 @@ def main() -> None:
     retrievals = retrieve_all(cases, vector_db.search, max_k=args.top_k, progress=progress)
 
     # Cutoffs come from the depth actually retrieved, never from a constant.
+    # Passed explicitly rather than left to default, so that a future change to
+    # how the script retrieves is refused by the scorers instead of reinterpreted.
     ks = cutoffs_for_depth(args.top_k)
     art = score_article_level(retrievals, ks)
     chunk = score_chunk_level(retrievals, cases, articles, ks)
@@ -80,11 +83,10 @@ def main() -> None:
 
     # Report the gap at the deepest cutoff both levels actually hold, so a
     # shallow --top-k cannot print a gap at a cutoff neither level reached.
-    shared = [k for k in ks if k in art.hit_at_k and k in chunk.hit_at_k]
-    if not shared:
-        print("article−chunk gap: not reportable — one level scored no cases")
+    gap_k = gap_cutoff(art, chunk)
+    if gap_k is None:
+        print("article−chunk gap: not reportable at this depth")
         return
-    gap_k = max(shared)
     gap = art.hit_at_k[gap_k] - chunk.hit_at_k[gap_k]
     print(f"article−chunk gap @{gap_k}: {gap:+.1%}"
           "   (right article, wrong chunk = chunking/embedding)")

--- a/scripts/score_retrieval.py
+++ b/scripts/score_retrieval.py
@@ -7,6 +7,13 @@ Score Tier-1 retrieval at both levels and print the pair.
 Article-level is publishable today; chunk-level is restricted to the grounded
 subset and says so. See ``src.eval.retrieval`` for why they are not equally
 trustworthy yet.
+
+**The reported cutoffs follow ``--top-k``**, via
+:func:`~src.eval.retrieval.cutoffs_for_depth`: ``--top-k 3`` prints Hit@1 and
+Hit@3 and nothing else, and ``--top-k 20`` prints Hit@1/3/5/10 *and* Hit@20. A
+cutoff deeper than the retrieval cannot be printed at all — the scorers raise —
+because a Hit@10 taken over three ranks is a Hit@3 under the wrong name, and it
+reads as a retrieval regression that never happened.
 """
 from __future__ import annotations
 
@@ -19,6 +26,7 @@ from src.config import get_settings
 from src.eval.dataset import load_gdpr_articles, load_tier1
 from src.eval.retrieval import (
     DEFAULT_K,
+    cutoffs_for_depth,
     retrieve_all,
     score_article_level,
     score_chunk_level,
@@ -28,8 +36,11 @@ from src.eval.retrieval import (
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--limit", type=int, default=None, help="score only the first N cases")
-    ap.add_argument("--top-k", type=int, default=max(DEFAULT_K))
+    ap.add_argument("--top-k", type=int, default=max(DEFAULT_K),
+                    help="retrieval depth; the reported cutoffs follow it")
     args = ap.parse_args()
+    if args.top_k < 1:
+        ap.error("--top-k must be at least 1")
 
     settings = get_settings()
     cases = load_tier1()
@@ -54,8 +65,10 @@ def main() -> None:
     print(f"scoring {len(cases)} cases at top_k={args.top_k}", file=sys.stderr)
     retrievals = retrieve_all(cases, vector_db.search, max_k=args.top_k, progress=progress)
 
-    art = score_article_level(retrievals)
-    chunk = score_chunk_level(retrievals, cases, articles)
+    # Cutoffs come from the depth actually retrieved, never from a constant.
+    ks = cutoffs_for_depth(args.top_k)
+    art = score_article_level(retrievals, ks)
+    chunk = score_chunk_level(retrievals, cases, articles, ks)
 
     print()
     print(f"Tier-1 retrieval — {len(cases)} cases, top_k={args.top_k}, {started:%Y-%m-%d %H:%M UTC}")
@@ -65,8 +78,15 @@ def main() -> None:
             print(line)
         print()
 
-    gap = art.hit_at_k.get(5, 0) - chunk.hit_at_k.get(5, 0)
-    print(f"article−chunk gap @5: {gap:+.1%}"
+    # Report the gap at the deepest cutoff both levels actually hold, so a
+    # shallow --top-k cannot print a gap at a cutoff neither level reached.
+    shared = [k for k in ks if k in art.hit_at_k and k in chunk.hit_at_k]
+    if not shared:
+        print("article−chunk gap: not reportable — one level scored no cases")
+        return
+    gap_k = max(shared)
+    gap = art.hit_at_k[gap_k] - chunk.hit_at_k[gap_k]
+    print(f"article−chunk gap @{gap_k}: {gap:+.1%}"
           "   (right article, wrong chunk = chunking/embedding)")
 
 

--- a/src/eval/retrieval.py
+++ b/src/eval/retrieval.py
@@ -41,8 +41,17 @@ scorers raise on a cutoff beyond it.
 
 Raising rather than clipping: a clipped Hit@10 is still printed under the label
 Hit@10, which is the defect itself. A caller that wants fewer cutoffs asks for
-fewer — :func:`cutoffs_for_depth` derives them. MRR is bounded the same way and
-is therefore labelled with the depth it was taken at.
+fewer — :func:`cutoffs_for_depth` derives them, and it is what the scorers use
+when no ``ks`` is passed, so the *default* path cannot reintroduce the defect
+and only an explicit over-ask reaches the raise. The check reads the retrieval
+batch rather than the cases that survive exclusion, so the same wrong call
+cannot raise on one run and pass on the next. MRR is bounded the same way and is
+therefore labelled with the depth it was taken at.
+
+The article−chunk gap is bounded too, by :func:`gap_cutoff`, but it is pinned at
+5 rather than following the depth upward: a deeper retrieval must not silently
+move a published diagnostic. What population that gap is computed over is a
+separate, still-open defect (issue #60).
 
 Matching imports :func:`~src.eval.golden_qa.normalize_for_grounding` rather than
 reimplementing it, so the gate that decides a quote is grounded and the metric
@@ -75,6 +84,9 @@ def cutoffs_for_depth(depth: int) -> tuple[int, ...]:
     if depth < 1:
         raise ValueError(f"retrieval depth must be at least 1, got {depth}")
     return tuple(sorted({k for k in DEFAULT_K if k <= depth} | {depth}))
+
+
+GAP_K = 5  # the cutoff the article−chunk gap has always been published at
 
 
 @dataclass(frozen=True)
@@ -129,6 +141,20 @@ class LevelScore:
         return out
 
 
+def gap_cutoff(art: LevelScore, chunk: LevelScore, prefer: int = GAP_K) -> int | None:
+    """The cutoff to report the article−chunk gap at, or None if there is none.
+
+    ``prefer`` — 5, the cutoff the baseline has always been published at —
+    whenever both levels hold it. A shallower retrieval falls back to the
+    deepest cutoff the two share, rather than printing a ``@5`` gap neither
+    level reached. It never goes *deeper* than ``prefer``: a deeper retrieval
+    must not silently move the published diagnostic, and the gap's population
+    defect is issue #60's to settle, not this function's.
+    """
+    shared = [k for k in art.hit_at_k if k in chunk.hit_at_k and k <= prefer]
+    return max(shared) if shared else None
+
+
 def retrieve_all(
     cases: Sequence[TestCase],
     search: SearchFn,
@@ -170,26 +196,40 @@ def _retrieval_depth(retrievals: Sequence[CaseRetrieval]) -> int:
 
     A mixed batch is bounded by its weakest member: a cutoff deeper than that
     would be a miss for some cases only because they were never asked.
+
+    An empty batch has no depth; 0 stands for "unknown", and no cutoff is
+    checked against it because there is nothing to report either way.
     """
     return min((r.max_k for r in retrievals), default=0)
 
 
+def _resolve_ks(ks: Sequence[int] | None, depth: int) -> Sequence[int]:
+    """An explicit ``ks``, or the honest cutoffs for ``depth`` when none given."""
+    if ks is not None:
+        return ks
+    return cutoffs_for_depth(depth) if depth >= 1 else ()
+
+
 def _score(ranks: List[int | None], level: str, excluded: int, reason: str,
            ks: Sequence[int], depth: int) -> LevelScore:
+    # Validated against the batch, before anything is scored: whether a cutoff
+    # is honest is a property of the retrieval depth alone. Deferring the check
+    # until something survives exclusion would make it data-dependent — the same
+    # wrong call raising on one run and passing on the next.
+    if depth >= 1:
+        too_deep = sorted({k for k in ks if k > depth})
+        if too_deep:
+            raise ValueError(
+                f"{level}: cutoffs {too_deep} exceed the retrieval depth {depth}; "
+                f"a Hit@{too_deep[0]} over {depth} ranks would be a Hit@{depth} "
+                f"wearing the wrong label. Retrieve deeper, or ask for fewer cutoffs "
+                f"(see cutoffs_for_depth)."
+            )
     n = len(ranks)
     s = LevelScore(level=level, scored=n, excluded=excluded, excluded_reason=reason,
                    depth=depth)
     if not n:
-        # Nothing is reported, so nothing can be mislabelled.
         return s
-    too_deep = sorted({k for k in ks if k > depth})
-    if too_deep:
-        raise ValueError(
-            f"{level}: cutoffs {too_deep} exceed the retrieval depth {depth}; "
-            f"a Hit@{too_deep[0]} over {depth} ranks would be a Hit@{depth} "
-            f"wearing the wrong label. Retrieve deeper, or ask for fewer cutoffs "
-            f"(see cutoffs_for_depth)."
-        )
     for k in ks:
         hits = sum(1 for r in ranks if r is not None and r <= k)
         s.hits[k] = hits
@@ -199,19 +239,22 @@ def _score(ranks: List[int | None], level: str, excluded: int, reason: str,
 
 
 def score_article_level(retrievals: Sequence[CaseRetrieval],
-                        ks: Sequence[int] = DEFAULT_K) -> LevelScore:
+                        ks: Sequence[int] | None = None) -> LevelScore:
     """Hit@k and MRR against the gold article number. Nothing is excluded.
 
-    Raises ``ValueError`` if any ``k`` is deeper than the retrieval.
+    ``ks`` defaults to :func:`cutoffs_for_depth` over the batch's own depth, so
+    the default path cannot ask for a cutoff the retrieval never reached. An
+    explicit ``ks`` deeper than the retrieval raises ``ValueError``.
     """
+    depth = _retrieval_depth(retrievals)
     ranks = [r.article_rank() for r in retrievals]
-    return _score(list(ranks), "article-level", 0, "", ks, _retrieval_depth(retrievals))
+    return _score(list(ranks), "article-level", 0, "", _resolve_ks(ks, depth), depth)
 
 
 def score_chunk_level(retrievals: Sequence[CaseRetrieval],
                       cases: Sequence[TestCase],
                       articles: Dict[str, Article],
-                      ks: Sequence[int] = DEFAULT_K) -> LevelScore:
+                      ks: Sequence[int] | None = None) -> LevelScore:
     """
     Hit@k and MRR against the chunk holding the gold quote.
 
@@ -220,7 +263,9 @@ def score_chunk_level(retrievals: Sequence[CaseRetrieval],
     including it would score the parser, not the retriever. The count dropped is
     carried on the result so a reader sees the restriction next to the number.
 
-    Raises ``ValueError`` if any ``k`` is deeper than the retrieval.
+    ``ks`` defaults and is bounded exactly as in :func:`score_article_level`.
+    The bound reads the retrieval batch, not the surviving subset, so excluding
+    every case does not quietly excuse a dishonest cutoff.
     """
     by_id = {c.case_id: c for c in cases}
     ranks: List[int | None] = []
@@ -232,5 +277,6 @@ def score_chunk_level(retrievals: Sequence[CaseRetrieval],
             excluded += 1
             continue
         ranks.append(r.chunk_rank(case.supporting_quote))
-    return _score(ranks, "chunk-level", excluded, "quote ungrounded in its article", ks,
-                  _retrieval_depth(retrievals))
+    depth = _retrieval_depth(retrievals)
+    return _score(ranks, "chunk-level", excluded, "quote ungrounded in its article",
+                  _resolve_ks(ks, depth), depth)

--- a/src/eval/retrieval.py
+++ b/src/eval/retrieval.py
@@ -29,6 +29,21 @@ article-level Hit@k from the gold article_number (unaffected by any of this)"* �
 and it is why an article-level number is publishable before the answer key is
 repaired.
 
+**A cutoff may never be deeper than the retrieval it is computed over.** One
+retrieval per case serves every k, so the depth it was taken at bounds every
+number read off it: a list fetched three deep can answer Hit@1 and Hit@3 and
+nothing more. Counting ``rank <= 10`` over three ranks still prints the label
+``Hit@10``, and what it reports is Hit@3 — pessimistic, stable across re-runs,
+and indistinguishable from a retrieval regression. So :class:`CaseRetrieval`
+carries ``max_k`` (what the backend was *asked* for, which ``len(retrieved_*)``
+cannot recover because a backend may legitimately return fewer), and the
+scorers raise on a cutoff beyond it.
+
+Raising rather than clipping: a clipped Hit@10 is still printed under the label
+Hit@10, which is the defect itself. A caller that wants fewer cutoffs asks for
+fewer — :func:`cutoffs_for_depth` derives them. MRR is bounded the same way and
+is therefore labelled with the depth it was taken at.
+
 Matching imports :func:`~src.eval.golden_qa.normalize_for_grounding` rather than
 reimplementing it, so the gate that decides a quote is grounded and the metric
 that looks for it cannot drift apart.
@@ -48,6 +63,20 @@ SearchFn = Callable[[str, int], List[Dict[str, Any]]]
 DEFAULT_K = (1, 3, 5, 10)
 
 
+def cutoffs_for_depth(depth: int) -> tuple[int, ...]:
+    """The cutoffs a retrieval taken ``depth`` deep can honestly report.
+
+    Those of :data:`DEFAULT_K` the retrieval actually reaches, plus ``depth``
+    itself. The second half settles what a depth beyond ``max(DEFAULT_K)``
+    prints: ``depth=20`` reports ``(1, 3, 5, 10, 20)``, so a deeper retrieval
+    shows what the extra ranks bought instead of changing only MRR. The rule is
+    uniform — ``depth=4`` reports ``(1, 3, 4)``, ``depth=3`` reports ``(1, 3)``.
+    """
+    if depth < 1:
+        raise ValueError(f"retrieval depth must be at least 1, got {depth}")
+    return tuple(sorted({k for k in DEFAULT_K if k <= depth} | {depth}))
+
+
 @dataclass(frozen=True)
 class CaseRetrieval:
     """What one case's retrieval returned, reduced to what the scorers need."""
@@ -57,6 +86,7 @@ class CaseRetrieval:
     retrieved_articles: List[str]  # ordered, best first
     retrieved_chunk_ids: List[str]
     retrieved_texts: List[str]
+    max_k: int  # depth the backend was asked for, not the depth it returned
 
     def article_rank(self) -> int | None:
         """1-based rank of the first chunk from the gold article, or None."""
@@ -82,6 +112,7 @@ class LevelScore:
     scored: int
     excluded: int
     excluded_reason: str
+    depth: int  # retrieval depth every cutoff below was computed over
     hit_at_k: Dict[int, float] = field(default_factory=dict)
     hits: Dict[int, int] = field(default_factory=dict)
     mrr: float = 0.0
@@ -93,7 +124,8 @@ class LevelScore:
         out = [head]
         for k in sorted(self.hit_at_k):
             out.append(f"  Hit@{k:<3} {self.hit_at_k[k]:6.1%}   ({self.hits[k]}/{self.scored})")
-        out.append(f"  MRR     {self.mrr:6.3f}")
+        # MRR reads the same truncated list, so it carries the depth too.
+        out.append(f"  MRR@{self.depth:<3} {self.mrr:6.3f}")
         return out
 
 
@@ -108,7 +140,13 @@ def retrieve_all(
     One retrieval per case serves every k: Hit@3 reads the first three of the
     same ranked list Hit@10 reads ten of. Scoring k separately would multiply
     cost and, with a non-deterministic backend, could disagree with itself.
+
+    ``max_k`` is recorded on every result, because it is the ceiling on what the
+    scorers may report and it cannot be recovered afterwards from the number of
+    results that came back.
     """
+    if max_k < 1:
+        raise ValueError(f"max_k must be at least 1, got {max_k}")
     out: List[CaseRetrieval] = []
     for i, case in enumerate(cases, start=1):
         results = search(case.question, max_k)
@@ -119,6 +157,7 @@ def retrieve_all(
                 retrieved_articles=[str(r["metadata"]["article_number"]) for r in results],
                 retrieved_chunk_ids=[r["chunk_id"] for r in results],
                 retrieved_texts=[r["text"] for r in results],
+                max_k=max_k,
             )
         )
         if progress:
@@ -126,12 +165,31 @@ def retrieve_all(
     return out
 
 
+def _retrieval_depth(retrievals: Sequence[CaseRetrieval]) -> int:
+    """The depth *every* retrieval reaches — the shallowest ``max_k`` among them.
+
+    A mixed batch is bounded by its weakest member: a cutoff deeper than that
+    would be a miss for some cases only because they were never asked.
+    """
+    return min((r.max_k for r in retrievals), default=0)
+
+
 def _score(ranks: List[int | None], level: str, excluded: int, reason: str,
-           ks: Sequence[int]) -> LevelScore:
+           ks: Sequence[int], depth: int) -> LevelScore:
     n = len(ranks)
-    s = LevelScore(level=level, scored=n, excluded=excluded, excluded_reason=reason)
+    s = LevelScore(level=level, scored=n, excluded=excluded, excluded_reason=reason,
+                   depth=depth)
     if not n:
+        # Nothing is reported, so nothing can be mislabelled.
         return s
+    too_deep = sorted({k for k in ks if k > depth})
+    if too_deep:
+        raise ValueError(
+            f"{level}: cutoffs {too_deep} exceed the retrieval depth {depth}; "
+            f"a Hit@{too_deep[0]} over {depth} ranks would be a Hit@{depth} "
+            f"wearing the wrong label. Retrieve deeper, or ask for fewer cutoffs "
+            f"(see cutoffs_for_depth)."
+        )
     for k in ks:
         hits = sum(1 for r in ranks if r is not None and r <= k)
         s.hits[k] = hits
@@ -142,9 +200,12 @@ def _score(ranks: List[int | None], level: str, excluded: int, reason: str,
 
 def score_article_level(retrievals: Sequence[CaseRetrieval],
                         ks: Sequence[int] = DEFAULT_K) -> LevelScore:
-    """Hit@k and MRR against the gold article number. Nothing is excluded."""
+    """Hit@k and MRR against the gold article number. Nothing is excluded.
+
+    Raises ``ValueError`` if any ``k`` is deeper than the retrieval.
+    """
     ranks = [r.article_rank() for r in retrievals]
-    return _score(list(ranks), "article-level", 0, "", ks)
+    return _score(list(ranks), "article-level", 0, "", ks, _retrieval_depth(retrievals))
 
 
 def score_chunk_level(retrievals: Sequence[CaseRetrieval],
@@ -158,6 +219,8 @@ def score_chunk_level(retrievals: Sequence[CaseRetrieval],
     normalized. An ungrounded quote is absent from the article by definition, so
     including it would score the parser, not the retriever. The count dropped is
     carried on the result so a reader sees the restriction next to the number.
+
+    Raises ``ValueError`` if any ``k`` is deeper than the retrieval.
     """
     by_id = {c.case_id: c for c in cases}
     ranks: List[int | None] = []
@@ -169,4 +232,5 @@ def score_chunk_level(retrievals: Sequence[CaseRetrieval],
             excluded += 1
             continue
         ranks.append(r.chunk_rank(case.supporting_quote))
-    return _score(ranks, "chunk-level", excluded, "quote ungrounded in its article", ks)
+    return _score(ranks, "chunk-level", excluded, "quote ungrounded in its article", ks,
+                  _retrieval_depth(retrievals))

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for the retrieval scorers (src/eval/retrieval.py).
+
+These pin one property: a reported cutoff never claims more depth than the
+retrieval was taken at. A ``Hit@10`` computed over three retrieved ranks is not
+a noisy number, it is a wrong one wearing a label that no re-run corrects — the
+exact failure the eval tier exists to prevent (issue #59).
+
+Scope is the fixed behaviour only; the module's wider coverage gap is not
+closed here. Expected cutoffs, counts and labels are written as literals, the
+search backend is a fake, and nothing here touches Qdrant, a database or a
+model API.
+"""
+import pytest
+
+from src.eval.dataset import TestCase
+from src.eval.retrieval import (
+    cutoffs_for_depth,
+    retrieve_all,
+    score_article_level,
+)
+
+
+def make_case(case_id: str, article_number: str, question: str) -> TestCase:
+    return TestCase(
+        case_id=case_id,
+        article_number=article_number,
+        article_title="Principles relating to processing of personal data",
+        question=question,
+        answer="Personal data must be limited to what is necessary.",
+        answer_type="definition",
+        supporting_quote="limited to what is necessary",
+        key_phrases=["data minimisation"],
+    )
+
+
+def result(chunk_id: str, article_number: str, text: str = "some chunk text") -> dict:
+    """One search hit, in the shape the scorers read."""
+    return {
+        "chunk_id": chunk_id,
+        "text": text,
+        "metadata": {"article_number": article_number},
+    }
+
+
+def fake_search(by_question: dict):
+    """A backend that replays a fixed ranked list, truncated to what was asked."""
+
+    def search(question: str, top_k: int) -> list:
+        return by_question[question][:top_k]
+
+    return search
+
+
+# A question whose gold article (5) first appears at rank 4, and one whose gold
+# article (6) appears at rank 2. Retrieved three deep, the first is a miss the
+# backend was never asked to find; the second is a hit at 3 but not at 1.
+GOLD_AT_RANK_4 = "What does data minimisation require?"
+GOLD_AT_RANK_2 = "When is processing lawful?"
+
+CORPUS = {
+    GOLD_AT_RANK_4: [
+        result("c1", "9"),
+        result("c2", "12"),
+        result("c3", "30"),
+        result("c4", "5"),
+        result("c5", "5"),
+    ],
+    GOLD_AT_RANK_2: [
+        result("d1", "44"),
+        result("d2", "6"),
+        result("d3", "6"),
+    ],
+}
+
+CASES = [
+    make_case("gdpr_art5_case1", "5", GOLD_AT_RANK_4),
+    make_case("gdpr_art6_case1", "6", GOLD_AT_RANK_2),
+]
+
+
+# ---------------------------- depth is carried ----------------------------- #
+
+def test_max_k_records_what_was_asked_for_not_what_came_back():
+    # The backend holds three results for this question; five are asked for.
+    retrievals = retrieve_all(
+        [make_case("gdpr_art6_case1", "6", GOLD_AT_RANK_2)],
+        fake_search(CORPUS),
+        max_k=5,
+    )
+    assert len(retrievals) == 1
+    assert retrievals[0].max_k == 5
+    assert len(retrievals[0].retrieved_chunk_ids) == 3
+
+
+# ------------------------- cutoffs bounded by depth ------------------------ #
+
+def test_cutoffs_deeper_than_the_retrieval_are_refused():
+    retrievals = retrieve_all(CASES, fake_search(CORPUS), max_k=3)
+    with pytest.raises(ValueError):
+        score_article_level(retrievals, ks=(10,))
+
+
+def test_hit_at_k_counts_only_ranks_actually_retrieved():
+    retrievals = retrieve_all(CASES, fake_search(CORPUS), max_k=3)
+    score = score_article_level(retrievals, ks=(1, 3))
+
+    # No cutoff above the retrieved depth is reported at all.
+    assert sorted(score.hit_at_k) == [1, 3]
+    assert score.scored == 2
+
+    # The rank-4 gold is absent from every reported cutoff; the rank-2 gold is
+    # counted at 3 and not at 1.
+    assert score.hits == {1: 0, 3: 1}
+    assert score.hit_at_k == {1: 0.0, 3: 0.5}
+
+    # MRR reads the same truncated list: 0 + 1/2, over two cases.
+    assert score.mrr == pytest.approx(0.25)
+    assert score.depth == 3
+
+
+# ------------------------- the cutoff rule itself -------------------------- #
+
+def test_cutoffs_for_depth_drops_what_the_retrieval_cannot_reach():
+    assert cutoffs_for_depth(1) == (1,)
+    assert cutoffs_for_depth(3) == (1, 3)
+    assert cutoffs_for_depth(10) == (1, 3, 5, 10)
+
+
+def test_cutoffs_for_depth_reports_the_depth_itself():
+    assert cutoffs_for_depth(4) == (1, 3, 4)
+    assert cutoffs_for_depth(20) == (1, 3, 5, 10, 20)

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -7,21 +7,32 @@ a noisy number, it is a wrong one wearing a label that no re-run corrects — th
 exact failure the eval tier exists to prevent (issue #59).
 
 Scope is the fixed behaviour only; the module's wider coverage gap is not
-closed here. Expected cutoffs, counts and labels are written as literals, the
-search backend is a fake, and nothing here touches Qdrant, a database or a
-model API.
+closed here. Expected cutoffs, counts and labels are written as literals, and
+nothing here touches Qdrant, a database or a model API.
+
+The scorer tests build :class:`CaseRetrieval` values directly rather than
+running ``retrieve_all`` to produce them: ``max_k`` is the field the whole
+guarantee turns on, and ``retrieve_all`` is itself under test below, so letting
+it supply that value would let one defect mask another. Only
+``test_max_k_records_what_was_asked_for_not_what_came_back``, whose subject
+*is* ``retrieve_all``, calls it — against a fake backend.
 """
 import pytest
 
-from src.eval.dataset import TestCase
+from src.eval.dataset import Article, TestCase
 from src.eval.retrieval import (
+    CaseRetrieval,
+    LevelScore,
     cutoffs_for_depth,
+    gap_cutoff,
     retrieve_all,
     score_article_level,
+    score_chunk_level,
 )
 
 
-def make_case(case_id: str, article_number: str, question: str) -> TestCase:
+def make_case(case_id: str, article_number: str, question: str,
+              supporting_quote: str = "limited to what is necessary") -> TestCase:
     return TestCase(
         case_id=case_id,
         article_number=article_number,
@@ -29,81 +40,75 @@ def make_case(case_id: str, article_number: str, question: str) -> TestCase:
         question=question,
         answer="Personal data must be limited to what is necessary.",
         answer_type="definition",
-        supporting_quote="limited to what is necessary",
+        supporting_quote=supporting_quote,
         key_phrases=["data minimisation"],
     )
 
 
-def result(chunk_id: str, article_number: str, text: str = "some chunk text") -> dict:
-    """One search hit, in the shape the scorers read."""
-    return {
-        "chunk_id": chunk_id,
-        "text": text,
-        "metadata": {"article_number": article_number},
-    }
+def make_retrieval(case_id: str, gold_article: str, articles: list,
+                   max_k: int, texts: list | None = None) -> CaseRetrieval:
+    """One case's retrieval, written out rather than produced by retrieve_all."""
+    return CaseRetrieval(
+        case_id=case_id,
+        gold_article=gold_article,
+        retrieved_articles=articles,
+        retrieved_chunk_ids=[f"{case_id}-chunk{i}" for i in range(1, len(articles) + 1)],
+        retrieved_texts=texts if texts is not None else ["unrelated text"] * len(articles),
+        max_k=max_k,
+    )
 
 
-def fake_search(by_question: dict):
-    """A backend that replays a fixed ranked list, truncated to what was asked."""
-
-    def search(question: str, top_k: int) -> list:
-        return by_question[question][:top_k]
-
-    return search
-
-
-# A question whose gold article (5) first appears at rank 4, and one whose gold
-# article (6) appears at rank 2. Retrieved three deep, the first is a miss the
-# backend was never asked to find; the second is a hit at 3 but not at 1.
-GOLD_AT_RANK_4 = "What does data minimisation require?"
-GOLD_AT_RANK_2 = "When is processing lawful?"
-
-CORPUS = {
-    GOLD_AT_RANK_4: [
-        result("c1", "9"),
-        result("c2", "12"),
-        result("c3", "30"),
-        result("c4", "5"),
-        result("c5", "5"),
-    ],
-    GOLD_AT_RANK_2: [
-        result("d1", "44"),
-        result("d2", "6"),
-        result("d3", "6"),
-    ],
-}
-
-CASES = [
-    make_case("gdpr_art5_case1", "5", GOLD_AT_RANK_4),
-    make_case("gdpr_art6_case1", "6", GOLD_AT_RANK_2),
-]
+# Gold article 5 first appears at rank 4, so a depth-3 retrieval holds three of
+# these ranks and none of them is the gold one. Gold article 6 sits at rank 2,
+# which a depth-3 retrieval does hold.
+GOLD_AT_RANK_4 = make_retrieval("gdpr_art5_case1", "5", ["9", "12", "30"], max_k=3)
+GOLD_AT_RANK_2 = make_retrieval("gdpr_art6_case1", "6", ["44", "6", "6"], max_k=3)
+SHALLOW_BATCH = [GOLD_AT_RANK_4, GOLD_AT_RANK_2]
 
 
 # ---------------------------- depth is carried ----------------------------- #
 
 def test_max_k_records_what_was_asked_for_not_what_came_back():
-    # The backend holds three results for this question; five are asked for.
-    retrievals = retrieve_all(
-        [make_case("gdpr_art6_case1", "6", GOLD_AT_RANK_2)],
-        fake_search(CORPUS),
-        max_k=5,
-    )
+    question = "When is processing lawful?"
+    # The fake holds two results for this question; five are asked for.
+    stored = [
+        {"chunk_id": "d1", "text": "t", "metadata": {"article_number": "44"}},
+        {"chunk_id": "d2", "text": "t", "metadata": {"article_number": "6"}},
+    ]
+
+    def fake_search(q: str, top_k: int) -> list:
+        assert q == question
+        return stored[:top_k]
+
+    retrievals = retrieve_all([make_case("gdpr_art6_case1", "6", question)],
+                              fake_search, max_k=5)
+
     assert len(retrievals) == 1
     assert retrievals[0].max_k == 5
-    assert len(retrievals[0].retrieved_chunk_ids) == 3
+    assert len(retrievals[0].retrieved_chunk_ids) == 2
+
+
+def test_a_mixed_batch_is_bounded_by_its_shallowest_member():
+    deep = make_retrieval("gdpr_art7_case1", "7", ["7"] + ["1"] * 9, max_k=10)
+    batch = [deep, GOLD_AT_RANK_2]  # max_k 10 and 3
+
+    score = score_article_level(batch)
+
+    assert score.depth == 3
+    assert sorted(score.hit_at_k) == [1, 3]
+    with pytest.raises(ValueError):
+        score_article_level(batch, ks=(5,))
 
 
 # ------------------------- cutoffs bounded by depth ------------------------ #
 
 def test_cutoffs_deeper_than_the_retrieval_are_refused():
-    retrievals = retrieve_all(CASES, fake_search(CORPUS), max_k=3)
     with pytest.raises(ValueError):
-        score_article_level(retrievals, ks=(10,))
+        score_article_level(SHALLOW_BATCH, ks=(10,))
 
 
 def test_hit_at_k_counts_only_ranks_actually_retrieved():
-    retrievals = retrieve_all(CASES, fake_search(CORPUS), max_k=3)
-    score = score_article_level(retrievals, ks=(1, 3))
+    score = score_article_level(SHALLOW_BATCH, ks=(1, 3))
 
     # No cutoff above the retrieved depth is reported at all.
     assert sorted(score.hit_at_k) == [1, 3]
@@ -119,6 +124,32 @@ def test_hit_at_k_counts_only_ranks_actually_retrieved():
     assert score.depth == 3
 
 
+def test_the_default_cutoffs_follow_the_batch_depth():
+    score = score_article_level(SHALLOW_BATCH)
+
+    assert sorted(score.hit_at_k) == [1, 3]
+    assert score.hits == {1: 0, 3: 1}
+
+
+def test_chunk_level_refuses_a_cutoff_deeper_than_the_retrieval():
+    cases = [make_case("gdpr_art5_case1", "5", "What must be minimised?")]
+    articles = {"5": Article(
+        number="5",
+        title="Principles relating to processing of personal data",
+        content="Personal data shall be limited to what is necessary in relation to the purposes.",
+    )}
+    retrievals = [make_retrieval("gdpr_art5_case1", "5", ["9", "12", "5"], max_k=3,
+                                 texts=["a", "b", "limited to what is necessary"])]
+
+    with pytest.raises(ValueError):
+        score_chunk_level(retrievals, cases, articles, ks=(10,))
+
+    score = score_chunk_level(retrievals, cases, articles)
+    assert score.depth == 3
+    assert sorted(score.hit_at_k) == [1, 3]
+    assert score.hits == {1: 0, 3: 1}
+
+
 # ------------------------- the cutoff rule itself -------------------------- #
 
 def test_cutoffs_for_depth_drops_what_the_retrieval_cannot_reach():
@@ -130,3 +161,28 @@ def test_cutoffs_for_depth_drops_what_the_retrieval_cannot_reach():
 def test_cutoffs_for_depth_reports_the_depth_itself():
     assert cutoffs_for_depth(4) == (1, 3, 4)
     assert cutoffs_for_depth(20) == (1, 3, 5, 10, 20)
+
+
+# --------------------------- the gap's cutoff ------------------------------ #
+
+def level(name: str, ks: list) -> LevelScore:
+    return LevelScore(level=name, scored=1, excluded=0, excluded_reason="",
+                      depth=max(ks), hit_at_k={k: 0.5 for k in ks},
+                      hits={k: 1 for k in ks})
+
+
+def test_the_gap_stays_at_five_however_deep_the_retrieval_goes():
+    both = [1, 3, 5, 10, 20]
+    assert gap_cutoff(level("article-level", both), level("chunk-level", both)) == 5
+
+
+def test_a_shallow_retrieval_reports_the_gap_at_a_cutoff_both_levels_reached():
+    shallow = [1, 3]
+    assert gap_cutoff(level("article-level", shallow), level("chunk-level", shallow)) == 3
+
+
+def test_the_gap_is_not_reportable_when_a_level_scored_nothing():
+    assert gap_cutoff(level("article-level", [1, 3, 5]),
+                      LevelScore(level="chunk-level", scored=0, excluded=9,
+                                 excluded_reason="quote ungrounded in its article",
+                                 depth=10)) is None


### PR DESCRIPTION
Closes #59.

`scripts/score_retrieval.py` retrieved at `--top-k` but scored at the constant `DEFAULT_K`, so `--top-k 3` printed four lines, two of them labelled `Hit@5` and `Hit@10` over three retrieved ranks. A relevant chunk at rank 4 counted as a miss because it was never asked for — a number wrong in the pessimistic direction, stable across re-runs, and indistinguishable from a retrieval regression that never happened. The default path was already correct, so the published baseline is unaffected.

## What changed

The guarantee went into `src/eval/retrieval.py` rather than into the one script, so the next caller of the scorers cannot reintroduce it.

- `CaseRetrieval` carries `max_k` — what the backend was *asked* for, which `len(retrieved_texts)` cannot recover, because a backend may legitimately return fewer results than asked.
- `_score` raises on any cutoff deeper than the shallowest `max_k` in the batch. Raising, not clipping: a clipped `Hit@10` still prints the label `Hit@10`, which is the defect.
- `ks` defaults to `cutoffs_for_depth` over the batch's own depth, so the default path is correct by construction and only an explicit over-ask reaches the raise.
- The check runs against the retrieval batch, ahead of the empty-ranks return. Whether a cutoff is honest is a property of the depth, not of how many cases survived exclusion — checking afterwards would let the same wrong call raise on one run and pass on the next.

**`--top-k` above `max(DEFAULT_K)`** — the issue asked for this to be stated and implemented either way. `cutoffs_for_depth` returns the reachable `DEFAULT_K` cutoffs *plus the depth itself*, so `--top-k 20` prints Hit@1/3/5/10 and Hit@20, and the extra ranks show what they bought instead of moving only MRR. One uniform rule: `depth=4` gives `(1, 3, 4)`, `depth=3` gives `(1, 3)`.

## Two labels beyond the ticket's list

Both on the ticket's own reasoning, both worth a look:

- **`MRR` → `MRR@<depth>`.** MRR reads the same truncated list, and the issue names it as bounded the same way. This changes a printed label against `docs/eval-reports/2026-09-09-tier1-retrieval-baseline.md`, which records `MRR | 0.853`. The number is unchanged at the default depth; only the label gains `@10`.
- **The article−chunk gap's cutoff.** It read `art.hit_at_k.get(5, 0)`, which under `--top-k 3` printed a `@5` gap neither level reached. It is now `gap_cutoff`, **pinned at 5** whenever both levels hold it, falling back to the deepest shared cutoff only when the retrieval is shallower, and never going deeper. A first pass used `max(shared)`, which silently moved the default from `@5` to `@10` — the spec review caught it, and there is now a test that turns red if it moves again. The gap's **population** defect is #60's and is untouched here.

## Tests

`tests/test_eval_retrieval.py` is new: 11 tests over the fixed behaviour only, literals and a fake backend, no live Qdrant, database or model API. The scorer tests write `CaseRetrieval` literals rather than running `retrieve_all` to produce them — `max_k` is the field the guarantee turns on, and `retrieve_all` is itself under test.

Mutation checked five ways, each turning a named test red: dropping the raise; recording `max_k=len(results)`; `min`→`max` in `_retrieval_depth`; dropping `k <= prefer` in `gap_cutoff`; reverting the default to `DEFAULT_K`.

`make test`: **586 passed, 5 xfailed** (all pre-existing chunker xfails).

## Two things for you

- **`make upgrade-safe` fails, unrelated to this branch.** It reverted `uv.lock` cleanly, but the upgrade *candidate* is GuardDog-BLOCKED on four packages: `docling-slim==2.126.0`, `google-genai==2.23.0`, `huggingface-hub==1.31.0`, `transformers==5.17.0`. That needs `waiver-review` adjudication and is your call, not this PR's.
- **`Closes #59` will not link from a `dev-05` base** — the known Development-section behaviour on a non-default base.

https://claude.ai/code/session_01BHCgCJQLvieE5BgYmzti9A
