### PR TITLE
Score the article−chunk gap on one population

### DIFF
--- a/docs/eval-reports/2026-09-11-tier1-retrieval-gap-corrected.md
+++ b/docs/eval-reports/2026-09-11-tier1-retrieval-gap-corrected.md
@@ -1,0 +1,136 @@
+# Tier-1 retrieval — the article−chunk gap, corrected — 2026-09-11
+
+**Correcting one number published on 2026-09-09: the article−chunk gap at k=5 is
+`+2.5` points, not `+4.2`.** Nothing else in that report moves. The 2026-09-09
+entry is history and is left untouched; this is the forward correction.
+
+| | |
+|---|---|
+| Cases | 433 (Tier-1, all 99 articles) |
+| Index | `compliance_docs`, 368 points, `text-embedding-3-small`, `indexed_at 2026-08-07T08:17:19Z` |
+| `top_k` | 10 (Hit@k read from one ranked list per case) |
+| Commit | `f5b17d1` |
+| Scorer | `src/eval/retrieval.py`, run by `scripts/score_retrieval.py` |
+| Issue | #60 |
+
+**The same index the 2026-09-09 baseline scored**, unchanged since 2026-08-07 —
+and every article-level and chunk-level figure below reproduces that report
+digit for digit. That is the point of this run: the retrieval did not change, so
+the only thing that moves is the arithmetic that was wrong.
+
+(The index advertises digest `a231f919…` while the committed snapshot
+`chunks_2026-08-10_060327_5caac594.jsonl` hashes to `5caac594…` — all 368 points
+stale, 0 orphans, 0 missing. Pre-existing, unrelated to this correction, and
+noted so the next reader does not take the reproduction as proof the index is
+current.)
+
+## What was wrong
+
+`scripts/score_retrieval.py` subtracted two rates taken over different cases:
+
+```
+(article hits / 433) − (chunk hits / 319)
+```
+
+Chunk-level scoring drops the 114 cases whose `supporting_quote` is not a
+substring of its own article — correctly, and it says so on the result.
+Article-level scoring excludes nothing — correctly, and that is the whole reason
+a publishable article number exists while the answer key is being repaired.
+Subtracting one from the other is neither quantity. It printed under the label
+*"right article, wrong chunk = chunking/embedding"*, which is a statement about
+cases that were retrieved well at one level and badly at the other — and no case
+can be in both terms unless both terms cover it.
+
+The 114 excluded cases are not a random sample of the 433. They are the ones the
+parser damaged, so the size and the **sign** of the bias were both unknown.
+
+Found by a Codex review of `dev-05` against `main`, alongside the Hit@k cutoff
+defect (#59, fixed first).
+
+## The corrected number
+
+Scored over the 319 grounded cases at both levels:
+
+| | value | |
+|---|---|---|
+| article-level, grounded subset | 89.3% | 285/319 |
+| chunk-level, grounded subset | 86.8% | 277/319 |
+| **article − chunk at k=5** | **+2.5 points** | **8 cases** |
+
+Published on 2026-09-09: `+4.2`, from `91.0% (394/433) − 86.8% (277/319)`.
+
+**1.7 of the published 4.2 points were population, not chunking.** The
+direction is now measurable rather than unknown: the damaged cases retrieve
+their own article *better* than the clean ones — 109 of 114 at k=5, **95.6%**,
+against 89.3% for the grounded 319. Keeping them in the first term and out of
+the second inflated the difference. It could as easily have gone the other way,
+and with a worse split it could have printed a negative "right article, wrong
+chunk" figure, which the quantity cannot be.
+
+The full-population article-level score is unchanged and stays published:
+**91.0% (394/433) at k=5**. It is not the term the gap uses, and it was never
+the defect.
+
+## The conclusion it was carrying, revisited
+
+2026-09-09 concluded:
+
+> When retrieval finds the right article it usually finds the chunk holding the
+> evidence too, so the dominant loss is not chunking or embedding — it is the
+> 9% of cases that miss the article entirely at k=5. That is where the next work
+> goes.
+
+**That conclusion survives, and the corrected number strengthens it.** Over the
+one population, at k=5:
+
+| loss | cases | of 319 |
+|---|---|---|
+| article missed entirely | 34 | 10.7% |
+| article found, chunk missed | 8 | 2.5% |
+
+Article misses outnumber chunk misses **more than four to one**. The error ran
+in the direction of *overstating* the chunking and embedding loss, so correcting
+it moves nothing about where the next work goes — the case for going after
+article-level misses is stronger at 8 cases than it was at the 13-or-so the
+published figure implied.
+
+Two things the correction does change:
+
+- **The article-miss rate quoted in that conclusion was over the wrong
+  population too.** "9% miss the article entirely at k=5" is `39/433`. Beside a
+  chunk-level number it should be `34/319` — **10.7%**. Same conclusion, and a
+  slightly larger share of the loss than was claimed.
+- **8 cases is a small enough number to look at individually.** A 2.5-point gap
+  over 319 is no longer a rate to reason about in aggregate; it is a list. That
+  is a cheaper next step than the published figure suggested, and it is worth
+  taking before any chunking work is scoped from this diagnostic.
+
+## What was changed to make the number honest
+
+The fix went into `src/eval/retrieval.py`, not into the one script, so that the
+next caller cannot repeat it:
+
+- `grounded_retrievals()` is public and is now the single place the grounding
+  restriction is applied. `score_chunk_level` is rebuilt on it instead of
+  keeping its own copy of the predicate — the same reason the module imports
+  `normalize_for_grounding` rather than reimplementing it.
+- `article_chunk_gap()` **raises** when the two scores it is handed cover
+  different numbers of cases. The cross-population subtraction now fails loudly
+  instead of returning a plausible float.
+- `gap_lines()` prints the population, its `n`, both terms and the difference in
+  cases, and says in as many words that the figure does not reconcile against
+  the article table above it.
+
+Equal `scored` is a necessary condition, not a sufficient one — two equal-sized
+populations could still be different cases. It catches the mistake that was
+actually made, and it is what a `LevelScore` carries.
+
+## Not measured here
+
+Everything the 2026-09-09 entry listed as not measured is still not measured:
+Context Precision, Score Separation, key-phrase coverage, citation
+article-match, every generation-side metric, and a run manifest. This is one
+re-run of the same index, not a distribution. The 95.6% article-level figure for
+the 114 damaged cases is derived from this run's counts (`394 − 285 = 109`), not
+separately scored, and it is reported as a diagnosis of the bias rather than as
+a number about retrieval quality — those cases still have a broken answer key.

--- a/scripts/score_retrieval.py
+++ b/scripts/score_retrieval.py
@@ -8,6 +8,12 @@ Article-level is publishable today; chunk-level is restricted to the grounded
 subset and says so. See ``src.eval.retrieval`` for why they are not equally
 trustworthy yet.
 
+**Three scores are computed and two are printed as a table.** The gap needs an
+article-level rate over the *same* cases chunk level scores, so it gets its own
+restricted score; the published article-level number keeps every case, and the
+two must not be subtracted from each other (issue #60). The gap line names the
+population it was taken over for that reason.
+
 **The reported cutoffs follow ``--top-k``**, via
 :func:`~src.eval.retrieval.cutoffs_for_depth`: ``--top-k 3`` prints Hit@1 and
 Hit@3 and nothing else, and ``--top-k 20`` prints Hit@1/3/5/10 *and* Hit@20. A
@@ -28,6 +34,8 @@ from src.eval.retrieval import (
     DEFAULT_K,
     cutoffs_for_depth,
     gap_cutoff,
+    gap_lines,
+    grounded_retrievals,
     retrieve_all,
     score_article_level,
     score_chunk_level,
@@ -70,8 +78,13 @@ def main() -> None:
     # Passed explicitly rather than left to default, so that a future change to
     # how the script retrieves is refused by the scorers instead of reinterpreted.
     ks = cutoffs_for_depth(args.top_k)
-    art = score_article_level(retrievals, ks)
-    chunk = score_chunk_level(retrievals, cases, articles, ks)
+    art = score_article_level(retrievals, ks)                     # all cases, published
+    chunk = score_chunk_level(retrievals, cases, articles, ks)    # grounded subset
+
+    # A third score, published nowhere: the article level over the same cases
+    # chunk level scores, so that the gap below is a difference between two
+    # rates and not between two populations (issue #60).
+    art_grounded = score_article_level(grounded_retrievals(retrievals, cases, articles), ks)
 
     print()
     print(f"Tier-1 retrieval — {len(cases)} cases, top_k={args.top_k}, {started:%Y-%m-%d %H:%M UTC}")
@@ -83,13 +96,12 @@ def main() -> None:
 
     # Report the gap at the deepest cutoff both levels actually hold, so a
     # shallow --top-k cannot print a gap at a cutoff neither level reached.
-    gap_k = gap_cutoff(art, chunk)
+    gap_k = gap_cutoff(art_grounded, chunk)
     if gap_k is None:
         print("article−chunk gap: not reportable at this depth")
         return
-    gap = art.hit_at_k[gap_k] - chunk.hit_at_k[gap_k]
-    print(f"article−chunk gap @{gap_k}: {gap:+.1%}"
-          "   (right article, wrong chunk = chunking/embedding)")
+    for line in gap_lines(art_grounded, chunk, gap_k):
+        print(line)
 
 
 if __name__ == "__main__":

--- a/scripts/score_retrieval.py
+++ b/scripts/score_retrieval.py
@@ -96,6 +96,15 @@ def main() -> None:
 
     # Report the gap at the deepest cutoff both levels actually hold, so a
     # shallow --top-k cannot print a gap at a cutoff neither level reached.
+    #
+    # What is *not* pinned by a test: that these two lines are handed
+    # `art_grounded` and not `art`. Nothing in tests/ imports this module — it
+    # pulls the Qdrant client at import time, and the import-cost rule in
+    # CLAUDE.md is why that is left alone. So the defect's own site is guarded
+    # at runtime rather than in the suite: article_chunk_gap raises on two
+    # populations, which turns the wrong wiring into a crash on the next run
+    # instead of a plausible number in a report. Writing the subtraction out by
+    # hand here would evade that, and is the one way back to the defect.
     gap_k = gap_cutoff(art_grounded, chunk)
     if gap_k is None:
         print("article−chunk gap: not reportable at this depth")

--- a/src/eval/retrieval.py
+++ b/src/eval/retrieval.py
@@ -165,8 +165,12 @@ def gap_cutoff(art: LevelScore, chunk: LevelScore, prefer: int = GAP_K) -> int |
     whenever both levels hold it. A shallower retrieval falls back to the
     deepest cutoff the two share, rather than printing a ``@5`` gap neither
     level reached. It never goes *deeper* than ``prefer``: a deeper retrieval
-    must not silently move the published diagnostic, and the gap's population
-    defect is issue #60's to settle, not this function's.
+    must not silently move the published diagnostic.
+
+    Which cutoff, only. Which *population* the gap is taken over is
+    :func:`article_chunk_gap`'s to enforce — pass it the article score over
+    :func:`grounded_retrievals`, and this function sees the same two levels
+    either way.
     """
     shared = [k for k in art.hit_at_k if k in chunk.hit_at_k and k <= prefer]
     return max(shared) if shared else None
@@ -209,9 +213,11 @@ def gap_lines(art: LevelScore, chunk: LevelScore, k: int) -> List[str]:
     return [
         f"article−chunk gap @{k}: {gap:+.1%}"
         f"   (right article, wrong chunk = chunking/embedding)",
+        # Both counts carry their denominator, as every count in LevelScore
+        # does: a bare "(285)" beside an "n=319" reads for a moment as the n.
         f"  over the grounded subset only, n={art.scored}: "
-        f"article {art.hit_at_k[k]:.1%} ({art.hits[k]}) − "
-        f"chunk {chunk.hit_at_k[k]:.1%} ({chunk.hits[k]}) = "
+        f"article {art.hit_at_k[k]:.1%} ({art.hits[k]}/{art.scored}) − "
+        f"chunk {chunk.hit_at_k[k]:.1%} ({chunk.hits[k]}/{chunk.scored}) = "
         f"{art.hits[k] - chunk.hits[k]} cases."
         f" Not the article table above, which covers every case.",
     ]

--- a/src/eval/retrieval.py
+++ b/src/eval/retrieval.py
@@ -13,6 +13,24 @@ The gap between them is the diagnostic the failure taxonomy (§9) reads: right
 article / wrong chunk is a chunking or embedding problem; wrong article is a
 retrieval problem.
 
+**The gap is a difference, so it is only that diagnostic when both terms are
+taken over the same cases.** Chunk-level scoring drops the ungrounded cases
+(below); the published article-level score keeps all of them, deliberately.
+Subtracting the second from the first mixes a population difference into a
+number whose label claims to measure right-article/wrong-chunk, and the dropped
+cases are not a random sample — they are the ones the parser damaged, so their
+article-level performance biases the result by an unknown amount *and sign*. The
+published +4.2 points of
+``docs/eval-reports/2026-09-09-tier1-retrieval-baseline.md`` was that
+subtraction, ``91.0% (394/433) − 86.8% (277/319)``, and a conclusion about where
+the next work goes rested on it (issue #60). So the gap now subtracts a *second*
+article score taken over :func:`grounded_retrievals` — the same cases chunk
+level scores — while the full-population article score stays exactly as it is,
+because being publishable over all 433 is the whole reason it exists.
+:func:`article_chunk_gap` refuses two scores of unequal ``scored``, so the
+cross-population subtraction cannot be written again by accident, and
+:func:`gap_lines` prints the population and its ``n`` beside the number.
+
 **Why the two levels are not equally trustworthy today.** 114 of the 433 Tier-1
 cases carry a ``supporting_quote`` that is not a substring of its own article —
 the parser damaged them, not the retriever. A quote that is absent from its
@@ -50,8 +68,7 @@ therefore labelled with the depth it was taken at.
 
 The article−chunk gap is bounded too, by :func:`gap_cutoff`, but it is pinned at
 5 rather than following the depth upward: a deeper retrieval must not silently
-move a published diagnostic. What population that gap is computed over is a
-separate, still-open defect (issue #60).
+move a published diagnostic.
 
 Matching imports :func:`~src.eval.golden_qa.normalize_for_grounding` rather than
 reimplementing it, so the gate that decides a quote is grounded and the metric
@@ -155,6 +172,49 @@ def gap_cutoff(art: LevelScore, chunk: LevelScore, prefer: int = GAP_K) -> int |
     return max(shared) if shared else None
 
 
+def article_chunk_gap(art: LevelScore, chunk: LevelScore, k: int) -> float:
+    """Right article, wrong chunk at ``k`` — from two scores over the same cases.
+
+    ``art`` must be the article-level score over :func:`grounded_retrievals`,
+    not the published full-population one. Unequal populations are refused
+    rather than subtracted: the difference of two rates over different case sets
+    is not the quantity this name promises, and the one shape the defect took
+    read exactly like arithmetic (issue #60).
+
+    Equal ``scored`` is a necessary condition, not a sufficient one — two
+    same-sized populations could still be different cases. It is what a
+    :class:`LevelScore` carries, it catches the mistake that was actually made,
+    and the alternative (carrying case ids on every score) buys nothing against
+    a caller who is already constructing scores by hand.
+    """
+    if art.scored != chunk.scored:
+        raise ValueError(
+            f"the article−chunk gap needs two scores over the same cases, got "
+            f"{art.level} over {art.scored} and {chunk.level} over {chunk.scored}. "
+            f"Score the article level over grounded_retrievals(...) for the gap; "
+            f"the full-population article score is for publishing, not subtracting."
+        )
+    return art.hit_at_k[k] - chunk.hit_at_k[k]
+
+
+def gap_lines(art: LevelScore, chunk: LevelScore, k: int) -> List[str]:
+    """The printed gap, naming the population it was taken over.
+
+    Both terms are stated next to the difference, and the ``n`` is named, so the
+    reader is not invited to reconcile the number against the full-population
+    article table printed above it — which is the reconciliation that produced
+    the defect in the first place.
+    """
+    gap = article_chunk_gap(art, chunk, k)
+    return [
+        f"article−chunk gap @{k}: {gap:+.1%}"
+        f"   (right article, wrong chunk = chunking/embedding)",
+        f"  over the grounded subset only, n={art.scored}: "
+        f"article {art.hit_at_k[k]:.1%} − chunk {chunk.hit_at_k[k]:.1%}."
+        f" Not the article table above, which covers every case.",
+    ]
+
+
 def retrieve_all(
     cases: Sequence[TestCase],
     search: SearchFn,
@@ -251,6 +311,31 @@ def score_article_level(retrievals: Sequence[CaseRetrieval],
     return _score(list(ranks), "article-level", 0, "", _resolve_ks(ks, depth), depth)
 
 
+GROUNDING_EXCLUSION = "quote ungrounded in its article"
+
+
+def grounded_retrievals(retrievals: Sequence[CaseRetrieval],
+                        cases: Sequence[TestCase],
+                        articles: Dict[str, Article]) -> List[CaseRetrieval]:
+    """The cases whose quote is grounded in its article — the population
+    chunk-level scoring is restricted to.
+
+    Public, and the one place the restriction is applied, so that a caller who
+    needs the same population for something else (the article−chunk gap, which
+    needs it to be a difference at all) takes it from here rather than writing a
+    second copy of the predicate. Order is preserved.
+    """
+    by_id = {c.case_id: c for c in cases}
+    out: List[CaseRetrieval] = []
+    for r in retrievals:
+        case = by_id[r.case_id]
+        issue = check_quote_grounding(case, articles.get(str(case.article_number)))
+        if issue is not None and issue.severity == "error":
+            continue
+        out.append(r)
+    return out
+
+
 def score_chunk_level(retrievals: Sequence[CaseRetrieval],
                       cases: Sequence[TestCase],
                       articles: Dict[str, Article],
@@ -258,25 +343,24 @@ def score_chunk_level(retrievals: Sequence[CaseRetrieval],
     """
     Hit@k and MRR against the chunk holding the gold quote.
 
-    Restricted to cases whose quote is grounded in its article — exact or
-    normalized. An ungrounded quote is absent from the article by definition, so
-    including it would score the parser, not the retriever. The count dropped is
-    carried on the result so a reader sees the restriction next to the number.
+    Restricted by :func:`grounded_retrievals` to the cases whose quote is
+    grounded in its article — exact or normalized. An ungrounded quote is absent
+    from the article by definition, so including it would score the parser, not
+    the retriever. The count dropped is carried on the result so a reader sees
+    the restriction next to the number.
+
+    The restriction is taken from that function rather than applied again here,
+    for the reason the module docstring gives for importing
+    ``normalize_for_grounding``: the population the gap is scored over and the
+    population this metric covers cannot be allowed to drift apart.
 
     ``ks`` defaults and is bounded exactly as in :func:`score_article_level`.
     The bound reads the retrieval batch, not the surviving subset, so excluding
     every case does not quietly excuse a dishonest cutoff.
     """
     by_id = {c.case_id: c for c in cases}
-    ranks: List[int | None] = []
-    excluded = 0
-    for r in retrievals:
-        case = by_id[r.case_id]
-        issue = check_quote_grounding(case, articles.get(str(case.article_number)))
-        if issue is not None and issue.severity == "error":
-            excluded += 1
-            continue
-        ranks.append(r.chunk_rank(case.supporting_quote))
+    grounded = grounded_retrievals(retrievals, cases, articles)
+    ranks = [r.chunk_rank(by_id[r.case_id].supporting_quote) for r in grounded]
     depth = _retrieval_depth(retrievals)
-    return _score(ranks, "chunk-level", excluded, "quote ungrounded in its article",
-                  _resolve_ks(ks, depth), depth)
+    return _score(ranks, "chunk-level", len(retrievals) - len(grounded),
+                  GROUNDING_EXCLUSION, _resolve_ks(ks, depth), depth)

--- a/src/eval/retrieval.py
+++ b/src/eval/retrieval.py
@@ -210,7 +210,9 @@ def gap_lines(art: LevelScore, chunk: LevelScore, k: int) -> List[str]:
         f"article−chunk gap @{k}: {gap:+.1%}"
         f"   (right article, wrong chunk = chunking/embedding)",
         f"  over the grounded subset only, n={art.scored}: "
-        f"article {art.hit_at_k[k]:.1%} − chunk {chunk.hit_at_k[k]:.1%}."
+        f"article {art.hit_at_k[k]:.1%} ({art.hits[k]}) − "
+        f"chunk {chunk.hit_at_k[k]:.1%} ({chunk.hits[k]}) = "
+        f"{art.hits[k] - chunk.hits[k]} cases."
         f" Not the article table above, which covers every case.",
     ]
 

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -332,4 +332,4 @@ def test_the_printed_gap_names_its_population():
     assert "grounded" in text
     # The gap in cases, not only in points: one of the two grounded cases hits
     # the article and it is the same one that hits the chunk.
-    assert "article 50.0% (1) − chunk 50.0% (1) = 0 cases" in text
+    assert "article 50.0% (1/2) − chunk 50.0% (1/2) = 0 cases" in text

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -23,8 +23,11 @@ from src.eval.dataset import Article, TestCase
 from src.eval.retrieval import (
     CaseRetrieval,
     LevelScore,
+    article_chunk_gap,
     cutoffs_for_depth,
     gap_cutoff,
+    gap_lines,
+    grounded_retrievals,
     retrieve_all,
     score_article_level,
     score_chunk_level,
@@ -186,3 +189,144 @@ def test_the_gap_is_not_reportable_when_a_level_scored_nothing():
                       LevelScore(level="chunk-level", scored=0, excluded=9,
                                  excluded_reason="quote ungrounded in its article",
                                  depth=10)) is None
+
+
+# ------------------- the gap's population (issue #60) ---------------------- #
+#
+# The gap answers "right article, wrong chunk". The subtraction is only that
+# quantity when both terms are taken over the same cases. Chunk-level scoring
+# drops the cases whose quote is ungrounded; the published article score keeps
+# all of them, on purpose. Subtracting one from the other mixes a population
+# difference into the answer — and the excluded cases are not a random sample,
+# they are the ones the parser damaged.
+#
+# The two fixtures below hold the grounded cases fixed and change only the
+# excluded ones, so anything that moves between them is population, not
+# retrieval quality.
+
+GAP_ARTICLES = {
+    "5": Article(
+        number="5", title="Principles relating to processing of personal data",
+        content="Personal data shall be limited to what is necessary in relation to the purposes."),
+    "6": Article(
+        number="6", title="Lawfulness of processing",
+        content="Processing is necessary for compliance with a legal obligation."),
+    "7": Article(
+        number="7", title="Conditions for consent",
+        content="The controller shall be able to demonstrate that the data subject consented."),
+    "8": Article(
+        number="8", title="Conditions applicable to child's consent",
+        content="The processing of the personal data of a child shall be lawful where the child is at least 16."),
+}
+
+# Two grounded cases: one hits both levels, the other misses both.
+GAP_GROUNDED_CASES = [
+    make_case("gdpr_art5_case1", "5", "What must processing be limited to?",
+              supporting_quote="limited to what is necessary"),
+    make_case("gdpr_art6_case1", "6", "When is processing lawful?",
+              supporting_quote="necessary for compliance with a legal obligation"),
+]
+GAP_GROUNDED_RETRIEVALS = [
+    make_retrieval("gdpr_art5_case1", "5", ["5", "9", "12"], max_k=3,
+                   texts=["limited to what is necessary", "b", "c"]),
+    make_retrieval("gdpr_art6_case1", "6", ["9", "12", "13"], max_k=3,
+                   texts=["a", "b", "c"]),
+]
+
+# Two ungrounded cases — the quote is nowhere in its own article, so chunk-level
+# scoring must drop both whatever the retriever did.
+GAP_UNGROUNDED_CASES = [
+    make_case("gdpr_art7_case1", "7", "Who must demonstrate consent?",
+              supporting_quote="a sentence that appears nowhere in Article 7"),
+    make_case("gdpr_art8_case1", "8", "What age applies to a child's consent?",
+              supporting_quote="a sentence that appears nowhere in Article 8"),
+]
+# Variant A: the excluded cases retrieve their own article at rank 1.
+GAP_EXCLUDED_HIT = [
+    make_retrieval("gdpr_art7_case1", "7", ["7", "9", "12"], max_k=3),
+    make_retrieval("gdpr_art8_case1", "8", ["8", "9", "12"], max_k=3),
+]
+# Variant B: the excluded cases miss their article entirely.
+GAP_EXCLUDED_MISS = [
+    make_retrieval("gdpr_art7_case1", "7", ["9", "12", "13"], max_k=3),
+    make_retrieval("gdpr_art8_case1", "8", ["9", "12", "13"], max_k=3),
+]
+
+GAP_CASES = GAP_GROUNDED_CASES + GAP_UNGROUNDED_CASES
+GAP_KS = (1, 3)
+GAP_AT = 3  # the deepest cutoff this max_k=3 fixture holds
+
+
+def test_gap_is_scored_on_one_population():
+    """Changing only the excluded cases moves the published number, not the gap."""
+    for retrievals, published_at_3 in ((GAP_GROUNDED_RETRIEVALS + GAP_EXCLUDED_HIT, 0.75),
+                                       (GAP_GROUNDED_RETRIEVALS + GAP_EXCLUDED_MISS, 0.25)):
+        art = score_article_level(retrievals, GAP_KS)
+        chunk = score_chunk_level(retrievals, GAP_CASES, GAP_ARTICLES, GAP_KS)
+        art_g = score_article_level(
+            grounded_retrievals(retrievals, GAP_CASES, GAP_ARTICLES), GAP_KS)
+
+        # The published article score covers all four cases and moves with them.
+        assert art.scored == 4
+        assert art.hit_at_k[3] == published_at_3
+
+        # The gap is taken over the two grounded cases and does not move: one of
+        # the two hits the article, and the same one hits the chunk.
+        assert (art_g.scored, chunk.scored) == (2, 2)
+        assert art_g.hit_at_k[3] == 0.5
+        assert chunk.hit_at_k[3] == 0.5
+        assert article_chunk_gap(art_g, chunk, GAP_AT) == 0.0
+
+
+def test_the_gap_refuses_two_scores_taken_over_different_cases():
+    """The cross-population subtraction is refused, not quietly computed."""
+    retrievals = GAP_GROUNDED_RETRIEVALS + GAP_EXCLUDED_HIT
+    art = score_article_level(retrievals, GAP_KS)
+    chunk = score_chunk_level(retrievals, GAP_CASES, GAP_ARTICLES, GAP_KS)
+
+    assert (art.scored, chunk.scored) == (4, 2)
+    with pytest.raises(ValueError):
+        article_chunk_gap(art, chunk, GAP_AT)
+
+
+def test_grounded_subset_is_what_chunk_level_scores():
+    retrievals = GAP_GROUNDED_RETRIEVALS + GAP_EXCLUDED_HIT
+    grounded = grounded_retrievals(retrievals, GAP_CASES, GAP_ARTICLES)
+    chunk = score_chunk_level(retrievals, GAP_CASES, GAP_ARTICLES, GAP_KS)
+
+    assert [r.case_id for r in grounded] == ["gdpr_art5_case1", "gdpr_art6_case1"]
+    assert len(grounded) == 2
+    assert chunk.scored == 2
+    assert chunk.excluded == 2
+    assert chunk.scored + chunk.excluded == 4
+    assert chunk.excluded_reason == "quote ungrounded in its article"
+
+
+def test_gap_cannot_be_negative_from_population_alone():
+    """The review's pathological case: excluded cases with poor article retrieval.
+
+    Article-level over all four is 25%, chunk-level over the grounded two is
+    50%, so the old subtraction printed −25 points — a "right article, wrong
+    chunk" figure below zero, which the quantity cannot be.
+    """
+    retrievals = GAP_GROUNDED_RETRIEVALS + GAP_EXCLUDED_MISS
+    art = score_article_level(retrievals, GAP_KS)
+    chunk = score_chunk_level(retrievals, GAP_CASES, GAP_ARTICLES, GAP_KS)
+    art_g = score_article_level(
+        grounded_retrievals(retrievals, GAP_CASES, GAP_ARTICLES), GAP_KS)
+
+    assert art.hit_at_k[3] - chunk.hit_at_k[3] == -0.25  # what the defect printed
+    assert article_chunk_gap(art_g, chunk, GAP_AT) == 0.0
+
+
+def test_the_printed_gap_names_its_population():
+    retrievals = GAP_GROUNDED_RETRIEVALS + GAP_EXCLUDED_HIT
+    chunk = score_chunk_level(retrievals, GAP_CASES, GAP_ARTICLES, GAP_KS)
+    art_g = score_article_level(
+        grounded_retrievals(retrievals, GAP_CASES, GAP_ARTICLES), GAP_KS)
+
+    text = "\n".join(gap_lines(art_g, chunk, GAP_AT))
+
+    assert "article−chunk gap @3: +0.0%" in text
+    assert "n=2" in text
+    assert "grounded" in text

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -330,3 +330,6 @@ def test_the_printed_gap_names_its_population():
     assert "article−chunk gap @3: +0.0%" in text
     assert "n=2" in text
     assert "grounded" in text
+    # The gap in cases, not only in points: one of the two grounded cases hits
+    # the article and it is the same one that hits the chunk.
+    assert "article 50.0% (1) − chunk 50.0% (1) = 0 cases" in text


### PR DESCRIPTION
Fixes the second of the two retrieval-scorer defects found by the Codex review of `dev-05` (the first was #59). This one had already reached a published number.

## What was wrong

`scripts/score_retrieval.py` subtracted an article-level rate over all 433 cases from a chunk-level rate over the 319 grounded ones, under a label claiming to measure "right article, wrong chunk". No case can be in both terms unless both terms cover it. The 114 excluded cases are not a random sample — they are the ones the parser damaged — so the size and the sign of the bias were both unknown.

## What changed

The fix went into `src/eval/retrieval.py`, not the one script, so the grounded subset stops being private to `score_chunk_level`:

- **`grounded_retrievals()`** is public and is now the single place the grounding restriction is applied. `score_chunk_level` is rebuilt on it instead of keeping its own copy of the predicate — the same reason the module imports `normalize_for_grounding` rather than reimplementing it.
- **`article_chunk_gap()`** raises when the two scores it is handed cover different numbers of cases, so the cross-population subtraction fails loudly instead of returning a plausible float. Equal `scored` is necessary, not sufficient; the trade is recorded in the docstring.
- **`gap_lines()`** prints the population, its `n`, both terms with denominators and the difference in cases, and says the figure does not reconcile against the article table above it.

The published article-level score still covers all 433 and is unchanged. The gap uses a second, restricted article score that is published nowhere.

## The measurement

Re-ran the baseline against the same index the 2026-09-09 report scored — `compliance_docs`, 368 points, unchanged since 2026-08-07 — so every article-level and chunk-level figure reproduces that report digit for digit and the only thing that moves is the arithmetic.

| | value | |
|---|---|---|
| article-level, grounded subset | 89.3% | 285/319 |
| chunk-level, grounded subset | 86.8% | 277/319 |
| **article − chunk at k=5** | **+2.5 points** | **8 cases** |

Published on 2026-09-09: `+4.2`, from `91.0% (394/433) − 86.8% (277/319)`. **1.7 of those points were population.** The direction is now measurable: the 114 damaged cases retrieve their own article *better* than the clean ones — 109/114, 95.6%, against 89.3% — so keeping them in the first term and out of the second inflated the difference.

**The conclusion the number was carrying survives and is strengthened.** The error overstated the chunking loss. Over the one population at k=5, article misses (34 cases, 10.7%) outnumber chunk misses (8 cases, 2.5%) more than four to one. Two things do change: the "9% miss the article entirely" quoted in that conclusion was `39/433`, and beside a chunk-level number it should be `34/319` = 10.7%; and 8 cases is a list to read rather than a rate to reason about, which is a cheaper next step than the published figure suggested.

Recorded in a **new** dated entry, `docs/eval-reports/2026-09-11-tier1-retrieval-gap-corrected.md`. The 2026-09-09 report is left untouched — corrections go forward.

## Tests

Five tests added to `tests/test_eval_retrieval.py`, literals and fakes only, no live Qdrant/DB/model API. Two fixtures hold the grounded cases fixed and change only the excluded ones, so anything that moves between them is population rather than retrieval quality.

Mutation-checked in both directions:

- dropping the population guard in `article_chunk_gap` → 1 test red
- dropping the restriction in `grounded_retrievals` → 5 tests red

`make test`: 591 passed, 5 xfailed.

## Two things to know before merging

- **One acceptance criterion is partial, deliberately.** Nothing in `tests/` pins that the script hands `gap_lines` the *grounded* article score, because nothing in `tests/` imports that script — it pulls the Qdrant client at import time, and the import-cost rule is why that is left alone. The defect's own site is guarded at runtime instead: `article_chunk_gap` raises on two populations, so the wrong wiring crashes on the next run rather than printing a plausible number into a report. Writing the subtraction out by hand there would evade it, and is the one way back to the defect. The trade is written into `scripts/score_retrieval.py` where the next reader meets it.
- **`make audit` fails on `accelerate` 1.14.0** (PYSEC-2026-3804 / GHSA-4j2p-28q2-5m79, no fixed version published). This branch does not touch `uv.lock`, so it is inherited from `dev-05` and not introduced here — flagging it because CLAUDE.md makes `make upgrade-safe` a condition of closing a PR, and that gate cannot pass on this advisory today.

Beyond the issue's sketch, by deliberate choice: the raising guard and its test, `gap_lines` living in the module rather than the script (the printed line is an acceptance criterion, and it needed to be reachable by a test), the case counts in that line, and the `GROUNDING_EXCLUSION` constant. Each serves the issue's stated aim that "the next caller cannot repeat the mistake".

Refs #60

https://claude.ai/code/session_01Mw3jmvkB3SqqkBA73kHRqt
