### PR TITLE
Match `gh` as a word, so a commit message saying *high* is not a PR decision

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -931,6 +931,46 @@ check no-pr-decisions.sh ALLOW 'bash -c gh issue close'      'bash -c "gh issue 
 check no-pr-decisions.sh ALLOW 'bash -c gh issue list'       'bash -c "gh issue list"'
 check no-pr-decisions.sh ALLOW 'bash -c an ordinary command' 'bash -c "make test"'
 
+echo "=== REGRESSION: #72, gh is a word here and not a suffix ==="
+# The sentence three lines above is the spec, and the pattern did not implement
+# it. `gh` was the one token in this file matched unbounded on its left, so any
+# word ENDING in gh satisfied it -- high, enough, through, sigh, dough -- and
+# once a wrapper was on the line, one of those followed by a delimited pr,
+# release or api anywhere later was refused. The first row is the one that
+# matters: it names no gh, calls no GitHub surface, and is the shape of an
+# ordinary commit from inside a wrapper. It was refused with a reason that was
+# false rather than merely conservative -- "a shell wrapper does not change what
+# the command decides" said to a commit that decides nothing.
+#
+# The ALLOW directly above was the only fixture guarding this path, and it
+# carries neither a gh-ending word nor a trigger token, so no regex could have
+# tripped it; its two neighbours exercise the subcommand dimension, not this
+# one. That is the hole this section fills. Measured before the one-line fix:
+# every ALLOW below was BLOCK.
+check no-pr-decisions.sh ALLOW 'bash -c a commit message saying high' \
+  "bash -c \"git commit -m 'refactor high level api client'\""
+check no-pr-decisions.sh ALLOW 'bash -c grep high pr.txt'      'bash -c "grep high pr.txt"'
+check no-pr-decisions.sh ALLOW 'bash -c cat sigh api.md'       'bash -c "cat sigh api.md"'
+check no-pr-decisions.sh ALLOW 'bash -c ls dough api'          'bash -c "ls dough api"'
+check no-pr-decisions.sh ALLOW 'bash -c echo through pr'       'bash -c "echo through pr"'
+check no-pr-decisions.sh ALLOW 'bash -c cat enough release.md' 'bash -c "cat enough release.md"'
+# A left boundary, not a left anchor. A path ends in a character that is none of
+# gh's own, so an invoked gh still matches wherever it is spelled from. Without
+# this pair the boundary could be tightened to `(^|[[:space:]])` -- or the whole
+# group anchored -- and nothing in this suite would notice.
+check no-pr-decisions.sh BLOCK 'bash -c ./gh pr merge'         'bash -c "./gh pr merge 5"'
+check no-pr-decisions.sh BLOCK 'bash -c /usr/bin/gh pr merge'  'bash -c "/usr/bin/gh pr merge 5"'
+# The narrowing the boundary accepts, pinned rather than left for a later review
+# to find. The character class excludes - and _ as every other token in this
+# file does, so a command whose NAME ends in gh behind one of those stops
+# matching. Both are evasion shapes rather than mistakes, and the two BLOCKs
+# above show the spellings that reach gh itself still refuse; accepted under
+# "these stop mistakes, not adversaries". Measured before the fix: both BLOCK.
+# This pair is what would notice if the trade were quietly taken back, or
+# quietly widened past what the comment on the pattern claims.
+check no-pr-decisions.sh ALLOW 'bash -c my-gh pr merge'        'bash -c "my-gh pr merge 5"'
+check no-pr-decisions.sh ALLOW 'bash -c my_gh pr merge'        'bash -c "my_gh pr merge 5"'
+
 echo "=== REGRESSION: review of 02a14d8, close and release through gh api ==="
 # Closing a PR and publishing a release were refused in the gh spelling and open
 # through gh api, so the boundary was spelling-dependent exactly where the file

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -932,8 +932,10 @@ check no-pr-decisions.sh ALLOW 'bash -c gh issue list'       'bash -c "gh issue 
 check no-pr-decisions.sh ALLOW 'bash -c an ordinary command' 'bash -c "make test"'
 
 echo "=== REGRESSION: #72, gh is a word here and not a suffix ==="
-# The sentence three lines above is the spec, and the pattern did not implement
-# it. `gh` was the one token in this file matched unbounded on its left, so any
+# "The rule reaches gh's three deciding surfaces and stops there" -- the comment
+# heading the block above -- is the spec, and the pattern did not implement it.
+# (Named rather than pointed at by line count, which any insertion would make
+# wrong.) `gh` was the one token in this file matched unbounded on its left, so any
 # word ENDING in gh satisfied it -- high, enough, through, sigh, dough -- and
 # once a wrapper was on the line, one of those followed by a delimited pr,
 # release or api anywhere later was refused. The first row is the one that
@@ -970,6 +972,15 @@ check no-pr-decisions.sh BLOCK 'bash -c /usr/bin/gh pr merge'  'bash -c "/usr/bi
 # quietly widened past what the comment on the pattern claims.
 check no-pr-decisions.sh ALLOW 'bash -c my-gh pr merge'        'bash -c "my-gh pr merge 5"'
 check no-pr-decisions.sh ALLOW 'bash -c my_gh pr merge'        'bash -c "my_gh pr merge 5"'
+# The third narrowed shape, and the one with the other cause: a literal \n
+# escape puts `n` in front of gh, which no class this file would write admits,
+# so this follows from having a left boundary at all rather than from which one.
+# It is the single verdict the fix changed across the 7,621-command corpus #72
+# sampled. Pinned because the comment on the pattern claims all three are, and a
+# check suite is evidence about the cases it names and about nothing else -- the
+# two rows above cannot speak for this one, having a different cause.
+check no-pr-decisions.sh ALLOW 'bash -c a \n escape before gh' \
+  "bash -c \"printf 'summary\\ngh pr review --approve 5' > /tmp/x\""
 
 echo "=== REGRESSION: review of 02a14d8, close and release through gh api ==="
 # Closing a PR and publishing a release were refused in the gh spelling and open

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -363,14 +363,24 @@ VERDICT='(^|[[:space:]])(--approve|--request-changes|-[A-Za-z]*[ar][A-Za-z]*)([[
 # under `grep -qE` as a boolean, so consuming the boundary character costs
 # nothing.
 #
-# The class excludes `-` and `_` as the rest of the file does, which narrows
-# three shapes: `my-gh pr merge 5` and `my_gh pr merge 5` stop matching, and so
-# does a literal `\n` escape written immediately before gh. All three are evasion
-# shapes rather than mistakes -- `./gh` and `/usr/bin/gh` still refuse, a path
-# ending in a character that is none of gh's own -- and they are accepted under
-# the same "these stop mistakes, not adversaries" that decides the rest, stated
-# here rather than left for a later review to find. Pinned in both directions
-# under REGRESSION: #72 in check-hooks.sh.
+# Three shapes stop matching, and they have two different causes -- worth
+# keeping apart, because only one of them is a choice this file made.
+#
+# The boundary EXISTING narrows a literal `\n` escape written immediately before
+# gh: the character in front is then `n`, which no class this file would write
+# admits. `printf 'summary\ngh pr review --approve 5'` inside a wrapper matched
+# before and does not now. That is the single verdict the fix changes across the
+# 7,621-command corpus #72 sampled, and it follows from having a left boundary
+# at all rather than from which one -- measured, both candidate classes agree.
+#
+# The class EXCLUDING `-` and `_`, as every other token here does, separately
+# narrows `my-gh pr merge 5` and `my_gh pr merge 5`.
+#
+# All three are evasion shapes rather than mistakes -- `./gh` and `/usr/bin/gh`
+# still refuse, a path ending in a character that is none of gh's own -- and
+# they are accepted under the same "these stop mistakes, not adversaries" that
+# decides the rest, stated here rather than left for a later review to find.
+# All three are pinned under REGRESSION: #72 in check-hooks.sh.
 GH_SURFACE_ANYWHERE='(^|[^-A-Za-z0-9_])gh[[:space:]]+(.*[^-A-Za-z0-9_])?(pr|release|api)([^-A-Za-z0-9_]|$)'
 
 # Every base a gh api call names, in the two shapes gh accepts one. Both print

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -363,9 +363,9 @@ VERDICT='(^|[[:space:]])(--approve|--request-changes|-[A-Za-z]*[ar][A-Za-z]*)([[
 # under `grep -qE` as a boolean, so consuming the boundary character costs
 # nothing.
 #
-# The class excludes `-` and `_` as the rest of the file does, which narrows two
-# shapes: `my-gh pr merge 5` and `my_gh pr merge 5` stop matching, as does a
-# literal `\n` escape written immediately before gh. All three are evasion
+# The class excludes `-` and `_` as the rest of the file does, which narrows
+# three shapes: `my-gh pr merge 5` and `my_gh pr merge 5` stop matching, and so
+# does a literal `\n` escape written immediately before gh. All three are evasion
 # shapes rather than mistakes -- `./gh` and `/usr/bin/gh` still refuse, a path
 # ending in a character that is none of gh's own -- and they are accepted under
 # the same "these stop mistakes, not adversaries" that decides the rest, stated

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -349,7 +349,29 @@ VERDICT='(^|[[:space:]])(--approve|--request-changes|-[A-Za-z]*[ar][A-Za-z]*)([[
 # All three are reads or ordinary edits, all are refused with the writes for the
 # same reason the method of a wrapped `gh api` was already not read, and all are
 # one edit away from working. Run them unwrapped, on a line of their own.
-GH_SURFACE_ANYWHERE='gh[[:space:]]+(.*[^-A-Za-z0-9_])?(pr|release|api)([^-A-Za-z0-9_]|$)'
+#
+# What is NOT part of that trade: `gh` had no left boundary, so any word ending
+# in gh was a gh -- high, enough, through, sigh, dough -- and a wrapped
+# `git commit -m 'refactor high level api client'` was refused as a PR decision
+# though it names no gh and decides nothing. All three parts above presuppose a
+# gh on the line, so that command fell outside every one of them, and the
+# refusal text was false rather than conservative. #72. The left boundary is the
+# one every other token here already has, argued for in as many words: the
+# group's own right edge below, `eval` in the wrapper detector, `release delete`
+# against `release delete-asset`, `rest_bases` anchoring on its field flag to
+# keep `rebase` and `database` the words they are. The pattern is only ever used
+# under `grep -qE` as a boolean, so consuming the boundary character costs
+# nothing.
+#
+# The class excludes `-` and `_` as the rest of the file does, which narrows two
+# shapes: `my-gh pr merge 5` and `my_gh pr merge 5` stop matching, as does a
+# literal `\n` escape written immediately before gh. All three are evasion
+# shapes rather than mistakes -- `./gh` and `/usr/bin/gh` still refuse, a path
+# ending in a character that is none of gh's own -- and they are accepted under
+# the same "these stop mistakes, not adversaries" that decides the rest, stated
+# here rather than left for a later review to find. Pinned in both directions
+# under REGRESSION: #72 in check-hooks.sh.
+GH_SURFACE_ANYWHERE='(^|[^-A-Za-z0-9_])gh[[:space:]]+(.*[^-A-Za-z0-9_])?(pr|release|api)([^-A-Za-z0-9_]|$)'
 
 # Every base a gh api call names, in the two shapes gh accepts one. Both print
 # the values, one per line, for bases_all_dev -- the same "every, not the last"


### PR DESCRIPTION
Fixes the over-refusal reported in #72: `GH_SURFACE_ANYWHERE` matched `gh` as a
substring, so any word *ending* in gh was a gh.

## The rule

```diff
-GH_SURFACE_ANYWHERE='gh[[:space:]]+(.*[^-A-Za-z0-9_])?(pr|release|api)([^-A-Za-z0-9_]|$)'
+GH_SURFACE_ANYWHERE='(^|[^-A-Za-z0-9_])gh[[:space:]]+(.*[^-A-Za-z0-9_])?(pr|release|api)([^-A-Za-z0-9_]|$)'
```

The boundary is the one every other token in the file already has, each argued
for a few lines away — the group's own right edge, `eval` in the wrapper
detector, `release delete` against `release delete-asset`, `rest_bases`
anchoring on its field flag. `gh` was the only boundary decision here that no
comment defended. The pattern has one definition and one use, under `grep -qE`
as a boolean, so consuming the boundary character costs nothing.

Over-refusal only. Nothing is permitted that was not permitted before, except
the three evasion shapes recorded below.

## Why it mattered

`bash -c "git commit -m 'refactor high level api client'"` names no gh, calls no
GitHub surface, and decides nothing — and was refused as a PR decision, with a
reason that was false rather than merely conservative: *"A shell wrapper does
not change what the command decides, and its payload cannot be read."*

It was outside every trade this repository has written down. All three parts of
the trade comment presuppose a `gh` on the line, and CLAUDE.md's **Deliberately
left open** list names no such consequence. `check-hooks.sh` states the spec
directly — *"The rule reaches gh's three deciding surfaces and stops there"* —
and the pattern did not implement it.

## Measured

| | before | after |
|---|---|---|
| the 6 evidence rows in #72 | BLOCK | **ALLOW** |
| the 9 control rows in #72 | unchanged | unchanged |
| `./gh`, `/usr/bin/gh` | BLOCK | BLOCK |

## The trade this accepts, recorded rather than left to be found

Three shapes stop matching, with **two different causes** — kept apart in the
comment because only one is a choice this file made:

- The boundary **existing** narrows a literal `\n` escape written immediately
  before gh (the preceding character is then `n`). This is the single verdict
  the fix changes across the 7,621-command corpus #72 sampled, and it follows
  from having a boundary at all rather than from which one — measured against
  both candidate classes, which agree.
- The class **excluding** `-` and `_`, as the rest of the file does, separately
  narrows `my-gh pr merge 5` and `my_gh pr merge 5`.

All are evasion shapes, not mistakes; `./gh` and `/usr/bin/gh` still refuse.
Accepted under *"these stop mistakes, not adversaries"*.

## Checks — 11 rows, because the suite had a hole in the permitting direction

CLAUDE.md claims `check-hooks.sh` "checks the boundary in both directions". The
only ALLOW guarding this path was `bash -c "make test"`, which carries neither a
gh-ending word nor a trigger token and so could not have tripped the pattern
under any regex. The new rows pin all three directions: the 6 false refusals,
the 2 path spellings that must still refuse, and the 3 shapes the boundary gives
up.

**Mutation-tested three ways** — the repo's rule is that no fix lands without a
check that fails without it:

| mutation | rows failed | of which new |
|---|---|---|
| restore the defect (no left boundary) | 9 | **9** |
| left *anchor* `(^\|[[:space:]])` instead of a class | 33 | 2 (`./gh`, `/usr/bin/gh`) |
| class widened to admit `-` and `_` | 2 | **2** — invisible to the suite as it stood |

The third mutation is the one that matters: without the new rows nothing in the
suite would have noticed it.

## Review

Both axes of `/code-review` ran. Spec: no findings. Standards: three findings,
all about what the new comments claimed rather than about the rule — a cause
mis-attributed, a "pinned in both directions" that covered two of three shapes,
and a comment pointing at its subject by line count. All three fixed in 698de8f;
the third was fixed by adding the missing row rather than by narrowing the
claim.

## State

- `bash .claude/hooks/check-hooks.sh` — **629 checks, all pass.** The failure #72
  records as pre-existing on `main` is already gone on `dev-05` (8b14525).
- `make test` — 586 passed, 5 recorded xfails.
- **No CLAUDE.md change is owed.** The "if the fix does not land" branch of #72
  asked for a new **Deliberately left open** entry; the fix landed. The fix also
  makes CLAUDE.md's existing "the `pr|release|api` group after a `gh`" true,
  where before it was not.
- No dev-log entry, matching the directly comparable hook PR (#76 / 8b14525).

Refs #72

https://claude.ai/code/session_01DuX7jC6CXMC8SB2PHC1oWb
