### PR TITLE
Convention hooks: close two silent permits, and stop matching a command name as a substring (#69)

### DIFF
--- a/.claude/hooks/alembic-via-uv-group.sh
+++ b/.claude/hooks/alembic-via-uv-group.sh
@@ -47,7 +47,7 @@ fi
 # sanctioned one and is asked for the group; the rest cannot name a dependency
 # group at all, so naming alembic is enough to refuse.
 UV_RUN='^uv[[:space:]]+run([[:space:]]|$)'
-OTHER_RUNNER='^(uvx|uv[[:space:]]+tool[[:space:]]+run|poetry[[:space:]]+run|pdm[[:space:]]+run|hatch[[:space:]]+run|pipenv[[:space:]]+run|rye[[:space:]]+run|conda[[:space:]]+run|nix[[:space:]]+run)([[:space:]]|$)'
+OTHER_RUNNER='^(uvx|uv[[:space:]]+tool[[:space:]]+run|poetry[[:space:]]+run|pdm[[:space:]]+run|hatch[[:space:]]+run|pipenv[[:space:]]+run|rye[[:space:]]+run|conda[[:space:]]+run|micromamba[[:space:]]+run|pixi[[:space:]]+run|pipx[[:space:]]+run|nix[[:space:]]+run)([[:space:]]|$)'
 # A quote ends the name as a space does. See the trade in the companion file.
 NAME='(^|[^A-Za-z0-9_.-])alembic([^A-Za-z0-9_.-]|$)'
 

--- a/.claude/hooks/alembic-via-uv-group.sh
+++ b/.claude/hooks/alembic-via-uv-group.sh
@@ -13,14 +13,22 @@
 # `grep -rn alembic docs/`, `git log --grep alembic` and
 # `echo "we run alembic upgrade head via the group"` were all refused, and the
 # allowlist beneath could not rescue them because prose does not carry
-# `uv run --group migrations`. The companion file carries the fuller note,
-# including why the verdict on a quoted mention depended on which character
-# happened to precede the name; the fix is the same one and is made the same
-# way, because a rule answered twice is how these two came to disagree with the
-# four hooks that already knew the answer.
+# `uv run --group migrations`.
+#
+# The companion file carries the fuller note: why the verdict on a quoted
+# mention depended on which character happened to precede the name, why the
+# rule about runners is a list, why the group must be named before the tool,
+# and what a quote costs as a word boundary. The fix is the same one and is
+# made the same way, deliberately -- a rule answered twice is how these two
+# came to disagree with the four hooks that already knew the answer, and the
+# only honest way to keep them in step is to keep them identical.
 LIB="$(dirname "$0")/lib/command-scan.sh"
 [ -r "$LIB" ] && . "$LIB"
-if ! command -v cs_split >/dev/null 2>&1; then
+# Both functions this file calls, not just the one that names the file's
+# subject. Testing cs_split alone left cs_normalise unguarded, and a library
+# missing only that one permitted a bare `alembic upgrade head` silently.
+if ! command -v cs_split >/dev/null 2>&1 \
+   || ! command -v cs_normalise >/dev/null 2>&1; then
   echo "Blocked: alembic-via-uv-group.sh could not load lib/command-scan.sh, so it cannot tell an alembic invocation from a mention of one. Refusing rather than permitting." >&2
   exit 2
 fi
@@ -35,15 +43,30 @@ if printf '%s\n' "$CMDS" | grep -qE '^alembic([[:space:]]|$)'; then
   exit 2
 fi
 
-# `uv run` that reaches alembic without naming the group. Scoped to the one
-# fragment, so the group has to be named by the command that runs alembic and
-# not merely somewhere on the line, which is what the allowlist asked.
-if printf '%s\n' "$CMDS" \
-   | grep -E '^uv[[:space:]]+run([[:space:]]|$)' \
-   | grep -E '(^|[[:space:]])alembic([[:space:]]|$)' \
-   | grep -qvE -e '--group[[:space:]]+migrations([[:space:]]|$)'; then
-  echo "Blocked: uv run reaches alembic without the 'migrations' dependency group. CLAUDE.md pins Alembic to that group. Run it as: uv run --group migrations alembic <args>" >&2
-  exit 2
-fi
+# A runner standing where a command word goes, naming alembic. `uv run` is the
+# sanctioned one and is asked for the group; the rest cannot name a dependency
+# group at all, so naming alembic is enough to refuse.
+UV_RUN='^uv[[:space:]]+run([[:space:]]|$)'
+OTHER_RUNNER='^(uvx|uv[[:space:]]+tool[[:space:]]+run|poetry[[:space:]]+run|pdm[[:space:]]+run|hatch[[:space:]]+run|pipenv[[:space:]]+run|rye[[:space:]]+run|conda[[:space:]]+run|nix[[:space:]]+run)([[:space:]]|$)'
+# A quote ends the name as a space does. See the trade in the companion file.
+NAME='(^|[^A-Za-z0-9_.-])alembic([^A-Za-z0-9_.-]|$)'
+
+while IFS= read -r FRAGMENT; do
+  echo "$FRAGMENT" | grep -qE "$NAME" || continue
+  if echo "$FRAGMENT" | grep -qE "$OTHER_RUNNER"; then
+    echo "Blocked: that runner reaches alembic outside the 'migrations' dependency group, which it cannot name. CLAUDE.md pins Alembic to that group. Run it as: uv run --group migrations alembic <args>" >&2
+    exit 2
+  fi
+  echo "$FRAGMENT" | grep -qE "$UV_RUN" || continue
+  # Everything before the name. The group has to be an argument of uv, not of
+  # alembic, and this is what tells the two apart.
+  if ! printf '%s' "${FRAGMENT%%alembic*}" \
+       | grep -qE -e '--group[[:space:]]+migrations([[:space:]]|$)'; then
+    echo "Blocked: uv run reaches alembic without the 'migrations' dependency group named first. CLAUDE.md pins Alembic to that group. Run it as: uv run --group migrations alembic <args>" >&2
+    exit 2
+  fi
+done <<CS_FRAGMENTS
+$CMDS
+CS_FRAGMENTS
 
 exit 0

--- a/.claude/hooks/alembic-via-uv-group.sh
+++ b/.claude/hooks/alembic-via-uv-group.sh
@@ -6,14 +6,44 @@
 # A bare `alembic ...` runs outside that group and resolves its environment
 # differently, which is the failure mode the doc warns about. Every sanctioned
 # invocation in CLAUDE.md and pyproject.toml carries `uv run --group migrations`.
+#
+# Issue #69: this hook and pytest-via-uv-group.sh were the two that read a
+# command without knowing where one starts. The name was matched after a
+# separator or any whitespace, so it matched as an ARGUMENT and as PROSE --
+# `grep -rn alembic docs/`, `git log --grep alembic` and
+# `echo "we run alembic upgrade head via the group"` were all refused, and the
+# allowlist beneath could not rescue them because prose does not carry
+# `uv run --group migrations`. The companion file carries the fuller note,
+# including why the verdict on a quoted mention depended on which character
+# happened to precede the name; the fix is the same one and is made the same
+# way, because a rule answered twice is how these two came to disagree with the
+# four hooks that already knew the answer.
+LIB="$(dirname "$0")/lib/command-scan.sh"
+[ -r "$LIB" ] && . "$LIB"
+if ! command -v cs_split >/dev/null 2>&1; then
+  echo "Blocked: alembic-via-uv-group.sh could not load lib/command-scan.sh, so it cannot tell an alembic invocation from a mention of one. Refusing rather than permitting." >&2
+  exit 2
+fi
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+CMDS=$(printf '%s\n' "$COMMAND" | cs_normalise | cs_split)
 
-if echo "$COMMAND" | grep -qE '(^|[;&|]|\s)alembic(\s|$)'; then
-  if ! echo "$COMMAND" | grep -qE 'uv\s+run\s+.*--group\s+migrations'; then
-    echo "Blocked: bare alembic invocation. CLAUDE.md pins Alembic to the 'migrations' dependency group. Run it as: uv run --group migrations alembic <args>" >&2
-    exit 2
-  fi
+# alembic standing where a command word goes.
+if printf '%s\n' "$CMDS" | grep -qE '^alembic([[:space:]]|$)'; then
+  echo "Blocked: bare alembic invocation. CLAUDE.md pins Alembic to the 'migrations' dependency group. Run it as: uv run --group migrations alembic <args>" >&2
+  exit 2
+fi
+
+# `uv run` that reaches alembic without naming the group. Scoped to the one
+# fragment, so the group has to be named by the command that runs alembic and
+# not merely somewhere on the line, which is what the allowlist asked.
+if printf '%s\n' "$CMDS" \
+   | grep -E '^uv[[:space:]]+run([[:space:]]|$)' \
+   | grep -E '(^|[[:space:]])alembic([[:space:]]|$)' \
+   | grep -qvE -e '--group[[:space:]]+migrations([[:space:]]|$)'; then
+  echo "Blocked: uv run reaches alembic without the 'migrations' dependency group. CLAUDE.md pins Alembic to that group. Run it as: uv run --group migrations alembic <args>" >&2
+  exit 2
 fi
 
 exit 0

--- a/.claude/hooks/append-only-docs-edit.sh
+++ b/.claude/hooks/append-only-docs-edit.sh
@@ -44,10 +44,19 @@ FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 # A guarded file reached through a symlink is therefore still permitted; that is
 # a smaller hole than the one being closed, and it is not a spelling anyone
 # writes by accident.
-cs_path_norm() {  # cs_path_norm <absolute path>
+#
+# It carries no cs_ prefix on purpose. That namespace belongs to
+# lib/command-scan.sh, which this hook does not source and which answers a
+# different question -- where a command word is, not what a path reduces to.
+# Its sibling append-only-docs.sh cannot use this function either: the path
+# there is embedded in a command rather than handed over as one, so that file
+# matches the two spellings where they stand and says so.
+norm_path() {  # norm_path <absolute path>
   local seg out="" oldopts=$-
   # The loop splits on / by word splitting, which would also glob each segment
-  # against the tree.
+  # against the tree. Both call sites are command substitutions, so the restore
+  # below has nothing to restore today; it is kept so that a later call which
+  # is NOT a substitution does not leave globbing off for the rest of the hook.
   set -f
   local IFS=/
   for seg in $1; do
@@ -66,8 +75,8 @@ case "$FILE" in
   /*) ABS="$FILE" ;;
   *)  ABS="$ROOT/$FILE" ;;
 esac
-ROOT=$(cs_path_norm "$ROOT")
-ABS=$(cs_path_norm "$ABS")
+ROOT=$(norm_path "$ROOT")
+ABS=$(norm_path "$ABS")
 
 # Anchor to the project root so an identically-named path in another checkout
 # is not caught by a bare substring match. Both sides are normalised first, so

--- a/.claude/hooks/append-only-docs-edit.sh
+++ b/.claude/hooks/append-only-docs-edit.sh
@@ -17,19 +17,61 @@
 # omission is load-bearing rather than incidental: a research document carries
 # [NEEDS OBSERVATION] markers, and clearing one as the observation is made is
 # the edit the directory exists to allow.
+#
+# Issue #69: the project root was stripped off by string prefix and the result
+# anchored at ^docs/, so the comparison was between spellings rather than
+# between paths. Any spelling of a guarded file that did not reduce to that one
+# literal prefix was permitted, on a file that exists -- `./docs/dev-log/<entry>`
+# and `docs/../docs/dev-log/<entry>` both were. A leading `./` is not an evasion;
+# it is an ordinary way to write a relative path, which is the shape of the
+# ordinary mistake this hook exists to stop.
 INPUT=$(cat)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 [ -z "$FILE" ] && exit 0
+
+# Collapse `.`, `..` and repeated slashes, lexically. This is what `realpath -ms`
+# does, written out rather than shelled out to: the hook already depends on jq,
+# and a second external tool would be a second thing that can be absent -- with
+# no answer to what this guard should do when it is, other than refusing every
+# edit in the repository.
+#
+# Lexical, not physical: no symlink is resolved. That is deliberate as well as
+# cheap. Resolving the file and not the root, or either through a root that is
+# itself reached by a symlink, is how the two sides stop being comparable --
+# which is the defect above in a second spelling. Both sides go through the same
+# function here and neither touches the filesystem, so they cannot disagree.
+# A guarded file reached through a symlink is therefore still permitted; that is
+# a smaller hole than the one being closed, and it is not a spelling anyone
+# writes by accident.
+cs_path_norm() {  # cs_path_norm <absolute path>
+  local seg out="" oldopts=$-
+  # The loop splits on / by word splitting, which would also glob each segment
+  # against the tree.
+  set -f
+  local IFS=/
+  for seg in $1; do
+    case "$seg" in
+      ''|.) ;;
+      ..)   out="${out%/*}" ;;
+      *)    out="$out/$seg" ;;
+    esac
+  done
+  case $oldopts in *f*) ;; *) set +f ;; esac
+  printf '%s' "${out:-/}"
+}
 
 ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 case "$FILE" in
   /*) ABS="$FILE" ;;
   *)  ABS="$ROOT/$FILE" ;;
 esac
+ROOT=$(cs_path_norm "$ROOT")
+ABS=$(cs_path_norm "$ABS")
 
 # Anchor to the project root so an identically-named path in another checkout
-# is not caught by a bare substring match.
+# is not caught by a bare substring match. Both sides are normalised first, so
+# what is compared is the path rather than the way it was typed.
 REL="${ABS#"$ROOT"/}"
 
 if echo "$REL" | grep -qE '^docs/(dev-log|lessons-learned|eval-reports)/'; then

--- a/.claude/hooks/append-only-docs.sh
+++ b/.claude/hooks/append-only-docs.sh
@@ -11,15 +11,40 @@
 # one as the observation is made is the edit the directory exists to allow;
 # CLAUDE.md's table marks it "revised in place" for that reason. The same is
 # true of docs/design/. See the companion note in append-only-docs-edit.sh.
+#
+# Issue #69: the directory pattern required a trailing slash, so the removal
+# that destroys the most history was the one thing this hook did not see.
+# `rm -rf docs/dev-log` was permitted and `rm -rf docs/dev-log/` refused -- the
+# same command, one character apart, opposite verdicts, and the permitted half
+# takes every entry with it. The boundary is written out now instead: a slash,
+# or any character that cannot continue a path name, or the end of the string.
+# It is not simply made optional, because `docs/dev-logbook/` is a different
+# directory and must stay untouched.
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 
-APPEND_ONLY='docs/(dev-log|lessons-learned|eval-reports)/'
+# The trailing group is the directory boundary, and it is what #69 was about.
+# `.` and `-` are path-name characters here so that `docs/dev-log.bak` and
+# `docs/dev-logbook` are other paths rather than this one; a quote, a space or
+# a separator ends the name and is matched.
+APPEND_ONLY='docs/(dev-log|lessons-learned|eval-reports)(/|[^A-Za-z0-9_.-]|$)'
 
 if echo "$COMMAND" | grep -qE "$APPEND_ONLY"; then
-  # rm / mv / cp over an existing entry
-  if echo "$COMMAND" | grep -qE "(^|[;&|]|\s)(rm|mv|cp)\s+[^;&|]*$APPEND_ONLY"; then
-    echo "Blocked: removing or overwriting a file under an append-only docs directory. CLAUDE.md treats docs/dev-log/, docs/lessons-learned/ and docs/eval-reports/ as history; corrections belong in a new entry." >&2
+  # rm / mv / cp over an existing entry, or over the directory itself.
+  #
+  # truncate and tee are here because both overwrite an entry in place without
+  # naming a redirect, so the two rules below saw neither: `truncate -s 0` and
+  # `tee <path> < new.md` were both measured permitted in #69. The list is what
+  # has been measured and nothing more -- a verb added on a guess is a rule no
+  # check asks about.
+  #
+  # The trade, taken knowingly: `tee -a` appends, which is the operation this
+  # directory exists to allow, and it is refused here with the truncating
+  # spelling because the verb is read and its options are not. `>>` is the
+  # documented way to append and stays permitted; the check suite pins the
+  # refusal so that it is a decision rather than a surprise.
+  if echo "$COMMAND" | grep -qE "(^|[;&|]|\s)(rm|mv|cp|truncate|tee)\s+[^;&|]*$APPEND_ONLY"; then
+    echo "Blocked: removing or overwriting an append-only docs directory, or a file under one. CLAUDE.md treats docs/dev-log/, docs/lessons-learned/ and docs/eval-reports/ as history; corrections belong in a new entry." >&2
     exit 2
   fi
   # in-place rewrite

--- a/.claude/hooks/append-only-docs.sh
+++ b/.claude/hooks/append-only-docs.sh
@@ -27,7 +27,18 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 # `.` and `-` are path-name characters here so that `docs/dev-log.bak` and
 # `docs/dev-logbook` are other paths rather than this one; a quote, a space or
 # a separator ends the name and is matched.
-APPEND_ONLY='docs/(dev-log|lessons-learned|eval-reports)(/|[^A-Za-z0-9_.-]|$)'
+#
+# The leading `/+(\./+)*` is the same finding on the other side of the slash,
+# found by review of the fix above rather than by the issue. This hook compares
+# spellings, exactly as append-only-docs-edit.sh did before #69 normalised it,
+# and the spellings that a shell reduces to the same directory were permitted:
+# `rm -rf docs//dev-log` and `rm -rf docs/./dev-log` both were. Nothing here
+# can normalise the way the Edit companion does -- the path is embedded in a
+# command rather than handed over as one -- so the two spellings a reader
+# actually writes are matched where they stand. That is a narrower answer than
+# the companion's and it is named as one: `docs/foo/../dev-log` is still
+# permitted, and closing that would mean parsing paths out of shell text.
+APPEND_ONLY='docs/+(\./+)*(dev-log|lessons-learned|eval-reports)(/|[^A-Za-z0-9_.-]|$)'
 
 if echo "$COMMAND" | grep -qE "$APPEND_ONLY"; then
   # rm / mv / cp over an existing entry, or over the directory itself.

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -42,6 +42,15 @@
 # substitution are pinned side by side, because it was the anchor that decided
 # the verdict and that is the part that reads as arbitrary.
 #
+# The append-only checks from issue #69 are the first here that are not about
+# the boundary at all, and they are the same finding a second time: the hooks
+# that carry a convention had been reviewed only in the refusing direction. The
+# permitting direction was swept and `rm -rf docs/dev-log` turned out to be
+# permitted -- with `rm -rf docs/dev-log/`, one character away, refused. So did
+# every spelling of an entry's path that was not the one literal prefix the
+# Edit companion stripped. Neither was in the original report of that issue,
+# and neither had a check.
+#
 # So the number below is not a measure of the boundary. A check suite is
 # evidence about the cases it names and about nothing else, and every case here
 # was named by someone who went looking for one it had missed.
@@ -2333,6 +2342,54 @@ check append-only-docs.sh ALLOW 'sed -i over a research document' \
 check append-only-docs.sh ALLOW 'sed -i over a design document' \
   "sed -i 's/a/b/' docs/design/llm-call-log.md"
 
+echo "=== REGRESSION: #69, the whole-directory case the slash hid ==="
+# The pattern required a trailing slash, so the outer guard never fired on the
+# directory itself and the removal that destroys the most history was the one
+# that passed. Every verdict here was measured on dev-05 at 7cb4891, where the
+# first four were ALLOW. The fifth is the control they sit one character away
+# from, and it was already BLOCK: same command, opposite verdict, on a
+# difference that has nothing to do with what it would run.
+check append-only-docs.sh BLOCK 'rm -rf of the dev-log directory, no trailing slash' \
+  'rm -rf docs/dev-log'
+check append-only-docs.sh BLOCK 'rm -rf of the lessons-learned directory' \
+  'rm -rf docs/lessons-learned'
+check append-only-docs.sh BLOCK 'rm -rf of the eval-reports directory' \
+  'rm -rf docs/eval-reports'
+check append-only-docs.sh BLOCK 'mv of the dev-log directory out from under its name' \
+  'mv docs/dev-log docs/archive'
+check append-only-docs.sh BLOCK 'the control it is one character from' \
+  'rm -rf docs/dev-log/'
+# The boundary is written out rather than made optional, because a directory
+# whose name merely starts with a guarded one is a different directory. These
+# two are what would break if the fix had been `/?`.
+check append-only-docs.sh ALLOW 'a directory whose name only begins with a guarded one' \
+  'rm -rf docs/dev-logbook'
+check append-only-docs.sh ALLOW 'a sibling file whose name begins with a guarded one' \
+  'rm docs/dev-log.bak'
+check append-only-docs.sh ALLOW 'reading the directory is not removing it' \
+  'ls docs/dev-log'
+
+echo "=== REGRESSION: #69, overwriting an entry without naming a redirect ==="
+# Both routes overwrite an existing entry in place and neither was reached by
+# the rm/mv/cp list or by the redirect rule, so both were ALLOW at 7cb4891.
+# The third is the control that was already BLOCK.
+check append-only-docs.sh BLOCK 'truncate over a dev-log entry' \
+  'truncate -s 0 docs/dev-log/devlog_2026-08-25_session-2.md'
+check append-only-docs.sh BLOCK 'tee over a dev-log entry' \
+  'tee docs/dev-log/devlog_2026-08-25_session-2.md < new.md'
+check append-only-docs.sh BLOCK 'the control it sits beside' \
+  ': > docs/dev-log/devlog_2026-08-25_session-2.md'
+
+echo "=== ACCEPTED false positive: #69, tee -a appends and is refused anyway ==="
+# The verb is read and its options are not, so the appending spelling of tee
+# goes with the truncating one. `>>` is the documented way to append and stays
+# permitted, which is the check beneath this one. Written down because a fix
+# that gives up a case has to say which case.
+check append-only-docs.sh BLOCK 'tee -a, which appends, refused with the rest of tee' \
+  'tee -a docs/dev-log/devlog_2026-08-25_session-2.md < new.md'
+check append-only-docs.sh ALLOW 'the append that is documented is still permitted' \
+  'echo x >> docs/dev-log/devlog_2026-08-25_session-2.md'
+
 # The Edit/Write companion reads tool_input.file_path rather than .command, and
 # its verdict turns on whether the file already exists -- so it is asked about
 # real paths in this repository, with CLAUDE_PROJECT_DIR naming the root it
@@ -2368,6 +2425,30 @@ check_file append-only-docs-edit.sh ALLOW 'Edit of a dev-log README that does ex
   'docs/dev-log/README.md'
 check_file append-only-docs-edit.sh ALLOW 'Edit of an existing research document' \
   'docs/research/non-openrouter-response-bodies.md'
+
+echo "=== REGRESSION: #69, a spelling of the path that was not the literal prefix ==="
+# The root was stripped by string prefix and the remainder anchored at ^docs/,
+# so the comparison was between spellings rather than between paths. The first
+# two were ALLOW at 7cb4891, on a file that exists. A leading ./ is not an
+# evasion -- it is an ordinary way to write a relative path, which is the shape
+# of the ordinary mistake this hook is for. The absolute spelling is the
+# control that already worked.
+check_file append-only-docs-edit.sh BLOCK 'Edit of an existing entry written with a leading ./' \
+  './docs/dev-log/devlog_2026-08-25_session-2.md'
+check_file append-only-docs-edit.sh BLOCK 'Edit of an existing entry reached through ..' \
+  'docs/../docs/dev-log/devlog_2026-08-25_session-2.md'
+check_file append-only-docs-edit.sh BLOCK 'Edit of an existing entry with a doubled slash' \
+  'docs//dev-log/devlog_2026-08-25_session-2.md'
+check_file append-only-docs-edit.sh BLOCK 'Edit of an existing entry, absolute spelling' \
+  "$REPO_ROOT/docs/dev-log/devlog_2026-08-25_session-2.md"
+# Normalising must not widen the guarded set: the directories left out of it
+# stay out however the path is written, and a new entry stays writable.
+check_file append-only-docs-edit.sh ALLOW 'Edit of a research document written with a leading ./' \
+  './docs/research/non-openrouter-response-bodies.md'
+check_file append-only-docs-edit.sh ALLOW 'Write of a new entry written with a leading ./' \
+  './docs/dev-log/devlog_2099-01-01_session-1.md'
+check_file append-only-docs-edit.sh ALLOW 'Edit of a README written with a leading ./' \
+  './docs/dev-log/README.md'
 
 echo "=== the arming properties, asserted as literals ==="
 # A second kind of check: the ones above drive a hook as a process and read its

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -2418,6 +2418,55 @@ check pytest-via-uv-group.sh ALLOW 'uv add, which is not uv run' \
 check alembic-via-uv-group.sh ALLOW 'uv add, which is not uv run' \
   'uv add --group migrations alembic'
 
+echo "=== REGRESSION: review of #69, ^ narrowed the guard to one runner ==="
+# The first version of the rule above asked only about `uv run`, and review
+# measured five silent permits against the file it replaced: each of these was
+# BLOCK before the migration, by the substring match, and ALLOW after it. Each
+# really does run the tool outside the group, which is the failure these hooks
+# are for. A runner is a runner however it is spelled, and the list in the
+# hooks is checked member by member here rather than read and believed.
+check pytest-via-uv-group.sh BLOCK 'poetry run' 'poetry run pytest tests/'
+check pytest-via-uv-group.sh BLOCK 'uvx'        'uvx pytest'
+check pytest-via-uv-group.sh BLOCK 'uv tool run' 'uv tool run pytest'
+check pytest-via-uv-group.sh BLOCK 'hatch run'  'hatch run pytest'
+check pytest-via-uv-group.sh BLOCK 'pdm run'    'pdm run pytest'
+check pytest-via-uv-group.sh BLOCK 'pipenv run' 'pipenv run pytest'
+check pytest-via-uv-group.sh BLOCK 'rye run'    'rye run pytest'
+check pytest-via-uv-group.sh BLOCK 'conda run'  'conda run pytest'
+check pytest-via-uv-group.sh BLOCK 'nix run'    'nix run pytest'
+check alembic-via-uv-group.sh BLOCK 'poetry run, alembic' 'poetry run alembic upgrade head'
+check alembic-via-uv-group.sh BLOCK 'uvx, alembic'        'uvx alembic upgrade head'
+
+echo "=== REGRESSION: review of #69, the group was matched after the tool ==="
+# `--group test` was looked for anywhere in the fragment, so the tool's own
+# argument rescued the command and the comment claiming the group had to be
+# named by the runner was false. It is named before the tool now: the fragment
+# is cut at the name and only what precedes it is searched. Both were ALLOW.
+check pytest-via-uv-group.sh BLOCK 'the group as an argument of pytest' \
+  'uv run pytest --group test'
+check alembic-via-uv-group.sh BLOCK 'the group as an argument of alembic' \
+  'uv run alembic upgrade head --group migrations'
+
+echo "=== REGRESSION: review of #69, the intermittency survived inside the rule ==="
+# The same quote-versus-space split the migration was supposed to end, one rule
+# further down: the second rule re-matched the name as an argument with a
+# whitespace-only boundary, so `uv run echo "pytest ..."` was ALLOW or BLOCK
+# according to which character preceded the name. A quote is a word boundary
+# now and the pair agrees. It agrees in the refusing direction, which is the
+# trade the hook's header states: treating quoted text as data would permit
+# `uv run "pytest"`, and that really does run pytest.
+check pytest-via-uv-group.sh BLOCK 'runner, name straight after the quote' \
+  'uv run echo "pytest lives in the test group"'
+check pytest-via-uv-group.sh BLOCK 'runner, name after a space' \
+  'uv run echo "we run pytest via the test group"'
+# The pair the issue reported is at top level, where no rule here reaches it,
+# and it stays permitted. Both halves, because it was the disagreement rather
+# than either verdict that was the defect.
+check pytest-via-uv-group.sh ALLOW 'prose is still prose, name after the quote' \
+  'echo "pytest lives in the test group"'
+check pytest-via-uv-group.sh ALLOW 'prose is still prose, name after a space' \
+  'echo "we run pytest via the test group"'
+
 echo "=== ACCEPTED gap: #69, these two carry no wrapper rule ==="
 # The four boundary hooks refuse a wrapped command outright, because nothing
 # can be read out of a quoted payload. These two do not, and both verdicts
@@ -2441,6 +2490,25 @@ check_in "$ON_DEV" "$FIXTURES/nolib/pytest-via-uv-group.sh" BLOCK \
   'no lib/, pytest-via-uv-group.sh refuses anything at all' 'ls'
 check_in "$ON_DEV" "$FIXTURES/nolib/alembic-via-uv-group.sh" BLOCK \
   'no lib/, alembic-via-uv-group.sh refuses anything at all' 'ls'
+# And a library that is there but missing one of the two functions each file
+# calls. The first version of this guard tested cs_split only -- the function
+# that names the file's subject -- so a library missing cs_normalise left both
+# hooks permitting a bare invocation, silently. Same fixture shape as the
+# cs_git_args one below, and the same reason for it.
+mkdir -p "$FIXTURES/halflib-uv/lib"
+cp pytest-via-uv-group.sh alembic-via-uv-group.sh "$FIXTURES/halflib-uv/"
+sed 's/^cs_normalise()/cs_renamed_away()/' lib/command-scan.sh \
+  > "$FIXTURES/halflib-uv/lib/command-scan.sh"
+# A sed that matched nothing would leave a complete library here, and both
+# checks below would pass without asking anything.
+grep -q '^cs_renamed_away()' "$FIXTURES/halflib-uv/lib/command-scan.sh" || {
+  echo "the half-library fixture still defines cs_normalise; the two checks below prove nothing" >&2
+  exit 1
+}
+check_in "$ON_DEV" "$FIXTURES/halflib-uv/pytest-via-uv-group.sh" BLOCK \
+  'a library missing only cs_normalise, pytest-via-uv-group.sh' 'pytest tests/'
+check_in "$ON_DEV" "$FIXTURES/halflib-uv/alembic-via-uv-group.sh" BLOCK \
+  'a library missing only cs_normalise, alembic-via-uv-group.sh' 'alembic upgrade head'
 
 echo "=== append-only: which docs directories are guarded, and which are not ==="
 # First coverage for append-only-docs.sh and its Edit/Write companion. It was
@@ -2479,6 +2547,12 @@ check append-only-docs.sh BLOCK 'mv of the dev-log directory out from under its 
   'mv docs/dev-log docs/archive'
 check append-only-docs.sh BLOCK 'the control it is one character from' \
   'rm -rf docs/dev-log/'
+# The issue's other control on this rule. An equivalent shape is pinned above
+# on docs/eval-reports/, and it is written out here as well because stage 3
+# asked for the verdicts as the issue measured them: an equivalent is evidence
+# about the rule, and the line is evidence about the report.
+check append-only-docs.sh BLOCK 'rm of a single dev-log entry' \
+  'rm docs/dev-log/x.md'
 # The boundary is written out rather than made optional, because a directory
 # whose name merely starts with a guarded one is a different directory. These
 # two are what would break if the fix had been `/?`.
@@ -2488,6 +2562,29 @@ check append-only-docs.sh ALLOW 'a sibling file whose name begins with a guarded
   'rm docs/dev-log.bak'
 check append-only-docs.sh ALLOW 'reading the directory is not removing it' \
   'ls docs/dev-log'
+
+echo "=== REGRESSION: review of #69, the spellings the Bash side still compared ==="
+# The Edit companion was normalised and this one was not, so the same finding
+# stood on this side of the pair: a spelling a shell reduces to the guarded
+# directory was permitted. All four were ALLOW after the first fix. Nothing
+# here can normalise the way the companion does -- the path is embedded in a
+# command rather than handed over as one -- so the two spellings a reader
+# actually writes are matched where they stand, and `docs/foo/../dev-log`
+# stays permitted, which the hook's comment says in as many words.
+check append-only-docs.sh BLOCK 'a doubled slash before the directory' \
+  'rm -rf docs//dev-log'
+check append-only-docs.sh BLOCK 'a dot segment before the directory' \
+  'rm -rf docs/./dev-log'
+check append-only-docs.sh BLOCK 'a doubled slash on the truncate route' \
+  'truncate -s 0 docs//dev-log/x.md'
+check append-only-docs.sh BLOCK 'a dot segment on the in-place edit route' \
+  'sed -i s/a/b/ docs/./dev-log/x.md'
+# What that widening must not swallow. `docs` and the directory name have to
+# stay two path segments with only slashes and dot segments between them.
+check append-only-docs.sh ALLOW 'no separator at all is a different name' \
+  'rm -rf docsdev-log'
+check append-only-docs.sh ALLOW 'a hyphen is not a path separator' \
+  'rm -rf other/docs-dev-log'
 
 echo "=== REGRESSION: #69, overwriting an entry without naming a redirect ==="
 # Both routes overwrite an existing entry in place and neither was reached by
@@ -3171,10 +3268,20 @@ echo "=== the tokeniser's header names every hook that sources it ==="
 CS_LIB="$HOOKS/lib/command-scan.sh"
 CS_HEADER=$(awk 'NR == 1 { next } /^#$/ { exit } /^#/ { print; next } { exit }' "$CS_LIB")
 CS_NAMED=$(printf '%s\n' "$CS_HEADER" | grep -oE '[A-Za-z0-9_-]+\.sh' | sort -u | tr '\n' ' ')
-# Who actually sources it, read off the disk rather than listed here. The
-# literal is the path as every hook spells it when it assigns LIB.
-CS_SOURCERS=$(grep -lF '/lib/command-scan.sh"' "$HOOKS"/*.sh 2>/dev/null \
-  | sed 's|.*/||' | sort -u | tr '\n' ' ')
+# Who actually sources it, read off the disk rather than listed here.
+#
+# Two questions, answered in the order they bite. The needle is the bare file
+# name rather than the path as a hook spells it when it assigns LIB, because
+# keying on one spelling means a hook that sources it differently drops out of
+# this audit silently -- which is the failure the audit exists for. But the
+# loose needle then matches a file that only MENTIONS the library in a comment,
+# and append-only-docs-edit.sh does exactly that: it says in prose why its path
+# normaliser carries no cs_ prefix. So comments are stripped first, the way
+# `armed` strips them, and what is left is the file as it runs.
+CS_SOURCERS=$(for f in "$HOOKS"/*.sh; do
+    sed 's/[[:space:]]*#.*$//' "$f" 2>/dev/null | grep -qF 'command-scan.sh' \
+      && printf '%s\n' "${f##*/}"
+  done | sort -u | tr '\n' ' ')
 # This suite reads that path too, to run this audit, and it is not a consumer.
 # Named here for the reason NOT_THE_BOUNDARY is named above: the exception is
 # the part that would otherwise be discovered rather than read.

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -42,14 +42,26 @@
 # substitution are pinned side by side, because it was the anchor that decided
 # the verdict and that is the part that reads as arbitrary.
 #
-# The append-only checks from issue #69 are the first here that are not about
-# the boundary at all, and they are the same finding a second time: the hooks
-# that carry a convention had been reviewed only in the refusing direction. The
-# permitting direction was swept and `rm -rf docs/dev-log` turned out to be
-# permitted -- with `rm -rf docs/dev-log/`, one character away, refused. So did
-# every spelling of an entry's path that was not the one literal prefix the
-# Edit companion stripped. Neither was in the original report of that issue,
-# and neither had a check.
+# Issue #69 brought the first checks here that are not about the boundary at
+# all. Four hooks carry a CLAUDE.md convention rather than the agent boundary --
+# pytest-via-uv-group.sh, alembic-via-uv-group.sh, append-only-docs.sh and its
+# Edit companion -- and three of the four had no coverage whatever. What the
+# sweep found in them is the finding this suite keeps making: the reported
+# defect was in the refusing direction, and the serious ones were in the other.
+#
+# The refusing one is that neither uv-group hook sourced lib/command-scan.sh,
+# so a name matched as an argument or as prose and an ordinary
+# `grep -rn pytest docs/` was refused. Intermittently, which is the part worth
+# pinning: the match needed a separator before the name, so a quoted mention
+# was permitted or refused according to whether a quote or a space happened to
+# sit in front of it. Those pairs are checked side by side.
+#
+# The permitting ones were in the append-only guarantee. `rm -rf docs/dev-log`
+# was permitted while `rm -rf docs/dev-log/`, one character away, was refused;
+# truncate and tee overwrote an entry without naming a redirect; and every
+# spelling of an entry's path that did not reduce to the one literal prefix the
+# Edit companion stripped was permitted on a file that exists. None of the
+# three was in the original report of that issue, and none had a check.
 #
 # So the number below is not a measure of the boundary. A check suite is
 # evidence about the cases it names and about nothing else, and every case here
@@ -2322,6 +2334,114 @@ grep -q '^cs_renamed_away()' "$FIXTURES/halflib/lib/command-scan.sh" || {
 check_in "$WT_STALE" "$FIXTURES/halflib/no-work-on-stale-branch.sh" BLOCK 'a library missing only cs_git_args' \
   'git commit -m "wip"'
 
+echo "=== REGRESSION: #69, a command name matched as a substring ==="
+# First coverage of any kind for these two hooks. Neither sourced
+# lib/command-scan.sh, so neither knew where a command word was, and the name
+# matched as an argument and as prose. Every verdict here was measured on
+# dev-05 at 7cb4891, where the six below were BLOCK -- ordinary greps and
+# git log invocations, refused for naming the tool they search for.
+check pytest-via-uv-group.sh ALLOW 'grep for pytest in the docs' \
+  'grep -rn pytest docs/'
+check pytest-via-uv-group.sh ALLOW 'grep for pytest after a pipe' \
+  'ls tests/ | grep pytest'
+check pytest-via-uv-group.sh ALLOW 'git log searching for pytest' \
+  'git log --grep pytest'
+check alembic-via-uv-group.sh ALLOW 'grep for alembic in the docs' \
+  'grep -rn alembic docs/'
+check alembic-via-uv-group.sh ALLOW 'git log searching for alembic' \
+  'git log --grep alembic'
+check alembic-via-uv-group.sh ALLOW 'prose naming the sanctioned invocation' \
+  'echo "we run alembic upgrade head via the group"'
+# The pair that made the old behaviour intermittent, kept side by side. Both
+# were prose; the first was permitted only because a quote sat in front of the
+# name and a quote is not in the separator class, and the second was refused
+# because a space did. Same sentence shape, opposite verdicts. They are one
+# verdict now, and it is the pair rather than either one that says so.
+check pytest-via-uv-group.sh ALLOW 'prose, name straight after the quote' \
+  'echo "pytest lives in the test group"'
+check pytest-via-uv-group.sh ALLOW 'prose, name after a space' \
+  'echo "we run pytest via the test group"'
+
+echo "=== the controls those two hooks are for, which keep their verdicts ==="
+check pytest-via-uv-group.sh BLOCK 'bare pytest' \
+  'pytest tests/'
+check pytest-via-uv-group.sh BLOCK 'bare python -m pytest' \
+  'python -m pytest tests/'
+check pytest-via-uv-group.sh ALLOW 'the sanctioned invocation' \
+  'uv run --group test pytest tests/'
+check pytest-via-uv-group.sh ALLOW 'make test, which is that invocation' \
+  'make test'
+check alembic-via-uv-group.sh BLOCK 'bare alembic' \
+  'alembic upgrade head'
+check alembic-via-uv-group.sh BLOCK 'bare alembic as the second command' \
+  'cd x && alembic upgrade head'
+check alembic-via-uv-group.sh ALLOW 'the sanctioned invocation' \
+  'uv run --group migrations alembic upgrade head'
+# A command word is a command word wherever cs_split finds one. These are the
+# shapes that library was written for, asked of these two hooks for the first
+# time.
+check pytest-via-uv-group.sh BLOCK 'bare pytest behind a wrapper word' \
+  'sudo pytest tests/'
+check pytest-via-uv-group.sh BLOCK 'bare pytest behind a wrapper with an operand' \
+  'timeout 30 pytest tests/'
+check pytest-via-uv-group.sh BLOCK 'bare pytest after a control word' \
+  'if true; then pytest tests/; fi'
+check pytest-via-uv-group.sh ALLOW 'the sanctioned invocation behind a wrapper' \
+  'timeout 300 uv run --group test pytest tests/'
+check pytest-via-uv-group.sh ALLOW 'and behind a wrapper whose option takes a value' \
+  'sudo -u me uv run --group test pytest tests/'
+
+echo "=== #69, what the deleted allowlist covered, asked of the rule that replaced it ==="
+# The allowlist is gone: with the command word at ^, `uv run --group test
+# pytest` never matches the first rule, so there was nothing left to rescue.
+# But `uv run pytest` was refused by it and has to stay refused -- it runs
+# pytest outside the group, which is the failure these hooks are about. The
+# group is asked for on the `uv run` fragment now rather than anywhere on the
+# line, which is the part the allowlist got wrong and which the last two of
+# these pin.
+check pytest-via-uv-group.sh BLOCK 'uv run reaching pytest with no group named' \
+  'uv run pytest tests/'
+check pytest-via-uv-group.sh BLOCK 'uv run naming the wrong group' \
+  'uv run --group dev pytest tests/'
+check pytest-via-uv-group.sh BLOCK 'uv run reaching python -m pytest with no group' \
+  'uv run python -m pytest tests/'
+check alembic-via-uv-group.sh BLOCK 'uv run reaching alembic with no group named' \
+  'uv run alembic upgrade head'
+check pytest-via-uv-group.sh ALLOW 'uv run naming the group, reaching python -m pytest' \
+  'uv run --group test python -m pytest tests/test_chunker.py'
+# uv subcommands that are not `run` install or add a package rather than
+# running one, and naming pytest is what they are for.
+check pytest-via-uv-group.sh ALLOW 'uv pip install, which is not uv run' \
+  'uv pip install pytest'
+check pytest-via-uv-group.sh ALLOW 'uv add, which is not uv run' \
+  'uv add --group test pytest'
+check alembic-via-uv-group.sh ALLOW 'uv add, which is not uv run' \
+  'uv add --group migrations alembic'
+
+echo "=== ACCEPTED gap: #69, these two carry no wrapper rule ==="
+# The four boundary hooks refuse a wrapped command outright, because nothing
+# can be read out of a quoted payload. These two do not, and both verdicts
+# below were ALLOW before this change as well -- by accident rather than by
+# decision, on the same quote that made the prose pair above disagree. It stays
+# a gap rather than becoming a rule: CLAUDE.md's boundary is what a wrapper
+# rule protects, and a dependency group is a convention, so refusing every
+# `bash -c` in the repository would cost more than the convention is worth.
+check pytest-via-uv-group.sh ALLOW 'a wrapped bare pytest is not read' \
+  'bash -c "pytest tests/"'
+check alembic-via-uv-group.sh ALLOW 'a wrapped bare alembic is not read' \
+  'sh -c "alembic upgrade head"'
+
+echo "=== #69, the two convention hooks fail closed without the tokeniser ==="
+# They depend on lib/command-scan.sh now, so they answer the question the
+# boundary hooks already answer: a guard's own breakage refuses. Without this
+# the sourcing would leave cs_split undefined, the fragment list empty and
+# every bare invocation permitted.
+cp pytest-via-uv-group.sh alembic-via-uv-group.sh "$FIXTURES/nolib/"
+check_in "$ON_DEV" "$FIXTURES/nolib/pytest-via-uv-group.sh" BLOCK \
+  'no lib/, pytest-via-uv-group.sh refuses anything at all' 'ls'
+check_in "$ON_DEV" "$FIXTURES/nolib/alembic-via-uv-group.sh" BLOCK \
+  'no lib/, alembic-via-uv-group.sh refuses anything at all' 'ls'
+
 echo "=== append-only: which docs directories are guarded, and which are not ==="
 # First coverage for append-only-docs.sh and its Edit/Write companion. It was
 # added with issue #61, which put a comment in both files saying docs/research/
@@ -3032,6 +3152,51 @@ written 'and leaves the unclassified alone' \
 # leave the claim behind it as false as it was. Pinned for that reason.
 written 'the sweep says how often it is run, which is by hand and never' \
   "$SWEEP_SECTION" 'Cadence: manual, and unscheduled'
+echo "=== the tokeniser's header names every hook that sources it ==="
+# The same audit the section above gets, pointed at the one other sentence in
+# this tree that claims to list the hooks. lib/command-scan.sh opens "which is
+# every hook that reads a command", and that claim has now gone stale twice:
+# #63 found it naming three of the four that sourced the file, and #69 found
+# two more that read a command and were not on the list because they did not
+# source it at all -- true of the hooks it knew about, false of the repository.
+# A sentence that has gone stale twice is checked rather than maintained.
+#
+# It sits here, after the section above, because it uses that section's
+# `present`. Written where it belongs by subject, it ran before the helper
+# existed: twelve `present: command not found` lines, no FAILED set, and the
+# suite green. A check that cannot fail is the thing this file is most for.
+#
+# The paragraph is the first comment block, which is where the claim is made;
+# the rest of the header is history and names files for other reasons.
+CS_LIB="$HOOKS/lib/command-scan.sh"
+CS_HEADER=$(awk 'NR == 1 { next } /^#$/ { exit } /^#/ { print; next } { exit }' "$CS_LIB")
+CS_NAMED=$(printf '%s\n' "$CS_HEADER" | grep -oE '[A-Za-z0-9_-]+\.sh' | sort -u | tr '\n' ' ')
+# Who actually sources it, read off the disk rather than listed here. The
+# literal is the path as every hook spells it when it assigns LIB.
+CS_SOURCERS=$(grep -lF '/lib/command-scan.sh"' "$HOOKS"/*.sh 2>/dev/null \
+  | sed 's|.*/||' | sort -u | tr '\n' ' ')
+# This suite reads that path too, to run this audit, and it is not a consumer.
+# Named here for the reason NOT_THE_BOUNDARY is named above: the exception is
+# the part that would otherwise be discovered rather than read.
+CS_SOURCERS=$(printf '%s' " $CS_SOURCERS " | sed 's| check-hooks.sh | |')
+[ -n "$CS_NAMED" ] && [ -n "$CS_SOURCERS" ] || {
+  echo "no hook names were read out of the tokeniser header or off the disk; the checks below prove nothing" >&2
+  exit 1
+}
+set -f
+for hook in $CS_SOURCERS; do
+  present "the header names $hook, which sources the tokeniser" "$hook" "$CS_NAMED"
+done
+# The other direction: a name in the paragraph that no longer sources the file.
+# check-hooks.sh is named in it as the thing running this audit, which is why it
+# is dropped from the list above rather than from the paragraph.
+for hook in $CS_NAMED; do
+  case "$hook" in check-hooks.sh|command-scan.sh) continue ;; esac
+  present "the header names $hook, and that file sources the tokeniser" \
+          "$hook" "$CS_SOURCERS"
+done
+set +f
+
 echo
 if [ $FAILED -eq 0 ]; then echo "ALL CHECKS PASSED"; else echo "SOME CHECKS FAILED"; fi
 exit $FAILED

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -2488,6 +2488,56 @@ check pytest-via-uv-group.sh BLOCK 'nix run'    'nix run pytest'
 check alembic-via-uv-group.sh BLOCK 'poetry run, alembic' 'poetry run alembic upgrade head'
 check alembic-via-uv-group.sh BLOCK 'uvx, alembic'        'uvx alembic upgrade head'
 
+echo "=== REGRESSION: review of the #69 PR, the list stopped one family early ==="
+# Review of the fix above found three more, each the sibling of something
+# already on the list: pipx run beside uvx and uv tool run, micromamba run
+# beside conda run, pixi run beside poetry run. All three were BLOCK on dev-05
+# by the substring match and ALLOW once the rule became a list. Recorded as the
+# same finding twice, because that is what it is: narrowing a substring match
+# to a list costs whatever the list omits, and what it omits is found by
+# someone asking rather than by the rule.
+check pytest-via-uv-group.sh BLOCK 'pipx run'       'pipx run pytest'
+check pytest-via-uv-group.sh BLOCK 'micromamba run' 'micromamba run pytest'
+check pytest-via-uv-group.sh BLOCK 'pixi run'       'pixi run pytest'
+check alembic-via-uv-group.sh BLOCK 'pipx run, alembic'       'pipx run alembic upgrade head'
+check alembic-via-uv-group.sh BLOCK 'micromamba run, alembic' 'micromamba run alembic upgrade head'
+check alembic-via-uv-group.sh BLOCK 'pixi run, alembic'       'pixi run alembic upgrade head'
+
+echo "=== ACCEPTED gap: a wrapper word is not a runner, and belongs in #79 ==="
+# These two reach pytest as well, and neither is a runner in the sense the list
+# above means: they take no subcommand and simply run the words after them,
+# which is what cs_split calls a wrapper word and already strips for `time`,
+# `sudo` and the rest. Naming them in the runner list would answer "what is a
+# wrapper word" in a third place -- the habit lib/command-scan.sh exists to end
+# -- and would fix these two hooks while leaving the four boundary hooks just
+# as blind to `xvfb-run git push --all origin`.
+#
+# So they are pinned as permitted rather than fixed here, and the pin is the
+# point: when #79 adds them to cs_split's wrapper list these two flip to BLOCK,
+# and that is the intended outcome rather than a regression. Change them there.
+check pytest-via-uv-group.sh ALLOW 'xvfb-run, a wrapper word cs_split does not strip' \
+  'xvfb-run pytest tests/'
+check pytest-via-uv-group.sh ALLOW 'watch, the same shape' \
+  'watch pytest'
+# The contrast that says why those two are a wrapper question and not a runner
+# question: a wrapper word cs_split DOES strip leaves the command word at ^,
+# and the first rule refuses it with no list involved.
+check pytest-via-uv-group.sh BLOCK 'time, which cs_split does strip' \
+  'time pytest tests/'
+
+echo "=== REGRESSION: #69, the allowlist was matched against the whole string ==="
+# Not named in the PR body, and a silent permit on dev-05 rather than a false
+# refusal: the old allowlist asked whether `uv run ... --group test` appeared
+# anywhere in the command, so one sanctioned invocation rescued a bare one
+# beside it, and a `cd` in front of a bare one did too. Both were ALLOW there.
+# cs_split judges each command on its own, so neither rescue survives.
+check pytest-via-uv-group.sh BLOCK 'a cd in front of a bare pytest' \
+  'cd tests && pytest'
+check pytest-via-uv-group.sh BLOCK 'a sanctioned invocation rescuing a bare one' \
+  'uv run --group test pytest && pytest tests/'
+check alembic-via-uv-group.sh BLOCK 'the same rescue, alembic' \
+  'uv run --group migrations alembic upgrade head && alembic downgrade -1'
+
 echo "=== REGRESSION: review of #69, the group was matched after the tool ==="
 # `--group test` was looked for anywhere in the fragment, so the tool's own
 # argument rescued the command and the comment claiming the group had to be

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
 # Where a command starts, where its arguments end, and how many commands a
-# string holds. Sourced by no-git-push.sh, no-pr-decisions.sh, and since issue
-# #43 no-commit-to-main.sh and since #44 no-work-on-stale-branch.sh -- which is
-# every hook that reads a command. Issue #63 found this line naming three of the
-# four, the same way it found CLAUDE.md's boundary section naming two of them: a
+# string holds. Sourced by no-git-push.sh, no-pr-decisions.sh, since issue #43
+# no-commit-to-main.sh, since #44 no-work-on-stale-branch.sh, and since #69
+# pytest-via-uv-group.sh and alembic-via-uv-group.sh -- which is every hook that
+# reads a command. Issue #63 found this line naming three of the four there were
+# then, the same way it found CLAUDE.md's boundary section naming two of them: a
 # hook is added, and the sentence saying which hooks there are is not revised
-# with it.
+# with it. #69 found it a second time from the other end -- two hooks that read
+# a command and were not on the list because they did not source this file at
+# all, so the sentence was true of the hooks it knew about and false of the
+# repository. It is checked now rather than maintained: check-hooks.sh reads
+# which files source this one and asserts that this paragraph names each.
+#
+# The last two are the only consumers that are not part of the agent boundary.
+# They enforce a CLAUDE.md convention -- a dependency group -- and the
+# difference shows in what they do not have: no wrapper rule, because a quoted
+# payload is not worth refusing every `bash -c` over. Their fail-closed
+# behaviour is the same as the others', for the same reason.
 #
 # This exists because of what the defects in PR #35 turned out to have in
 # common. Every one of them, found by Bertan or by the assistant, was the same

--- a/.claude/hooks/pytest-via-uv-group.sh
+++ b/.claude/hooks/pytest-via-uv-group.sh
@@ -33,6 +33,25 @@
 # runner not on it is permitted; the check suite names each member so that the
 # list is read rather than discovered.
 #
+# Review of #69 then found the list one family short -- `pipx run` alongside
+# `uvx` and `uv tool run`, `micromamba run` alongside `conda run`, `pixi run`
+# alongside `poetry run`. Each was the sibling of something already on it, so
+# the list had stopped where the writing stopped rather than where the question
+# does. Worth recording as the same finding twice: narrowing a substring match
+# to a list costs whatever the list omits, and the omissions are found by
+# someone asking, not by the rule.
+#
+# Two things it still omits, and on purpose. `xvfb-run pytest` and
+# `watch pytest` reach pytest as well, but neither is a runner in this sense:
+# they take no subcommand and simply run the words after them, which is what
+# cs_split calls a wrapper word and already strips for `time`, `sudo` and the
+# rest. Naming them here would answer "what is a wrapper word" in a third
+# place, which is the habit lib/command-scan.sh exists to end, and would fix
+# these two hooks while leaving the four boundary hooks just as blind. They
+# belong in that list, which is issue #79. The check suite pins both as
+# permitted so the gap is visible; when #79 adds them, those two checks flip to
+# BLOCK and that is the intended outcome, not a regression.
+#
 # Two things that list is not. It is not the tool's own arguments: `--group
 # test` has to be named BEFORE pytest, or `uv run pytest --group test` passes
 # the option to pytest and reads as sanctioned. The prefix is cut at the name
@@ -76,7 +95,7 @@ fi
 # sanctioned one and is asked for the group; the rest cannot name a dependency
 # group at all, so naming pytest is enough to refuse.
 UV_RUN='^uv[[:space:]]+run([[:space:]]|$)'
-OTHER_RUNNER='^(uvx|uv[[:space:]]+tool[[:space:]]+run|poetry[[:space:]]+run|pdm[[:space:]]+run|hatch[[:space:]]+run|pipenv[[:space:]]+run|rye[[:space:]]+run|conda[[:space:]]+run|nix[[:space:]]+run)([[:space:]]|$)'
+OTHER_RUNNER='^(uvx|uv[[:space:]]+tool[[:space:]]+run|poetry[[:space:]]+run|pdm[[:space:]]+run|hatch[[:space:]]+run|pipenv[[:space:]]+run|rye[[:space:]]+run|conda[[:space:]]+run|micromamba[[:space:]]+run|pixi[[:space:]]+run|pipx[[:space:]]+run|nix[[:space:]]+run)([[:space:]]|$)'
 # A quote ends the name as a space does. See the trade above.
 NAME='(^|[^A-Za-z0-9_.-])pytest([^A-Za-z0-9_.-]|$)'
 

--- a/.claude/hooks/pytest-via-uv-group.sh
+++ b/.claude/hooks/pytest-via-uv-group.sh
@@ -20,21 +20,43 @@
 # nothing to do with what the command would run.
 #
 # Saying where a command word is is cs_split's job, and this file asks it now
-# rather than answering it again. That is the whole of the fix: with the
-# command word at ^, an argument and a mention are no longer command positions.
+# rather than answering it again. That is the first rule below.
 #
-# The allowlist went with it, and its replacement is worth writing down because
-# it is not simply a deletion. `uv run --group test pytest tests/` has `uv` as
-# its command word and never matches the first rule, so the rescue had nothing
-# left to rescue. But `uv run pytest` also has `uv` as its command word, and
-# that one was refused before and has to stay refused -- it runs pytest outside
-# the group, which is the failure this hook is about. So the group is asked for
-# on the `uv run` fragment itself, where cs_split has already bounded the
-# arguments to one command, rather than anywhere on the line the way the
-# allowlist did. `uv pip install pytest` is not `uv run` and is untouched.
+# The second rule is the one that took two goes, and what it has to do is not
+# what the old allowlist did. Anchoring at ^ answers "is pytest the command
+# word", and a runner answers that question with its own name: `uv run pytest`,
+# `uvx pytest` and `poetry run pytest` each run pytest outside the group --
+# the failure this hook exists for -- while putting `uv`, `uvx` or `poetry` at
+# ^. The first version of this rule asked only about `uv run`, and review
+# measured four silent permits against the file it replaced. So a runner is a
+# runner however it is spelled, and the list is below. It IS a list, and a
+# runner not on it is permitted; the check suite names each member so that the
+# list is read rather than discovered.
+#
+# Two things that list is not. It is not the tool's own arguments: `--group
+# test` has to be named BEFORE pytest, or `uv run pytest --group test` passes
+# the option to pytest and reads as sanctioned. The prefix is cut at the name
+# for that reason. And it is not every uv subcommand: `uv pip install pytest`
+# and `uv add --group test pytest` install a package rather than running one,
+# which is what naming pytest is for, and neither is a runner.
+#
+# The trade, taken knowingly. A quote is a word boundary here, so the name is
+# found inside a quoted argument to a runner and `uv run echo "pytest lives in
+# the test group"` is refused. The alternative was to treat quoted text as
+# data, and that permits `uv run "pytest"`, which really does run pytest. This
+# file refuses both spellings of the prose rather than permitting one real
+# invocation -- the direction lib/command-scan.sh takes throughout, and the one
+# that makes the pair AGREE. The intermittency above was the defect; which way
+# the pair settles is the smaller question. `echo "pytest lives in the test
+# group"` on its own is untouched: its command word is echo, and no rule here
+# reaches it.
 LIB="$(dirname "$0")/lib/command-scan.sh"
 [ -r "$LIB" ] && . "$LIB"
-if ! command -v cs_split >/dev/null 2>&1; then
+# Both functions this file calls, not just the one that names the file's
+# subject. Testing cs_split alone left cs_normalise unguarded, and a library
+# missing only that one permitted a bare `pytest tests/` silently.
+if ! command -v cs_split >/dev/null 2>&1 \
+   || ! command -v cs_normalise >/dev/null 2>&1; then
   echo "Blocked: pytest-via-uv-group.sh could not load lib/command-scan.sh, so it cannot tell a pytest invocation from a mention of one. Refusing rather than permitting." >&2
   exit 2
 fi
@@ -50,13 +72,30 @@ if printf '%s\n' "$CMDS" \
   exit 2
 fi
 
-# `uv run` that reaches pytest without naming the group.
-if printf '%s\n' "$CMDS" \
-   | grep -E '^uv[[:space:]]+run([[:space:]]|$)' \
-   | grep -E '(^|[[:space:]])pytest([[:space:]]|$)' \
-   | grep -qvE -e '--group[[:space:]]+test([[:space:]]|$)'; then
-  echo "Blocked: uv run reaches pytest without the 'test' dependency group. CLAUDE.md runs tests through that group. Use: make test, or uv run --group test pytest tests/<file>::<test>" >&2
-  exit 2
-fi
+# A runner standing where a command word goes, naming pytest. `uv run` is the
+# sanctioned one and is asked for the group; the rest cannot name a dependency
+# group at all, so naming pytest is enough to refuse.
+UV_RUN='^uv[[:space:]]+run([[:space:]]|$)'
+OTHER_RUNNER='^(uvx|uv[[:space:]]+tool[[:space:]]+run|poetry[[:space:]]+run|pdm[[:space:]]+run|hatch[[:space:]]+run|pipenv[[:space:]]+run|rye[[:space:]]+run|conda[[:space:]]+run|nix[[:space:]]+run)([[:space:]]|$)'
+# A quote ends the name as a space does. See the trade above.
+NAME='(^|[^A-Za-z0-9_.-])pytest([^A-Za-z0-9_.-]|$)'
+
+while IFS= read -r FRAGMENT; do
+  echo "$FRAGMENT" | grep -qE "$NAME" || continue
+  if echo "$FRAGMENT" | grep -qE "$OTHER_RUNNER"; then
+    echo "Blocked: that runner reaches pytest outside the 'test' dependency group, which it cannot name. CLAUDE.md runs tests through that group. Use: make test, or uv run --group test pytest tests/<file>::<test>" >&2
+    exit 2
+  fi
+  echo "$FRAGMENT" | grep -qE "$UV_RUN" || continue
+  # Everything before the name. The group has to be an argument of uv, not of
+  # pytest, and this is what tells the two apart.
+  if ! printf '%s' "${FRAGMENT%%pytest*}" \
+       | grep -qE -e '--group[[:space:]]+test([[:space:]]|$)'; then
+    echo "Blocked: uv run reaches pytest without the 'test' dependency group named first. CLAUDE.md runs tests through that group. Use: make test, or uv run --group test pytest tests/<file>::<test>" >&2
+    exit 2
+  fi
+done <<CS_FRAGMENTS
+$CMDS
+CS_FRAGMENTS
 
 exit 0

--- a/.claude/hooks/pytest-via-uv-group.sh
+++ b/.claude/hooks/pytest-via-uv-group.sh
@@ -6,14 +6,57 @@
 # Deliberately narrow: bare `python -m src.scripts...` and
 # `python -m src.eval.golden_qa` are the documented forms for the corpus and
 # eval entry points and are not matched here.
+#
+# Issue #69: this hook and alembic-via-uv-group.sh were the two that read a
+# command without knowing where one starts. The name was matched after a
+# separator or any whitespace, so it matched as an ARGUMENT and as PROSE --
+# `grep -rn pytest docs/`, `ls tests/ | grep pytest` and `git log --grep pytest`
+# were all refused, and the allowlist beneath could not rescue them because
+# prose does not carry `uv run --group test`. Worse than the refusal is that it
+# was intermittent: the match needed a separator in front of the name, so
+# `echo "pytest lives in the test group"` was permitted only because a quote
+# happens not to be in the class, while the same sentence shape with a space
+# there was refused. Same shape, opposite verdict, on a difference that has
+# nothing to do with what the command would run.
+#
+# Saying where a command word is is cs_split's job, and this file asks it now
+# rather than answering it again. That is the whole of the fix: with the
+# command word at ^, an argument and a mention are no longer command positions.
+#
+# The allowlist went with it, and its replacement is worth writing down because
+# it is not simply a deletion. `uv run --group test pytest tests/` has `uv` as
+# its command word and never matches the first rule, so the rescue had nothing
+# left to rescue. But `uv run pytest` also has `uv` as its command word, and
+# that one was refused before and has to stay refused -- it runs pytest outside
+# the group, which is the failure this hook is about. So the group is asked for
+# on the `uv run` fragment itself, where cs_split has already bounded the
+# arguments to one command, rather than anywhere on the line the way the
+# allowlist did. `uv pip install pytest` is not `uv run` and is untouched.
+LIB="$(dirname "$0")/lib/command-scan.sh"
+[ -r "$LIB" ] && . "$LIB"
+if ! command -v cs_split >/dev/null 2>&1; then
+  echo "Blocked: pytest-via-uv-group.sh could not load lib/command-scan.sh, so it cannot tell a pytest invocation from a mention of one. Refusing rather than permitting." >&2
+  exit 2
+fi
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+CMDS=$(printf '%s\n' "$COMMAND" | cs_normalise | cs_split)
 
-if echo "$COMMAND" | grep -qE '(^|[;&|]|\s)(pytest|python[0-9.]*\s+-m\s+pytest)(\s|$)'; then
-  if ! echo "$COMMAND" | grep -qE 'uv\s+run\s+.*--group\s+test|make\s+test'; then
-    echo "Blocked: bare pytest invocation. CLAUDE.md runs tests through the 'test' dependency group. Use: make test, or uv run --group test pytest tests/<file>::<test>" >&2
-    exit 2
-  fi
+# pytest, or python -m pytest, standing where a command word goes.
+if printf '%s\n' "$CMDS" \
+   | grep -qE '^(pytest|python[0-9.]*[[:space:]]+-m[[:space:]]+pytest)([[:space:]]|$)'; then
+  echo "Blocked: bare pytest invocation. CLAUDE.md runs tests through the 'test' dependency group. Use: make test, or uv run --group test pytest tests/<file>::<test>" >&2
+  exit 2
+fi
+
+# `uv run` that reaches pytest without naming the group.
+if printf '%s\n' "$CMDS" \
+   | grep -E '^uv[[:space:]]+run([[:space:]]|$)' \
+   | grep -E '(^|[[:space:]])pytest([[:space:]]|$)' \
+   | grep -qvE -e '--group[[:space:]]+test([[:space:]]|$)'; then
+  echo "Blocked: uv run reaches pytest without the 'test' dependency group. CLAUDE.md runs tests through that group. Use: make test, or uv run --group test pytest tests/<file>::<test>" >&2
+  exit 2
 fi
 
 exit 0


### PR DESCRIPTION
Fixes the three defects in issue #69, in the order the issue sets: the silent
permits first, the substring match second, the checks alongside each.

The four hooks here enforce CLAUDE.md *conventions* — dependency groups and
append-only history — rather than the agent boundary. Three of the four had no
coverage of any kind before this.

### Stage 1 — the silent permits (76a3eb8)

`append-only-docs.sh` matched the guarded directories only with a trailing
slash, so the outer guard never fired on the directory itself:

    ALLOW  rm -rf docs/dev-log
    BLOCK  rm -rf docs/dev-log/

Same command, one character apart, opposite verdicts, and the permitted half
takes every entry with it. The boundary is written out rather than made
optional, so `docs/dev-logbook` and `docs/dev-log.bak` stay other paths.
`truncate` and `tee` join the verb list: both overwrite an entry in place while
naming no redirect, so neither of the other rules saw them.

`append-only-docs-edit.sh` stripped the project root by string prefix and
anchored the remainder at `^docs/`, so it compared spellings rather than paths.
`./docs/dev-log/<entry>` and `docs/../docs/dev-log/<entry>` were permitted on a
file that exists. Both sides are normalised lexically now, by a function that
touches no filesystem, so the two cannot disagree.

### Stage 2 — the substring match (193510c)

These were the last two hooks reading a command without sourcing
`lib/command-scan.sh`, so each matched its name as an argument and as prose —
ordinary `grep`s and `git log`s refused. Intermittently: the match needed a
separator before the name, so a quoted mention was permitted or refused
according to whether a quote or a space happened to precede it. Both files
route through `cs_normalise | cs_split` and anchor at `^`.

The tokeniser's own header claimed to name every hook that reads a command, and
#63 had already found it stale once. It is checked now rather than maintained:
the suite reads which files source the library and asserts the paragraph names
each, in both directions.

### The review round (18bf1d8)

Five findings, four of them permitting and all four introduced by the two
commits above.

- Anchoring at `^` narrowed the guard to one runner: `poetry run pytest`,
  `uvx pytest`, `hatch run pytest`, `uv tool run pytest` and
  `poetry run alembic upgrade head` were BLOCK before the migration and ALLOW
  after it.
- `--group` was matched anywhere in the fragment, so the tool's own argument
  rescued the command — `uv run pytest --group test` was permitted while the
  comment beside the rule claimed otherwise.
- The intermittency the migration was meant to end survived one rule further
  down, in the file that had just fixed it.
- The fail-closed guard tested `cs_split` only, while both hooks also call
  `cs_normalise`; a library missing just that one permitted a bare `pytest`.
- Stage 1 normalised the Edit side and left the Bash side comparing spellings:
  `rm -rf docs//dev-log` and `rm -rf docs/./dev-log` were permitted.

### The review's finding (4d4b73d)

The runner list stopped one family early. `pipx run`, `micromamba run` and
`pixi run` were BLOCK on `dev-05` by the substring match and ALLOW once the rule
became a list, each being the sibling of something already on it. Now listed,
with six checks.

`xvfb-run` and `watch` reach pytest too and are deliberately **not** fixed here:
they take no subcommand and simply run the words after them, which is what
`cs_split` calls a wrapper word and already strips for `time`. They belong in
that list, which is #79 and in flight. Both are pinned as permitted, with
`time pytest tests/` pinned beside them as the contrast — when #79 adds them,
those two checks flip to BLOCK, which is intended rather than a regression.

Two silent permits on `dev-05` that the sections above did not claim are also
pinned now: the old allowlist was matched against the whole string, so
`cd tests && pytest` and `uv run --group test pytest && pytest tests/` were both
permitted.

### Evidence

`bash .claude/hooks/check-hooks.sh` — ALL CHECKS PASSED, 830 checks. Every
verdict the issue measured is pinned, in both directions, plus the review
round's.

Each fix was mutation-checked separately, and each turns exactly its own group
red: the directory boundary → the four whole-directory cases; the verb list →
the three in-place ones; the path normalisation → the three spellings; reading
the raw command → the three wrapper and control-word cases; the substring match
→ ten; the `uv run` rule → three; the runner list → eleven; the group prefix →
two; the word boundary → the one half of the pair that was permitted; the
leading-slash widening → four; guarding `cs_split` alone → two; dropping the two
new names from the tokeniser header → those two.

`make test`: 591 passed, 5 xfailed. `make audit`: no issues. No dependency
changed on this branch.

### Deliberately not done

`report-stale-branches.sh` reads no command — it is a reporter, not a guard —
and the issue records it as correctly out of scope.

Three trades are taken knowingly and each is a check rather than a silence:
`tee -a` appends and is refused with the rest of `tee`; a quote is a word
boundary, so `uv run echo "pytest …"` is refused rather than permitting
`uv run "pytest"`; and these two hooks carry no wrapper rule, so
`bash -c "pytest tests/"` is not read — as it was not before.

https://claude.ai/code/session_01TJLh3YRWhAAE98qMrtMmQ5
