### PR TITLE
Read the merge settings instead of recording them by hand

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -306,6 +306,11 @@ beside() {  # beside <label> <file> <literal>
   fi
 }
 
+# A guard for the one check below that compares two numbers rather than
+# matching a literal. An absent derivation must not reach `[ -gt ]`, which
+# errors rather than answering.
+numeric() { case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+
 tok() {  # tok <label> <expected> <actual>
   if [ "$3" = "$2" ]; then
     printf '  ok   %s\n' "$1"
@@ -2047,6 +2052,71 @@ armed 'the fetch is bounded, so an offline session still starts' \
   "$HOOKS/report-stale-branches.sh" 'timeout "$FETCH_TIMEOUT" git fetch'
 armed 'a failed fetch says so, because neither detector is armed after one' \
   "$HOOKS/report-stale-branches.sh" 'FAILED or timed out'
+
+# THE MERGE SETTINGS, READ RATHER THAN RECORDED. Both detectors rest on a
+# repository setting no bash hook can assert, so #36's Amendment recorded the
+# three values in prose -- "these have no check behind them and this map plus
+# the guard's header are their only durable record." Why that was the wrong
+# answer is argued in no-work-on-stale-branch.sh's header and is not retold
+# here; the pins below hold it where it now lives.
+#
+# Be exact about what these are: pins on the report's code, in the same manner
+# as the fetch pins above. They are not evidence about the repository's
+# settings and cannot be. Nothing in `.claude/` can be that evidence, and a
+# file claiming to be is the defect these replace.
+armed 'the report reads the merge settings rather than trusting a record of them' \
+  "$HOOKS/report-stale-branches.sh" "gh api 'repos/{owner}/{repo}'"
+armed 'and reads all three the branch lifecycle rule depends on' \
+  "$HOOKS/report-stale-branches.sh" \
+  '[.allow_squash_merge, .allow_rebase_merge, .delete_branch_on_merge]'
+armed 'the settings read is bounded, so an unreachable API still starts the session' \
+  "$HOOKS/report-stale-branches.sh" 'timeout "$SETTINGS_TIMEOUT" gh api'
+armed 'a settings read that did not happen says so, rather than reading as fine' \
+  "$HOOKS/report-stale-branches.sh" 'merge settings: NOT READ'
+# What the pins above are worth, measured rather than reasoned: commenting out
+# the read turns the first and the third red and leaves the second -- the
+# settings list -- green, because `armed` strips from a `#` on the line it is
+# reading and the jq filter sits on a continuation line that no one commented.
+# That is why the read and its bound are pinned on their own line rather than
+# the settings list being trusted to stand for all three.
+#
+# The required values, one line each, because the read alone says nothing about
+# what it is compared against -- and a fixed string spanning two lines is
+# satisfied by a file holding either one, measured on a two-line fixture for the
+# derivation pins below.
+armed 'squash merging must be off, or the fallback detector is unsound' \
+  "$HOOKS/report-stale-branches.sh" 'drift allow_squash_merge "$SQUASH" false'
+armed 'rebase merging must be off, for the same reason' \
+  "$HOOKS/report-stale-branches.sh" 'drift allow_rebase_merge "$REBASE" false'
+armed 'and delete_branch_on_merge must be on, which is what the gone detector reads' \
+  "$HOOKS/report-stale-branches.sh" 'drift delete_branch_on_merge "$DELETE" true'
+# The guard's end of it. Its header carried the value in prose and drifted
+# twice; what replaces that is a pointer to the read above, and a pointer is the
+# thing a later edit deletes on its way to writing a value back down. `written`
+# rather than `armed`: this is prose in a comment, which is the whole of what it
+# asserts, and stripping comments would erase the line rather than a remark.
+written 'and the guard points at that report instead of recording a value itself' \
+  "$HOOKS/no-work-on-stale-branch.sh" 'That report is the live answer, and'
+# And the same counting the dev-branch argument gets below, for the same reason
+# and against the same failure. This history is the one thing in the change that
+# is prose rather than code, which is what the last two records of it were --
+# a third copy would be the defect the ticket is about, arriving inside its own
+# fix. It is told in the guard, counted at one there and at zero in the report,
+# and the report carries the pointer instead. This suite tells it nowhere, so
+# there is nothing here to count: a literal written out below would count
+# itself.
+HISTORY='it asserted both settings disabled before they were'
+tok 'the history of the recorded version is told in the guard, once' \
+    '1' "$(prose_count "$HOOKS/no-work-on-stale-branch.sh" "$HISTORY")"
+tok 'and the report does not tell it a second time' \
+    '0' "$(prose_count "$HOOKS/report-stale-branches.sh" "$HISTORY")"
+written 'the report says where that argument lives instead' \
+  "$HOOKS/report-stale-branches.sh" "is in no-work-on-stale-branch.sh's header"
+# What these six pins are NOT evidence of, named because the suite is evidence
+# about the cases it names and nothing else: they read the call sites, not
+# `drift` itself. Mutate that function to return early and all six stay green.
+# Pinning its body was considered and rejected -- the only seam that would drive
+# it is sourcing the report, and sourcing the report runs the fetch.
 # Read-only by name and by content. The name is checked by being the path above;
 # the content is checked here.
 unarmed 'the report removes no worktree' \
@@ -2188,11 +2258,40 @@ tok 'settings.json runs the report at SessionStart' \
 tok 'settings.json runs the guard on every Bash command' \
     '"$CLAUDE_PROJECT_DIR"/.claude/hooks/no-work-on-stale-branch.sh' \
     "$(jq -r '.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[]?.command' "$SETTINGS" 2>/dev/null | grep no-work-on-stale-branch)"
-# The report's timeout must outlast the fetch it waits on, or the hook is killed
-# before it can say that the fetch failed.
-tok 'the report hook outlasts its own fetch' \
-    '30' \
-    "$(jq -r '.hooks.SessionStart[]?.hooks[]? | select(.command | contains("report-stale-branches")) | .timeout' "$SETTINGS" 2>/dev/null)"
+# The report's timeout must outlast the network calls it waits on, or the hook
+# is killed before it can say that one of them failed -- and a killed
+# SessionStart hook takes the whole report with it, not only the line that was
+# pending. There are two such calls now, so the claim is no longer about the
+# fetch alone, and the budgets are read off the file rather than restated.
+#
+# 40 rather than the 30 this was: the second call took the margin over the two
+# budgets from 15s down to 5s, and what has to happen inside that margin is the
+# whole local half of the report -- a worktree listing and an ancestry read per
+# branch. Raising the cap costs nothing the budgets do not already cost, because
+# it is a cap and not a wait: the hook exits the moment it is done, and the two
+# `timeout` calls are what actually bound a dead network.
+REPORT_TIMEOUT=$(jq -r '.hooks.SessionStart[]?.hooks[]? | select(.command | contains("report-stale-branches")) | .timeout' "$SETTINGS" 2>/dev/null)
+tok 'the report hook outlasts its own network calls' '40' "$REPORT_TIMEOUT"
+# Both budgets, summed off the script. The END guard makes a renamed or deleted
+# budget print nothing rather than a smaller sum, which is the permitting
+# direction: a sum that lost a term would compare favourably and say nothing.
+BUDGET_SUM=$(awk -F= '/^FETCH_TIMEOUT=[0-9]+$/ || /^SETTINGS_TIMEOUT=[0-9]+$/ { s += $2; n += 1 }
+                      END { if (n == 2) print s }' "$HOOKS/report-stale-branches.sh")
+tok 'the report sets two budgets, and this is their sum' '25' "$BUDGET_SUM"
+# Redundant with the two literals above by arithmetic, and kept for the reason
+# the guard-equals-report check above is kept: it is the line that states the
+# property the other two only imply, and it is the one still standing the day
+# someone raises a budget and re-pins its literal in the same breath.
+# Each side tested on its own with `numeric`: concatenating them first lets a
+# present number and an absent one read as one number, and `[ 30 -gt "" ]` is a
+# shell error rather than a verdict. Found by running this before the read
+# existed.
+OUTLASTS=unreadable
+if numeric "$REPORT_TIMEOUT" && numeric "$BUDGET_SUM"; then
+  if [ "$REPORT_TIMEOUT" -gt "$BUDGET_SUM" ]; then OUTLASTS=yes; else OUTLASTS=no; fi
+fi
+tok 'and it outlasts them by arithmetic, not by both literals happening to agree' \
+    'yes' "$OUTLASTS"
 
 echo "=== CLAUDE.md names every hook that carries the boundary ==="
 # A third kind of check, and the second here that reads a file rather than

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -277,6 +277,15 @@ dev_read_count() {  # dev_read_count <file> -- how many lines read the dev refs
   grep -cE 'for-each-ref.*refs/remotes/origin/dev-' "$1" 2>/dev/null
 }
 
+# `drift`'s "not reported" case arm, as written. Anchored on `null) ` rather
+# than on the whole pattern so that a mutated arm is still extracted and shown
+# in the diff, instead of extracting to nothing and failing as an absence.
+unread_arm() {  # unread_arm <file> -- the arm that records a gap, as written
+  awk '/null\) / { a = 1 }
+       a          { print }
+       a && /;;$/ { exit }' "$1" 2>/dev/null
+}
+
 dev_derivation() {  # dev_derivation <file> -- the derivation, as written
   awk '/for-each-ref.*refs\/remotes\/origin\/dev-/ { inblock = 1 }
        inblock                                      { print }
@@ -2073,6 +2082,30 @@ armed 'the settings read is bounded, so an unreachable API still starts the sess
   "$HOOKS/report-stale-branches.sh" 'timeout "$SETTINGS_TIMEOUT" gh api'
 armed 'a settings read that did not happen says so, rather than reading as fine' \
   "$HOOKS/report-stale-branches.sh" 'merge settings: NOT READ'
+# And a read that half happened is not reported as a read that disagreed. The
+# per-setting line was already careful to say "was not reported by the API"; the
+# heading over it said DRIFTED, which is what a skimmer takes away. Found on
+# review of PR #77, not by this suite -- the pins above all stayed green,
+# because each one asks about a line and none asks what the lines are filed
+# under.
+armed 'an unread setting is reported as unknown, not as a changed one' \
+  "$HOOKS/report-stale-branches.sh" 'merge settings: NOT FULLY READ'
+armed 'and the DRIFTED heading is reached only by a value that came back wrong' \
+  "$HOOKS/report-stale-branches.sh" 'if [ -n "$MISMATCHED" ]; then'
+# Neither of those two notices the mutation that matters most here, which adds
+# a line rather than removing one: setting MISMATCHED on the unread arm as well
+# puts an unknown back under the DRIFTED heading, and both pins above stayed
+# green through it -- measured on this branch, not reasoned. `armed` asks
+# whether a literal is somewhere in a file and cannot ask what else is there.
+# So the arm is extracted and compared as a string, the way the dev derivation
+# is, that being the only shape of pin here that sees an addition.
+UNREAD_ARM=$(cat <<'ARM'
+    ''|null) DRIFTED="$DRIFTED
+  $1 was not reported by the API; the rule requires $3 -- otherwise $4" ;;
+ARM
+)
+tok 'the unread arm records a gap without also calling it a mismatch' \
+    "$UNREAD_ARM" "$(unread_arm "$HOOKS/report-stale-branches.sh")"
 # What the pins above are worth, measured rather than reasoned: commenting out
 # the read turns the first and the third red and leaves the second -- the
 # settings list -- green, because `armed` strips from a `#` on the line it is

--- a/.claude/hooks/no-work-on-stale-branch.sh
+++ b/.claude/hooks/no-work-on-stale-branch.sh
@@ -33,13 +33,30 @@
 # rather than by habit. An assumption a repository setting can silently break is
 # not an assumption; it is a bug with a delay.
 #
-# That is a repository setting and not something this file can assert. At the
-# time of writing it is NOT yet applied -- both are still enabled -- and issue
-# #44 carries it as an acceptance criterion for Bertan, because changing a
-# repository setting is not an act an agent takes. Until it is applied, a branch
-# merged by squash or by rebase defeats this detector: its commits are rewritten
-# on the dev branch, so it is no ancestor and reads as ahead > 0. The gone
-# detector still catches that branch, which is the point of having two.
+# That is a repository setting and not something this file can assert: a
+# PreToolUse hook has five seconds and cannot make a network call. It is also
+# not something to write down here. This paragraph stated the value twice and
+# was wrong both times -- it asserted both settings disabled before they were,
+# corrected on d840e57, and then asserted them unapplied after they had been,
+# which is #71. Neither error was noticed by anything; the second survived three
+# commits to this file in one day. A hand-kept record of live remote state is
+# the sentence above turned on its own mitigation: a record a repository setting
+# can silently falsify is the same bug with the same delay.
+#
+# So the value is read rather than recorded. report-stale-branches.sh runs at
+# SessionStart, is the one component here allowed a network call, and reports
+# allow_squash_merge, allow_rebase_merge and delete_branch_on_merge whenever any
+# has drifted from what this rule requires -- or reports that it could not read
+# them. That report is the live answer, and nothing in this file is.
+#
+# Which detector a drift costs depends on which setting drifted, and saying
+# "the other one still catches it" without that distinction is false in one of
+# the three cases. Squash or rebase merging back on rewrites a merged branch's
+# commits, so it is no ancestor and the fallback reads it as ahead > 0 -- there
+# the gone detector still catches it, which is the point of having two.
+# delete_branch_on_merge back off removes the gone detector itself, and the
+# fallback is then the only one left rather than the backstop. Two detectors
+# cover each other, but one at a time.
 #
 # THE ACTIVE DEV BRANCH is the highest-numbered refs/remotes/origin/dev-*, read
 # with no network because a hook has five seconds. Sorted with `sort -V` and

--- a/.claude/hooks/report-stale-branches.sh
+++ b/.claude/hooks/report-stale-branches.sh
@@ -31,8 +31,9 @@
 # performing it, so dropping --prune from the line below changes nothing
 # visible. The exclusion is not reopened; it is re-argued. Anything in
 # `.claude/` that arms enforcement rather than performing it carries a check
-# asserting its arming property, and check-hooks.sh asserts as a literal that
-# this file's fetch prunes and that settings.json still runs it. That check
+# asserting its arming property, and check-hooks.sh asserts as literals what
+# this file must do: that its fetch prunes, that it reads the merge settings
+# rather than recording them, and that settings.json still runs it. That check
 # announces at the next review rather than on the next push, because this
 # repository has no CI: there is no .github/workflows/, so the suite runs when
 # someone runs it. That is how all the existing checks already behave.
@@ -42,9 +43,28 @@
 # consequence is not cosmetic: neither detector is armed for that session, and
 # the guard will read whatever the last successful fetch left behind.
 #
+# IT READS THE MERGE SETTINGS, BECAUSE IT IS THE ONLY PLACE THAT CAN. Both of
+# that guard's detectors rest on a repository setting no bash hook can assert,
+# and #36's Amendment recorded the three values in prose instead. Why they are
+# read here rather than recorded anywhere, and what the recorded version cost,
+# is in no-work-on-stale-branch.sh's header -- once, rather than twice here in
+# different words, for the reason given beside the dev-branch derivation below.
+# check-hooks.sh counts both copies, so a retelling here turns the suite red.
+#
+# What this file adds is only the opportunity: it already opens with a network
+# call and has a SessionStart budget to spend, so here the claim can be a check
+# instead of a sentence. What it reports is drift, and only drift -- changing a
+# repository setting is Bertan's, like every other reserved act this file
+# declines to perform.
+#
 # Exits 0 always. A SessionStart hook that fails is a session that does not
 # start, and nothing here is worth that.
 FETCH_TIMEOUT=15
+# Its own budget rather than the fetch's, and smaller: one small API request
+# against a fetch of every ref. The two are spent in series and the hook's own
+# timeout in settings.json has to outlast their sum, which check-hooks.sh
+# asserts from these two lines rather than from a third copy of the numbers.
+SETTINGS_TIMEOUT=10
 
 cd "$(dirname "$0")/../.." || exit 0
 git rev-parse --git-dir >/dev/null 2>&1 || exit 0
@@ -66,6 +86,59 @@ else
     echo "       as stale as the last successful fetch, so no-work-on-stale-branch.sh"
     echo "       is not armed for this session."
     FETCHED=
+  fi
+fi
+
+# Drift from the branch lifecycle rule in #36's Amendment, named with the
+# detector that rests on each one, because a reader who has to work that out
+# will not. Reported and never changed: a repository setting is Bertan's, and a
+# file called report- alters nothing. A value the API did not report is its own
+# sentence -- a fine-grained token can be denied these fields, and "is null" put
+# beside "requires false" reads as a setting rather than as a missing answer. An
+# empty field is the same answer arriving a different way (a read that exited 0
+# with nothing behind it), so it takes the same sentence rather than printing
+# "is " and a blank.
+drift() {  # drift <setting> <actual> <required> <what rests on it>
+  [ "$2" = "$3" ] && return 0
+  case "$2" in
+    ''|null) DRIFTED="$DRIFTED
+  $1 was not reported by the API; the rule requires $3 -- otherwise $4" ;;
+    *) DRIFTED="$DRIFTED
+  $1 is $2; the rule requires $3 -- otherwise $4" ;;
+  esac
+}
+
+FALLBACK='a squashed or rebased branch is no ancestor and reads as ahead > 0'
+# Two ways not to get an answer, one sentence about what that costs. Written as
+# a reason and one message rather than as two messages, because the second was a
+# reworded copy of the first the moment it was typed, and this file's own
+# objection to a second copy of an argument is four paragraphs down.
+if ! command -v gh >/dev/null 2>&1; then
+  UNREAD='no gh on PATH'
+elif ! MERGE=$(timeout "$SETTINGS_TIMEOUT" gh api 'repos/{owner}/{repo}' \
+     --jq '[.allow_squash_merge, .allow_rebase_merge, .delete_branch_on_merge] | map(tostring) | @tsv' \
+     2>/dev/null); then
+  UNREAD="gh api failed or timed out after ${SETTINGS_TIMEOUT}s"
+else
+  UNREAD=
+fi
+
+if [ -n "$UNREAD" ]; then
+  echo "merge settings: NOT READ -- ${UNREAD}, so whether either detector in"
+  echo "       no-work-on-stale-branch.sh rests on a true assumption is unknown."
+else
+  SQUASH=$(printf '%s' "$MERGE" | cut -f1)
+  REBASE=$(printf '%s' "$MERGE" | cut -f2)
+  DELETE=$(printf '%s' "$MERGE" | cut -f3)
+  DRIFTED=
+  drift allow_squash_merge "$SQUASH" false "$FALLBACK"
+  drift allow_rebase_merge "$REBASE" false "$FALLBACK"
+  drift delete_branch_on_merge "$DELETE" true 'a merged branch is never seen as one whose upstream is gone'
+  if [ -n "$DRIFTED" ]; then
+    echo "merge settings: DRIFTED from what the branch lifecycle rule requires:$DRIFTED"
+    echo "       Reported, not fixed -- changing a repository setting is Bertan's."
+  else
+    echo "merge settings: as required (squash off, rebase off, delete-on-merge on)"
   fi
 fi
 

--- a/.claude/hooks/report-stale-branches.sh
+++ b/.claude/hooks/report-stale-branches.sh
@@ -98,12 +98,21 @@ fi
 # empty field is the same answer arriving a different way (a read that exited 0
 # with nothing behind it), so it takes the same sentence rather than printing
 # "is " and a blank.
+#
+# The two cases are counted apart as well as worded apart, because the heading
+# over them is read by people who do not read the lines. A field the API did not
+# report under a heading that says DRIFTED tells a skimmer that a setting
+# changed, when what is true is that it is unknown -- the same shape of error
+# this whole change exists to remove, one level up from the sentence that was
+# careful about it. MISMATCHED is set only where a value came back and was the
+# wrong one.
 drift() {  # drift <setting> <actual> <required> <what rests on it>
   [ "$2" = "$3" ] && return 0
   case "$2" in
     ''|null) DRIFTED="$DRIFTED
   $1 was not reported by the API; the rule requires $3 -- otherwise $4" ;;
-    *) DRIFTED="$DRIFTED
+    *) MISMATCHED=1
+       DRIFTED="$DRIFTED
   $1 is $2; the rule requires $3 -- otherwise $4" ;;
   esac
 }
@@ -131,12 +140,16 @@ else
   REBASE=$(printf '%s' "$MERGE" | cut -f2)
   DELETE=$(printf '%s' "$MERGE" | cut -f3)
   DRIFTED=
+  MISMATCHED=
   drift allow_squash_merge "$SQUASH" false "$FALLBACK"
   drift allow_rebase_merge "$REBASE" false "$FALLBACK"
   drift delete_branch_on_merge "$DELETE" true 'a merged branch is never seen as one whose upstream is gone'
-  if [ -n "$DRIFTED" ]; then
+  if [ -n "$MISMATCHED" ]; then
     echo "merge settings: DRIFTED from what the branch lifecycle rule requires:$DRIFTED"
     echo "       Reported, not fixed -- changing a repository setting is Bertan's."
+  elif [ -n "$DRIFTED" ]; then
+    echo "merge settings: NOT FULLY READ -- the API answered without these, so what"
+    echo "       rests on them is unknown rather than wrong:$DRIFTED"
   else
     echo "merge settings: as required (squash off, rebase off, delete-on-merge on)"
   fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,7 +61,7 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/report-stale-branches.sh",
-            "timeout": 30
+            "timeout": 40
           }
         ]
       }


### PR DESCRIPTION
Closes #71.

#36's Amendment recorded three repository settings in prose because "a bash
hook cannot assert a GitHub setting without a network call". That is true of a
`PreToolUse` hook, which has five seconds. It was never true of
`report-stale-branches.sh`, which runs at SessionStart and already opens with a
pruning fetch.

The recorded version failed twice inside 48 hours, once in each direction —
`d840e57` corrected a flat claim that both merge settings were disabled when
they were not; #71 found that correction false once they were, after three
commits to the file in one day passed over the paragraph. Correcting the prose a
third time schedules the third firing, so the claim becomes a check.

## What changed

- **`report-stale-branches.sh` reads the three settings** each session and names
  any that has drifted, with the detector that rests on it. Bounded by its own
  10s budget; fails open exactly as the fetch does. Verified against `gh`
  absent, `gh` failing, `gh` hanging (killed at 10s), and a read returning empty
  or `null` fields.
- **The guard's header states no value.** It points at the report. Its
  consolation is also narrowed to the case it covers: *"the other detector still
  catches it"* is false when the setting that drifted is
  `delete_branch_on_merge`, which removes the gone detector itself.
- **The history is told once and counted** — one copy in the guard, zero in the
  report, which carries a pointer. Three retellings in three wordings had
  already diverged, which is the defect this ticket is about.
- **The hook timeout goes 30 → 40.** Two serial network calls took the margin
  over the budgets from 15s to 5s. A cap is not a wait; the hook still exits
  when done.

## Evidence

603 → 619 checks, all passing (17 check invocations added, 1 removed). Fifteen mutations, each turning its own check
red and nothing else: the read deleted and commented out, a setting dropped, a
required value flipped, the bound dropped, a budget raised and renamed, the
message softened, the hook timeout lowered, the guard's pointer replaced by a
recorded value, the history deleted, retold, and its pointer removed, the two
headings folded back together, and `MISMATCHED` set on the unread arm.

**Review follow-up (8856463).** An unread field printed under the `DRIFTED`
heading, telling a skimmer a setting had changed when the truth was that it was
unknown. `drift` now sets `MISMATCHED` only where a value came back wrong, and
an unread field reports under its own heading. Worth noting how that fix was
checked: two `armed` literals on the new heading both stayed green when
`MISMATCHED` was also set on the unread arm — the regression that puts an
unknown back under `DRIFTED` — because `armed` cannot ask what *else* is on a
line, and that mutation adds rather than removes. The arm is therefore extracted
and compared as a string, the way the dev derivation is; the mutation went 0 red
before that pin and 1 red after.

Two limits are named rather than closed. The six value pins read `drift`'s call
sites, not its body — the only seam that would drive the function is sourcing
the report, which runs the fetch. And commenting out the read leaves the jq pin
green, because `armed` strips from a `#` on the line it reads and the filter
sits on a continuation line; that measurement is recorded in the suite, and it
is why the read and its bound are pinned separately.

`make test`: 574 pass, 1 pre-existing failure (`test_installed_packages_match_uv_lock`,
local venv drift — no Python or lockfile is touched here).

https://claude.ai/code/session_01DRpSMo37qJPB9opP6qvBzf


