### PR TITLE
Land the Amendment's stage-3 re-scope: the branch lifetime, and the sweep the hooks cite

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -2430,6 +2430,24 @@ unarmed 'and it is that section rather than the rotation beside it' \
 # before #70 -- and it takes the rotation's care over the same flag.
 written 'the sweep removes the worktree' "$SWEEP_SECTION" 'git worktree remove'
 written 'and deletes the local branch' "$SWEEP_SECTION" 'git branch -d'
+# And unlocks it first, without which the other two cannot run here at all.
+# Review of the first two commits found the procedure unable to execute on this
+# repository: EnterWorktree locks every worktree it creates, `git worktree
+# remove` refuses a locked one and names `remove -f -f` as the way out, and
+# `git worktree prune` is exempted from locked worktrees by design -- so it
+# skips one, exits 0, and the closing invariant is never reached with nothing
+# saying why. Reproduced: all four worktrees present at the time carried
+# `locked claude session <name> (pid N start T)`.
+#
+# THE LIMIT, which is the one that let that ship. Every literal in this section
+# asks whether the section CONTAINS a command. None of them runs one, so none is
+# evidence that the procedure succeeds -- a sweep naming three commands that all
+# refuse would pass every check here. What guards the difference is a person
+# running it; these hold the text against the citations, and nothing more.
+written 'and unlocks it first, which is what makes the other two possible' \
+  "$SWEEP_SECTION" 'git worktree unlock'
+written 'and warns that prune will not rescue a worktree still locked' \
+  "$SWEEP_SECTION" 'exempt from pruning by design'
 written 'with the care the rotation takes over the same flag' \
   "$SWEEP_SECTION" 'never `-D`'
 # The report classifies three ways and only one of the three is the sweep's. A

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -2311,6 +2311,108 @@ tok 'one hook runs on an Edit, which is the number the section claims' \
                 | $m == "*" or $m == "" or ("Edit" | test($m)))
               | .hooks[]?] | length' "$SETTINGS" 2>/dev/null)"
 
+echo "=== the documents answer the citations the hooks make into them ==="
+# A fourth kind of check, and the section above with its direction reversed:
+# there settings.json is the fact and CLAUDE.md the claim; here the hooks are
+# the fact -- they ship, they run, and their headers send a reader somewhere --
+# and the documents are what has to be there when the reader arrives. Issue #70
+# found three such citations landing nowhere. Each had shipped; each is read at
+# the moment a reader has just been refused something; and none of them was
+# wrong in a way this suite could see, because nothing held a hook's pointer to
+# the thing it points at.
+#
+# These are evidence about the three citations named below and nothing else. A
+# fourth pointer added to a hook tomorrow is uncounted here, and so is any of
+# these three reworded, because every literal is the sentence as written.
+#
+# CONTEXT.md's entries are extracted rather than grepped whole, for the reason
+# the boundary paragraph is narrowed above: a glossary-wide grep is satisfied by
+# the word turning up in a neighbouring entry, which is the failure being fixed
+# rather than a check on it -- #70's finding was that the lifetime rule was
+# written down twice, in neither place a reader looking for vocabulary would go.
+# An entry runs from its bolded name to its `_Avoid_:` line, and the extraction
+# is checked from both ends before anything is asserted against it.
+CONTEXT_MD="$HOOKS/../../CONTEXT.md"
+SKILL_MD="$HOOKS/../skills/branch-hygiene/SKILL.md"
+entry() {  # entry <file> <bolded name> -- one glossary entry, name to _Avoid_
+  awk -v name="**$2**:" '$0 == name {f=1} f {print} f && /^_Avoid_:/ {exit}' "$1" 2>/dev/null
+}
+
+WORKTREE_ENTRY="$FIXTURES/context-worktree-branch.md"
+entry "$CONTEXT_MD" 'Worktree branch' > "$WORKTREE_ENTRY"
+written 'the extracted entry is the worktree branch entry' \
+  "$WORKTREE_ENTRY" '**Worktree branch**:'
+unarmed 'and it is that entry rather than the whole glossary' \
+  "$WORKTREE_ENTRY" '**Reserved act**:'
+
+# no-work-on-stale-branch.sh sends a reader here for what a worktree branch is,
+# and what that hook refuses is a commit on one whose pull request has merged.
+# Before #70 the entry defined the branch and stopped, so a reader who followed
+# the pointer learned everything about it except the fact the refusal turns on.
+written 'the entry says the branch lives for one pull request' \
+  "$WORKTREE_ENTRY" 'exists for exactly one pull request'
+written 'and that the worktree it was made in is not reused after it' \
+  "$WORKTREE_ENTRY" 'is not reused'
+
+RESERVED_ENTRY="$FIXTURES/context-reserved-act.md"
+entry "$CONTEXT_MD" 'Reserved act' > "$RESERVED_ENTRY"
+written 'the extracted entry is the reserved act entry' \
+  "$RESERVED_ENTRY" '**Reserved act**:'
+unarmed 'and it is that entry rather than the whole glossary' \
+  "$RESERVED_ENTRY" '**Worktree branch**:'
+
+# report-stale-branches.sh calls removing a worktree "a reserved act in
+# CONTEXT.md" in its header, and prints the same claim into every session's
+# transcript. The enumeration named four acts and that was not one of them.
+written 'the enumeration names the act the report cites' \
+  "$RESERVED_ENTRY" 'removing a worktree or deleting a worktree branch'
+
+# The skill reads that enumeration as closed and counts it. An act added to
+# CONTEXT.md and not to the sentence that counts them leaves the skill asserting
+# a number the glossary has outgrown -- the drift the section above is checked
+# for, one document along. Both directions, because only the second catches a
+# count corrected by deleting the claim instead of fixing it.
+written 'the skill counts the acts as the glossary now enumerates them' \
+  "$SKILL_MD" 'five acts'
+unarmed 'and does not still call the enumeration four' \
+  "$SKILL_MD" 'four acts'
+
+# The third citation, and the one that had gone unwritten rather than merely
+# undocumented: both hooks name a local sweep as what removes a merged worktree
+# branch, and no such procedure existed. The hooks are read for the citation
+# and the skill asserted to answer it, rather than the sweep's existence being
+# asserted on its own -- a procedure nothing cites is a procedure that can go.
+for hook in no-work-on-stale-branch.sh report-stale-branches.sh; do
+  tok "$hook cites a local sweep" 'cited' \
+      "$([ "$(prose_count "$HOOKS/$hook" 'sweep')" -gt 0 ] && echo cited || echo absent)"
+done
+
+# Extracted for the reason the glossary entries are: `git branch -d` is in this
+# file already, in the rotation, so a file-wide grep for it would pass with no
+# sweep written at all. Stopping at the next `## ` and not at the next heading
+# of any depth, because the sweep is numbered into steps the way the rotation
+# is -- a stop on `### ` would end the section at its own first step and assert
+# the rest of it against nothing.
+SWEEP_SECTION="$FIXTURES/branch-hygiene-sweep.md"
+awk '/^## The sweep/ {f=1; print; next} f && /^## / {exit} f {print}' \
+    "$SKILL_MD" > "$SWEEP_SECTION"
+written 'the extracted section is the sweep' "$SWEEP_SECTION" 'The sweep'
+unarmed 'and it is that section rather than the rotation beside it' \
+  "$SWEEP_SECTION" 'Create the new branch'
+
+# What a sweep has to say to be the thing those two headers name: it deletes the
+# local branch, it removes the worktree standing on it -- the act CONTEXT.md now
+# reserves, and one that no command in this repository's documents performed
+# before #70 -- and it takes the rotation's care over the same flag.
+written 'the sweep removes the worktree' "$SWEEP_SECTION" 'git worktree remove'
+written 'and deletes the local branch' "$SWEEP_SECTION" 'git branch -d'
+written 'with the care the rotation takes over the same flag' \
+  "$SWEEP_SECTION" 'never `-D`'
+# The report classifies three ways and only one of the three is the sweep's. A
+# sweep that acted on `unclassified` would delete a branch freshly cut for work
+# not yet started, which is the case that classification exists to protect.
+written 'and leaves the unclassified alone' "$SWEEP_SECTION" 'unclassified'
+
 echo
 if [ $FAILED -eq 0 ]; then echo "ALL CHECKS PASSED"; else echo "SOME CHECKS FAILED"; fi
 exit $FAILED

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -2331,7 +2331,13 @@ echo "=== the documents answer the citations the hooks make into them ==="
 # rather than a check on it -- #70's finding was that the lifetime rule was
 # written down twice, in neither place a reader looking for vocabulary would go.
 # An entry runs from its bolded name to its `_Avoid_:` line, and the extraction
-# is checked from both ends before anything is asserted against it.
+# is checked from both ends before anything is asserted against it -- with one
+# limit named, because the two extractions below are not equally evidenced.
+# *Reserved act* has an entry after it, so its `unarmed` is real evidence that
+# the `_Avoid_:` stop fires. *Worktree branch* is the last entry in the file:
+# nothing follows it for an over-run to swallow, so its `unarmed` tests only
+# that the extraction did not begin too early, and the `_Avoid_:` stop is
+# evidenced there by the other extraction rather than by its own.
 CONTEXT_MD="$HOOKS/../../CONTEXT.md"
 SKILL_MD="$HOOKS/../skills/branch-hygiene/SKILL.md"
 entry() {  # entry <file> <bolded name> -- one glossary entry, name to _Avoid_
@@ -2367,24 +2373,42 @@ unarmed 'and it is that entry rather than the whole glossary' \
 written 'the enumeration names the act the report cites' \
   "$RESERVED_ENTRY" 'removing a worktree or deleting a worktree branch'
 
-# The skill reads that enumeration as closed and counts it. An act added to
-# CONTEXT.md and not to the sentence that counts them leaves the skill asserting
-# a number the glossary has outgrown -- the drift the section above is checked
-# for, one document along. Both directions, because only the second catches a
-# count corrected by deleting the claim instead of fixing it.
-written 'the skill counts the acts as the glossary now enumerates them' \
-  "$SKILL_MD" 'five acts'
-unarmed 'and does not still call the enumeration four' \
+# The skill read that enumeration as closed and counted it -- "one of the four
+# acts CONTEXT.md names" -- and #70 found the count stale the moment a fifth act
+# was needed. Correcting the number to five would have left the same defect with
+# a later expiry date, so the count is gone from the skill altogether and the
+# enumeration is cited instead of counted. CONTEXT.md holds the list, once. That
+# is the pairing convention above -- argue once, point from the other place --
+# applied to prose in a second file.
+#
+# Both spellings are refused, the stale one and the corrected one. Refusing
+# `five acts` is the refusing direction on purpose: re-adding a count that is
+# accurate today turns this red although nothing is wrong yet, and that is a
+# failure which is visible and one edit away. A second copy of a count that is
+# allowed to stand goes stale in silence, which is the direction that matters.
+unarmed 'the skill does not carry the count that went stale' \
   "$SKILL_MD" 'four acts'
+unarmed 'nor a corrected one, which would go stale the same way' \
+  "$SKILL_MD" 'five acts'
+written 'it cites the enumeration instead of counting it' \
+  "$SKILL_MD" 'entry holds the list'
 
 # The third citation, and the one that had gone unwritten rather than merely
 # undocumented: both hooks name a local sweep as what removes a merged worktree
 # branch, and no such procedure existed. The hooks are read for the citation
 # and the skill asserted to answer it, rather than the sweep's existence being
 # asserted on its own -- a procedure nothing cites is a procedure that can go.
+#
+# The literal is the pointer and deliberately not the noun. The first version of
+# this check asked whether each header contained `sweep`, and both contained it
+# at dev-05 already -- once in the guard, three times in the report. That bare
+# word IS the dangling citation #70 found, so the check was satisfied by the
+# defect: it would have stayed green through a revert of every line these two
+# headers gained. Measured on `git show origin/dev-05:` copies of both files,
+# which carry the noun and not the pointer.
+CITATION='"The sweep" in the branch-hygiene skill'
 for hook in no-work-on-stale-branch.sh report-stale-branches.sh; do
-  tok "$hook cites a local sweep" 'cited' \
-      "$([ "$(prose_count "$HOOKS/$hook" 'sweep')" -gt 0 ] && echo cited || echo absent)"
+  written "$hook points at the sweep by name" "$HOOKS/$hook" "$CITATION"
 done
 
 # Extracted for the reason the glossary entries are: `git branch -d` is in this
@@ -2410,8 +2434,18 @@ written 'with the care the rotation takes over the same flag' \
   "$SWEEP_SECTION" 'never `-D`'
 # The report classifies three ways and only one of the three is the sweep's. A
 # sweep that acted on `unclassified` would delete a branch freshly cut for work
-# not yet started, which is the case that classification exists to protect.
-written 'and leaves the unclassified alone' "$SWEEP_SECTION" 'unclassified'
+# not yet started, which is the case that classification exists to protect. The
+# literal is the instruction and not the word: `unclassified` alone is satisfied
+# by a section that says to sweep those too.
+written 'and leaves the unclassified alone' \
+  "$SWEEP_SECTION" 'Leave every unclassified branch alone'
+
+# The cadence is the half that makes both hook headers honest. #70's complaint
+# was not that the sweep was undocumented but that it "is named as a thing that
+# happens", so a sweep written without its cadence would answer the citation and
+# leave the claim behind it as false as it was. Pinned for that reason.
+written 'the sweep says how often it is run, which is by hand and never' \
+  "$SWEEP_SECTION" 'Cadence: manual, and unscheduled'
 
 echo
 if [ $FAILED -eq 0 ]; then echo "ALL CHECKS PASSED"; else echo "SOME CHECKS FAILED"; fi

--- a/.claude/hooks/no-work-on-stale-branch.sh
+++ b/.claude/hooks/no-work-on-stale-branch.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 # A worktree branch exists for one pull request. When that pull request merges,
 # the branch has served its purpose: remotely `delete_branch_on_merge` removes
-# it, locally Bertan's sweep does. Nothing stopped work continuing on it in the
+# it, locally Bertan's sweep does -- "The sweep" in the branch-hygiene skill,
+# which is manual and unscheduled in the way allow_squash_merge below is a
+# setting not yet applied. So the interval this guard covers is however long it
+# is until someone runs it, and is not bounded by anything. CONTEXT.md's
+# *worktree branch* entry carries the lifetime the two of them enforce between
+# them. Nothing stopped work continuing on it in the
 # meantime, and that failure has fired twice -- the probe->check rename was
 # committed onto hooks-push-and-pr-guards after PR #35 had already merged it,
 # and research/non-openrouter-response-bodies sat one commit ahead and nineteen

--- a/.claude/hooks/no-work-on-stale-branch.sh
+++ b/.claude/hooks/no-work-on-stale-branch.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 # A worktree branch exists for one pull request. When that pull request merges,
 # the branch has served its purpose: remotely `delete_branch_on_merge` removes
-# it, locally Bertan's sweep does -- "The sweep" in the branch-hygiene skill,
-# which is manual and unscheduled in the way allow_squash_merge below is a
-# setting not yet applied. So the interval this guard covers is however long it
-# is until someone runs it, and is not bounded by anything. CONTEXT.md's
-# *worktree branch* entry carries the lifetime the two of them enforce between
-# them. Nothing stopped work continuing on it in the
-# meantime, and that failure has fired twice -- the probe->check rename was
-# committed onto hooks-push-and-pr-guards after PR #35 had already merged it,
-# and research/non-openrouter-response-bodies sat one commit ahead and nineteen
-# behind with no pull request, loaded to revert nineteen commits the moment
-# anyone proposed it.
+# it, locally "The sweep" in the branch-hygiene skill does. Nothing stopped work
+# continuing on that branch in the meantime, and that failure has fired twice --
+# the probe->check rename was committed onto hooks-push-and-pr-guards after
+# PR #35 had already merged it, and research/non-openrouter-response-bodies sat
+# one commit ahead and nineteen behind with no pull request, loaded to revert
+# nineteen commits the moment anyone proposed it.
+#
+# How often the sweep runs is that section's question and it answers it there;
+# what belongs here is the consequence. The sweep is not triggered by the merge,
+# so the window this guard covers opens when the pull request merges and closes
+# only when someone gets round to sweeping -- it is bounded by nothing, and the
+# guard is what makes that safe rather than merely untidy. CONTEXT.md's
+# *worktree branch* entry carries the lifetime the two halves enforce together.
 #
 # Keyed on running in a linked worktree, the same keying no-git-push.sh uses and
 # deliberately not on the branch's name. CONTEXT.md's *worktree branch* entry

--- a/.claude/hooks/report-stale-branches.sh
+++ b/.claude/hooks/report-stale-branches.sh
@@ -19,7 +19,9 @@
 # READ-ONLY, by name and by content. Removing a worktree or a branch is Bertan's
 # -- a reserved act in CONTEXT.md, and issue #41 declined to carve a hook
 # exception for the sweep. The name is report- and never sweep- because the
-# filename is where that constraint survives the next reader. The only thing
+# filename is where that constraint survives the next reader. The half that does
+# remove things is "The sweep" in the branch-hygiene skill, run by hand off this
+# file's output; what is printed here is the whole of what runs automatically. The only thing
 # here that writes anything is `git fetch --prune`, which writes
 # remote-tracking refs and nothing else: no local branch, no worktree, no
 # checkout.

--- a/.claude/hooks/report-stale-branches.sh
+++ b/.claude/hooks/report-stale-branches.sh
@@ -20,9 +20,9 @@
 # -- a reserved act in CONTEXT.md, and issue #41 declined to carve a hook
 # exception for the sweep. The name is report- and never sweep- because the
 # filename is where that constraint survives the next reader. The half that does
-# remove things is "The sweep" in the branch-hygiene skill, run by hand off this
-# file's output; what is printed here is the whole of what runs automatically. The only thing
-# here that writes anything is `git fetch --prune`, which writes
+# remove things is "The sweep" in the branch-hygiene skill, which reads the
+# report below; what is printed here is the whole of what runs automatically.
+# The only thing here that writes anything is `git fetch --prune`, which writes
 # remote-tracking refs and nothing else: no local branch, no worktree, no
 # checkout.
 #

--- a/.claude/skills/branch-hygiene/SKILL.md
+++ b/.claude/skills/branch-hygiene/SKILL.md
@@ -16,9 +16,11 @@ When that pull request into `main` is merged, the dev branch has served its
 purpose and is rotated: the next branch takes the next number, and the merged
 one is deleted from both the local repository and the remote.
 
-**Rotation is a reserved act.** Rotating the dev branch is one of the four acts
-`CONTEXT.md` names, and advancing the active dev branch on the remote is
-another, so every step of this that changes anything belongs to Bertan.
+**Rotation is a reserved act, and so is the sweep.** Rotating the dev branch is
+one of the five acts `CONTEXT.md` names; advancing the active dev branch on the
+remote is another, and removing a worktree or deleting a worktree branch — the
+whole of the sweep below — is a third. So every step of either procedure that
+changes anything belongs to Bertan.
 `.claude/hooks/no-git-push.sh` refuses both of the pushes a rotation needs — the
 first push of `dev-NN+1`, and the remote deletion of `dev-NN` — from anywhere,
 correctly. Issue #41 considered carving a hook exception for this skill and
@@ -55,6 +57,10 @@ else: it removes nothing, which is why it is named `report-` and not `sweep-`.
 Its output is already in the session; read it before running the commands below,
 and run them for what it does not cover — the pull request state, which needs
 `gh`, and the last commit dates.
+
+**The sweep** below is the other half — what acts on that report. It is Bertan's,
+for the reason the rotation is, and an agent that has produced the report stops
+there.
 
 That fetch is also what arms `.claude/hooks/no-work-on-stale-branch.sh`, which
 refuses a commit on a branch whose work is over. Both read remote-tracking refs,
@@ -176,7 +182,102 @@ delete.
 - The merged `dev-NN` is gone from the local repository and from `origin`.
 - Every other branch present is a worktree branch, and no pull request is left
   pointing at the deleted `dev-NN`: each was merged before the rotation or
-  retargeted to `dev-NN+1` after it.
+  retargeted to `dev-NN+1` after it. Whether each of those is still in flight or
+  merely not yet swept is the sweep's question, not the rotation's.
+
+## The sweep
+
+The local half of a worktree branch's end, and the counterpart of the remote
+half `delete_branch_on_merge` performs automatically. `CONTEXT.md`'s *worktree
+branch* entry states the lifetime this enforces: a worktree branch exists for
+one pull request, and the worktree that produced it is not reused afterwards.
+
+Also Bertan's. Removing a worktree is one of the five reserved acts, which is
+why `.claude/hooks/report-stale-branches.sh` names what is over and removes
+nothing, and why its name is `report-`.
+
+**Cadence: manual, and unscheduled.** Nothing runs this and nothing reminds
+anyone to. That is a deliberate position rather than an omission: a merged
+worktree branch left lying about locally costs nothing except a line in the
+report, and the one way it could cost something — work committed onto it after
+its pull request merged — is refused by
+`.claude/hooks/no-work-on-stale-branch.sh` whether or not anyone has swept. So
+this is run when the report has accumulated enough to be worth clearing, and a
+rotation is the natural moment: every branch in flight was merged or retargeted
+before it, so the report just after one names very nearly the whole backlog.
+
+Read the two hook headers that cite the sweep in that register. They name a
+procedure that is written and is run by hand — not one that has already
+happened.
+
+Run from a terminal, where no hook applies.
+
+### 1. Take the list from the report, and act only on the merged
+
+The report classifies three ways and exactly one of the three is the sweep's.
+
+- **stale** — a worktree branch whose pull request is merged or closed. These
+  are the sweep's, and only these.
+- **clear** — a worktree branch with an open pull request. It is in flight.
+  Several at once is the ordinary state of this repository, not drift.
+- **unclassified** — a branch with no pull request at all. A branch freshly cut
+  for work not yet started and a branch abandoned after a rotation read
+  identically, and ahead/behind does not separate them; the reasoning is at the
+  end of *Report what is stale* above. Leave every unclassified branch alone.
+  Sweeping one deletes work that was about to start.
+
+Confirm from the remote rather than from the report, the same read the rotation
+opens with — the report's classification is as fresh as its fetch, and a pull
+request merged or closed since then is a branch it has not reclassified:
+
+```bash
+gh pr list --state all --limit 30 --json number,headRefName,state,mergedAt \
+  --jq '.[] | "\(.headRefName)\t\(.state)\t\(.mergedAt)"'
+```
+
+A branch whose pull request is `CLOSED` rather than `MERGED` is stale by the
+same definition and is **not** swept on that evidence alone: its commits exist
+nowhere else. Report it, decide, and only then remove it.
+
+### 2. Remove the worktree, then the branch
+
+In that order, and the order is not a preference. A linked worktree holds its
+branch checked out, and `git branch -d` refuses to delete a checked-out branch,
+so reaching for the branch first simply fails — and fails in the direction that
+leaves a half-swept pair behind.
+
+```bash
+git worktree list
+git worktree remove .claude/worktrees/<name>
+git branch -d <branch>
+```
+
+`git worktree remove` refuses a worktree holding uncommitted changes or
+untracked files. Treat that refusal as `-d`'s: it is saying there is something
+there nobody has looked at. Look before reaching for `--force`.
+
+Use `-d`, never `-D`, for the reason step 4 of the rotation gives — the
+lowercase form refuses a branch whose commits are not reachable from HEAD, so a
+refusal here means the pull request did not merge the way the report believes.
+The squash-or-rebase exception named there applies unchanged, and so does its
+remedy: confirm the merge commit with `gh pr view` before forcing anything.
+
+### 3. Prune what the removals left behind
+
+```bash
+git worktree prune
+git fetch --prune
+git branch -a
+git worktree list
+```
+
+There is no `git push origin --delete` in this procedure.
+`delete_branch_on_merge` has already taken the remote half, and if it had not,
+`.claude/hooks/no-git-push.sh` would refuse the deletion form anyway.
+
+What must be true at the end: every branch the report called stale is gone
+locally, every worktree that stood on one is gone, every unclassified branch is
+untouched, and `git worktree list` names no worktree without a branch.
 
 ## Notes
 

--- a/.claude/skills/branch-hygiene/SKILL.md
+++ b/.claude/skills/branch-hygiene/SKILL.md
@@ -22,7 +22,11 @@ worktree or deleting a worktree branch are each reserved. `CONTEXT.md`'s
 *reserved act* entry holds the list; this file cites it rather than counting it,
 so that a number here cannot go stale while the list grows there. What it makes
 Bertan's is every step of either procedure that changes something — the whole
-of the rotation below, and step 2 of the sweep.
+of the rotation below, and steps 2 and 3 of the sweep. Step 3 is included
+rather than argued about: `git worktree prune` removes worktree entries too,
+and deciding whether pruning an administrative file is really *removing a
+worktree* is a distinction a reader would have to get right unprompted, for no
+gain over simply reserving both.
 `.claude/hooks/no-git-push.sh` refuses both of the pushes a rotation needs — the
 first push of `dev-NN+1`, and the remote deletion of `dev-NN` — from anywhere,
 correctly. Issue #41 considered carving a hook exception for this skill and
@@ -241,19 +245,49 @@ A branch whose pull request is `CLOSED` rather than `MERGED` is stale by the
 same definition and is **not** swept on that evidence alone: its commits exist
 nowhere else. Report it, decide, and only then remove it.
 
-### 2. Remove the worktree, then the branch
+### 2. Unlock the worktree, remove it, then delete the branch
 
-In that order, and the order is not a preference. A linked worktree holds its
-branch checked out, and git refuses to delete a branch a worktree is standing
-on — `cannot delete branch '<name>' used by worktree at '<path>'` — so reaching
-for the branch first simply fails, in the direction that leaves a half-swept
-pair behind.
+Three commands, and neither ordering is a preference.
+
+**Unlock first, because every worktree here is locked.** `EnterWorktree` locks
+the worktree it creates, so `git worktree remove` refuses one outright:
+
+```
+fatal: cannot remove a locked working tree, lock reason: claude session <name>
+use 'remove -f -f' to override or unlock first
+```
+
+Take the other door. git names `remove -f -f` first and it is the wrong one: a
+lock says a session is using this worktree, and forcing past it discards
+whatever that session has not committed. The lock reason carries what decides
+the question — the session's name, its pid, and that process's start time,
+which is what separates a live session from a stale lock whose pid has since
+been handed to something else:
 
 ```bash
-git worktree list
+git worktree list --porcelain
+```
+
+A session that ends cleanly removes its own worktree, so a locked worktree that
+outlived its session is precisely the sweep's population. Confirm that rather
+than assume it; if the process is alive, this worktree is not the sweep's and
+nothing here applies to it:
+
+```bash
+ps -p <pid>
+```
+
+Then, and only then:
+
+```bash
+git worktree unlock .claude/worktrees/<name>
 git worktree remove .claude/worktrees/<name>
 git branch -d <branch>
 ```
+
+The branch goes last because a linked worktree holds it checked out and git
+refuses to delete a branch a worktree is standing on — `cannot delete branch
+'<name>' used by worktree at '<path>'`.
 
 `git worktree remove` refuses a worktree holding uncommitted changes or
 untracked files — `'<path>' contains modified or untracked files, use --force
@@ -279,6 +313,14 @@ git worktree list
 here to finish step 2. It is for the other way a worktree ends — a directory
 deleted by hand, which leaves an administrative entry behind that `git worktree
 list` still reports.
+
+**`prune` will not rescue a worktree that is still locked, and does not say
+so.** A locked worktree is exempt from pruning by design — holding the
+administrative files against pruning is what `git worktree lock` is for — so if
+the directory went by hand while the lock stood, `prune` skips it, exits 0, and
+`git worktree list` goes on naming it. That is the one failure in this
+procedure that reports success, which is why the invariant below is checked
+against `git worktree list` rather than inferred from the exit codes above.
 
 There is no `git push origin --delete` in this procedure.
 `delete_branch_on_merge` has already taken the remote half, and if it had not,

--- a/.claude/skills/branch-hygiene/SKILL.md
+++ b/.claude/skills/branch-hygiene/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: branch-hygiene
-description: Report whether the active dev branch is ready to rotate and what branches are stale, and hold Bertan's procedure for the rotation itself. Use after a dev-NN pull request lands in main, or when branches beyond main, one active dev branch and the worktree branches in flight against it are lying around. The rotation is Bertan's; an agent runs only the read-only half.
+description: Report whether the active dev branch is ready to rotate and what branches are stale, and hold Bertan's two procedures - rotating the dev branch, and sweeping merged worktree branches and the worktrees standing on them. Use after a dev-NN pull request lands in main, after a worktree branch's pull request merges, or when branches beyond main, one active dev branch and the worktree branches in flight against it are lying around. Both procedures are Bertan's; an agent runs only the read-only half and reports what it found.
 ---
 
 # Branch hygiene
@@ -16,11 +16,13 @@ When that pull request into `main` is merged, the dev branch has served its
 purpose and is rotated: the next branch takes the next number, and the merged
 one is deleted from both the local repository and the remote.
 
-**Rotation is a reserved act, and so is the sweep.** Rotating the dev branch is
-one of the five acts `CONTEXT.md` names; advancing the active dev branch on the
-remote is another, and removing a worktree or deleting a worktree branch — the
-whole of the sweep below — is a third. So every step of either procedure that
-changes anything belongs to Bertan.
+**Rotation is a reserved act, and so are the sweep's removals.** Rotating the
+dev branch, advancing the active dev branch on the remote, and removing a
+worktree or deleting a worktree branch are each reserved. `CONTEXT.md`'s
+*reserved act* entry holds the list; this file cites it rather than counting it,
+so that a number here cannot go stale while the list grows there. What it makes
+Bertan's is every step of either procedure that changes something — the whole
+of the rotation below, and step 2 of the sweep.
 `.claude/hooks/no-git-push.sh` refuses both of the pushes a rotation needs — the
 first push of `dev-NN+1`, and the remote deletion of `dev-NN` — from anywhere,
 correctly. Issue #41 considered carving a hook exception for this skill and
@@ -58,9 +60,9 @@ Its output is already in the session; read it before running the commands below,
 and run them for what it does not cover — the pull request state, which needs
 `gh`, and the last commit dates.
 
-**The sweep** below is the other half — what acts on that report. It is Bertan's,
-for the reason the rotation is, and an agent that has produced the report stops
-there.
+**The sweep** below is the other half — what acts on that report. It is
+Bertan's, for the reason the rotation is, and an agent that has produced the
+report stops there.
 
 That fetch is also what arms `.claude/hooks/no-work-on-stale-branch.sh`, which
 refuses a commit on a branch whose work is over. Both read remote-tracking refs,
@@ -192,7 +194,7 @@ half `delete_branch_on_merge` performs automatically. `CONTEXT.md`'s *worktree
 branch* entry states the lifetime this enforces: a worktree branch exists for
 one pull request, and the worktree that produced it is not reused afterwards.
 
-Also Bertan's. Removing a worktree is one of the five reserved acts, which is
+Also Bertan's. Removing a worktree is one of the acts that entry names, which is
 why `.claude/hooks/report-stale-branches.sh` names what is over and removes
 nothing, and why its name is `report-`.
 
@@ -242,9 +244,10 @@ nowhere else. Report it, decide, and only then remove it.
 ### 2. Remove the worktree, then the branch
 
 In that order, and the order is not a preference. A linked worktree holds its
-branch checked out, and `git branch -d` refuses to delete a checked-out branch,
-so reaching for the branch first simply fails — and fails in the direction that
-leaves a half-swept pair behind.
+branch checked out, and git refuses to delete a branch a worktree is standing
+on — `cannot delete branch '<name>' used by worktree at '<path>'` — so reaching
+for the branch first simply fails, in the direction that leaves a half-swept
+pair behind.
 
 ```bash
 git worktree list
@@ -253,7 +256,8 @@ git branch -d <branch>
 ```
 
 `git worktree remove` refuses a worktree holding uncommitted changes or
-untracked files. Treat that refusal as `-d`'s: it is saying there is something
+untracked files — `'<path>' contains modified or untracked files, use --force
+to delete it`. Treat that refusal as `-d`'s: it is saying there is something
 there nobody has looked at. Look before reaching for `--force`.
 
 Use `-d`, never `-D`, for the reason step 4 of the rotation gives — the
@@ -262,7 +266,7 @@ refusal here means the pull request did not merge the way the report believes.
 The squash-or-rebase exception named there applies unchanged, and so does its
 remedy: confirm the merge commit with `gh pr view` before forcing anything.
 
-### 3. Prune what the removals left behind
+### 3. Verify, and prune what step 2 could not
 
 ```bash
 git worktree prune
@@ -270,6 +274,11 @@ git fetch --prune
 git branch -a
 git worktree list
 ```
+
+`git worktree remove` cleans up its own metadata, so `git worktree prune` is not
+here to finish step 2. It is for the other way a worktree ends — a directory
+deleted by hand, which leaves an administrative entry behind that `git worktree
+list` still reports.
 
 There is no `git push origin --delete` in this procedure.
 `delete_branch_on_merge` has already taken the remote half, and if it had not,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,8 @@ The five canonical roles, each label string equal to its name. See
 
 ### Domain docs
 
-Single-context: `docs/adr/` holds one ADR; `CONTEXT.md` holds the glossary, so
-far the one distinction between a *check* and a *probe*. See
-`docs/agents/domain.md`.
+Single-context: `docs/adr/` holds one ADR; `CONTEXT.md` holds the glossary — the
+distinction between a *check* and a *probe*, and the three terms the boundary
+above is read against: *active dev branch*, *worktree branch*, *reserved act*.
+The last two carry what the hooks cite into them, a worktree branch's lifetime
+and the acts an agent reports rather than performs. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,8 +286,10 @@ The five canonical roles, each label string equal to its name. See
 
 ### Domain docs
 
-Single-context: `docs/adr/` holds one ADR; `CONTEXT.md` holds the glossary — the
-distinction between a *check* and a *probe*, and the three terms the boundary
-above is read against: *active dev branch*, *worktree branch*, *reserved act*.
-The last two carry what the hooks cite into them, a worktree branch's lifetime
-and the acts an agent reports rather than performs. See `docs/agents/domain.md`.
+Single-context: `docs/adr/` holds one ADR; `CONTEXT.md` holds the glossary. It
+is written lazily — a term is added when a collision has actually been resolved
+— so it stays short enough to read whole, and this line deliberately does not
+enumerate it: the sentence that did named two terms of five and went stale
+without saying so. Several of the hooks above cite it, and
+`.claude/hooks/check-hooks.sh` holds those citations to what it says. See
+`docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,12 +30,13 @@ _Avoid_: check
 
 **Reserved act**:
 An act that belongs to Bertan and not to an agent: advancing the active dev
-branch on the remote, merging any pull request, rotating the dev branch, and
-publishing a release. Reserved is not a synonym for refused. The hooks refuse
-the ordinary spellings of some of these and they stop mistakes, not adversaries;
-others nothing refuses at all — the local half of a rotation, `git branch -d`,
-passes every hook and is reserved all the same. Where nothing enforces, an agent
-reports what it found and stops.
+branch on the remote, merging any pull request, rotating the dev branch,
+removing a worktree or deleting a worktree branch, and publishing a release.
+Reserved is not a synonym for refused. The hooks refuse the ordinary spellings
+of some of these and they stop mistakes, not adversaries; others nothing refuses
+at all. `git worktree remove`, the whole of the sweep, and `git branch -d`,
+which both the sweep and a rotation end with, pass every hook and are reserved
+all the same. Where nothing enforces, an agent reports what it found and stops.
 _Avoid_: forbidden act, blocked act
 
 **Worktree branch**:
@@ -52,4 +53,17 @@ add -b`, which does not — so a prefix rule would disagree between them; and a
 branch in the main checkout can be given whatever name the rule looks for, which
 would carry the exception to the one place it is meant not to reach. Do not
 "fix" this into a rule about the name.
+
+A worktree branch exists for exactly one pull request. When that pull request
+merges into the active dev branch the branch is finished: on the remote
+`delete_branch_on_merge` removes it, and locally the sweep in the
+`branch-hygiene` skill does — one of the acts the *reserved act* entry above
+names, so an agent reports a branch whose work is over and removes nothing. The
+next unit of work is cut from the active dev branch's tip onto a new branch in
+a new worktree; the worktree that produced the merged branch is not reused. That
+clause is the operative half. A worktree outliving its branch is precisely how
+work gets committed onto a branch whose pull request has already merged, which
+happened twice before anything refused it and is what
+`.claude/hooks/no-work-on-stale-branch.sh` now refuses; that file's header names
+both occasions.
 _Avoid_: feature branch, agent branch


### PR DESCRIPTION
Closes #70.

#36's Amendment re-scoped stage 3 in one sentence and neither half arrived.
This lands both, plus the one-line fix that rides with them.

## The vocabulary

`CONTEXT.md`'s *Worktree branch* entry defined the branch and stopped. A
reader following `no-work-on-stale-branch.sh`'s pointer learned everything
about a worktree branch except when it ends — which is the fact the refusal
turns on. The entry now carries the lifetime: one pull request, then the remote
half `delete_branch_on_merge` takes and the local half the sweep does, and the
worktree that produced the branch is not reused. That last clause is the
operative one; a worktree outliving its branch is precisely how work gets
committed onto a branch whose pull request has already merged.

`CLAUDE.md:239` is untouched, as #70 asked — the operative paragraph, not the
definition.

## The sweep

Named in two hook headers and written nowhere. #70 left the choice between
writing it and retracting the claim to Bertan, who chose **write it, and name
its cadence**. That decision and its rejected alternative are recorded on
[#70](https://github.com/bgunyel/clause-and-effect/issues/70#issuecomment-5638004356),
so the audit path does not depend on a transcript.

`branch-hygiene` gains it as a procedure of its own:

- **unlock, then remove, then delete** — see the review finding below;
- `-d` never `-D`, with the reason the rotation already gives, and the same
  squash-or-rebase exception;
- every `unclassified` branch left alone, since sweeping one deletes work that
  was about to start;
- **cadence stated outright** — manual and unscheduled, in the register
  `no-work-on-stale-branch.sh` already uses for `allow_squash_merge`. That is
  the half that makes the two headers honest: #70's complaint was not that the
  sweep was undocumented but that it "is named as a thing that happens".

Both headers now point at it rather than restating it, and the guard carries
only the consequence for itself — the window it covers opens at the merge and
closes when someone gets round to sweeping, so it is bounded by nothing.

## The fifth reserved act

Removing a worktree or deleting a worktree branch joins `CONTEXT.md`'s
enumeration, so the two citations in `report-stale-branches.sh` — its header,
and the line it prints into every session's transcript — land somewhere.

The count came **out** of `branch-hygiene` rather than being corrected from
four to five: a corrected count is the same defect with a later expiry date.
`CONTEXT.md` holds the list once and the skill cites it. Steps 2 **and** 3 of
the sweep are reserved, step 3 included rather than argued about, since
`git worktree prune` removes worktree entries too.

## The `CLAUDE.md` *Domain docs* hunk

Called out because a pull request this careful about each hunk should not leave
one unexplained. The sentence said the glossary held "so far the one
distinction between a *check* and a *probe*" while `CONTEXT.md` had five
entries — the `four acts` staleness in a second place, and already stale before
this branch touched anything. It no longer enumerates at all: a longer
enumeration guarded by nothing would go the same way.

## What guards it

`check-hooks.sh` gains twenty-one checks: the boundary-section check with its
direction reversed. There `settings.json` is the fact and `CLAUDE.md` the
claim; here the hooks are the fact — they ship, they run, their headers send a
reader somewhere — and the documents are what must be there on arrival.

Measured against the final check set, on a copy rather than in the tree:
**eleven red** with the three documents reverted to `dev-05` and the two hook
headers held at this branch, **thirteen** with the headers reverted too. (The
"ten of seventeen" this branch quoted earlier was a true measurement of the
first commit's check set and went stale when the second reworked it.)

### The second commit is a review finding against the first

The sweep-citation check originally asked whether each header contained
`sweep`. Both contained it at `dev-05` already — once in the guard, three times
in the report — and that bare word *is* the dangling citation #70 exists about.
So the check was satisfied by the defect and would have stayed green through a
revert of every line the two headers gained. The literal is now the pointer,
which appears in neither header at `dev-05`.

### The third commit is a review finding against the second

**The sweep as written could not run on this repository.** `EnterWorktree`
locks every worktree it creates; `git worktree remove` refuses a locked one and
offers `remove -f -f`. Worse, step 3 failed *silently*: a locked worktree is
exempt from pruning by design, so `git worktree prune` skips it, exits 0, and
`git worktree list` goes on naming it — the closing invariant never reached,
with nothing saying why.

Step 2 now unlocks first and sends the reader to the lock reason rather than to
git's suggested force. The reason carries the session name, the pid, and that
process's start time — field 22 of `/proc/<pid>/stat`, verified against a live
lock — which is what separates a live session from a stale lock whose pid has
been reused.

**The suite now names its own limit**, because that limit is what let this
ship: every literal in the section asks whether the section *contains* a
command. None runs one, so none is evidence the procedure succeeds. A sweep
naming three commands that all refuse would pass every check there.

## Verification

- `bash .claude/hooks/check-hooks.sh` — 624 checks, all pass.
- `make test` — **575 passed, 5 xfailed, 0 failed**, after `uv sync
  --all-groups`. The earlier `test_installed_packages_match_uv_lock` failure
  was this worktree's `.venv` short of `alembic` and `mako`; it is gone.
- `make verify` and `make upgrade-safe` **both fail, for reasons that predate
  this branch and that it cannot fix** — this diff changes no dependency
  (`git diff origin/dev-05...HEAD -- uv.lock pyproject.toml` is empty):
  - `make audit` fails on the **committed** lock: `accelerate==1.14.0`,
    PYSEC-2026-3804 / GHSA-4j2p-28q2-5m79, CVSS 7.1, and osv-scanner reports
    *0 vulnerabilities can be fixed* — no fixed version exists.
  - `make upgrade-safe` reverts the candidate lock and blocks on four GuardDog
    findings in upgrade candidates: `docling-slim==2.126.0`,
    `google-genai==2.23.0`, `huggingface-hub==1.31.0`, `transformers==5.17.0`.
    These need the `waiver-review` skill; accepting a finding writes to a
    machine-wide `accepted.json`, which is not something to do to unblock a
    documents-only pull request.

  `CLAUDE.md:32` makes `upgrade-safe` the floor before a pull request closes and
  states no exception for documents-only diffs. Flagging rather than waiving.

https://claude.ai/code/session_01Uke8GuhacrPbLvjPXWjmZr
