### PR TITLE
Log score_retrieval's diagnostics, keeping the report alone on stdout

### DIFF
--- a/scripts/score_retrieval.py
+++ b/scripts/score_retrieval.py
@@ -20,10 +20,30 @@ Hit@3 and nothing else, and ``--top-k 20`` prints Hit@1/3/5/10 *and* Hit@20. A
 cutoff deeper than the retrieval cannot be printed at all — the scorers raise —
 because a Hit@10 taken over three ranks is a Hit@3 under the wrong name, and it
 reads as a retrieval regression that never happened.
+
+**The report is printed; everything else is logged.** Of the eight callers of
+`setup_logging` this is the only one whose product is not the log — the table
+below is written to stdout with `print` so that a redirect of it into
+`docs/eval-reports/` captures the report and nothing else. The run banner and
+the progress counter are diagnostics about a 433-case run that takes minutes, so
+they go through the logger, which is pointed at stderr for exactly that reason
+(`src.logging_setup`). The split is the one the hand-written `file=sys.stderr`
+already had; what it gains is a level, a timestamp and a name, so the progress
+can be turned down without touching the report.
+
+**Not settled, deferred.** The cheaper arrangement is the one the five probe
+siblings have — put the report through the logger too, and no `stream` parameter
+is needed anywhere. Issue #85 put that out of scope in as many words ("*The
+scope of this ticket is diagnostics, not the report*"), because the report on
+stdout is what makes the redirect work and moving it would change what an
+eval-report file captures. So the `print` exception is kept deliberately and the
+parameter pays for it; a later change that moves the report onto the logger
+should take the parameter out with it.
 """
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 from datetime import datetime, timezone
 
@@ -40,6 +60,9 @@ from src.eval.retrieval import (
     score_article_level,
     score_chunk_level,
 )
+from src.logging_setup import setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def main() -> None:
@@ -50,6 +73,17 @@ def main() -> None:
     args = ap.parse_args()
     if args.top_k < 1:
         ap.error("--top-k must be at least 1")
+
+    # stderr, not the stdout default: the report on stdout is this script's
+    # product, and a redirect of it must not collect the progress counter.
+    #
+    # First call wins — `setup_logging` is idempotent in its stream too, so this
+    # only holds while nothing configures logging ahead of it. Nothing on this
+    # import graph does: the other callers are scripts and `migrations/env.py`,
+    # none of which this imports. An import-time caller added under `src/` would
+    # take the stdout default and put the progress counter back in the report,
+    # silently, which is the failure this line exists to prevent.
+    setup_logging(stream=sys.stderr)
 
     settings = get_settings()
     cases = load_tier1()
@@ -68,10 +102,10 @@ def main() -> None:
 
     def progress(i: int, n: int) -> None:
         if i % 25 == 0 or i == n:
-            print(f"  retrieved {i}/{n}", file=sys.stderr, flush=True)
+            logger.info("retrieved %d/%d", i, n)
 
     started = datetime.now(timezone.utc)
-    print(f"scoring {len(cases)} cases at top_k={args.top_k}", file=sys.stderr)
+    logger.info("scoring %d cases at top_k=%d", len(cases), args.top_k)
     retrievals = retrieve_all(cases, vector_db.search, max_k=args.top_k, progress=progress)
 
     # Cutoffs come from the depth actually retrieved, never from a constant.

--- a/src/logging_setup.py
+++ b/src/logging_setup.py
@@ -22,30 +22,53 @@ Multi-line reports are emitted as **one record** with embedded newlines rather
 than one record per line, so a table stays a table and carries a single
 timestamp instead of one per row.
 
-Output goes to **stdout**, not the `StreamHandler` default of stderr. For these
-scripts the report *is* the product rather than a diagnostic sidecar, and it was
-on stdout when it was `print`; moving it would silently change what a redirect
-captures.
+Output goes to **stdout** by default, not the `StreamHandler` default of stderr.
+For the callers that take the default the report *is* the product rather than a
+diagnostic sidecar, and it was on stdout when it was `print`; moving it would
+silently change what a redirect captures. Seven callers take it: the five probe
+scripts, `src.scripts.index_documents`, and `migrations/env.py`.
+
+**The default holds only while the logger carries the report.** `score_retrieval`
+is the eighth caller, the only one whose product is *not* the log, and the reason
+`stream` is a parameter: it prints its report to stdout by hand and logs nothing
+but a run banner and progress, so a logger on stdout would interleave diagnostics
+into the file a redirect of that report writes. It asks for `sys.stderr`, which
+is where those two lines already were, and the split survives becoming logging. A
+script whose report goes *through* the logger must not pass this — two streams
+would cut such a report in half.
+
+The count is of `setup_logging` callers, not of scripts. Eleven others under
+`scripts/` — the `probe_a1_*` and `probe_a2_*` families, `probe_panel_roster`,
+`probe_reasoning_channel` — print everything and call nothing here. They are not
+evidence either way about the default; they have not been brought to the rule
+yet. (`probe_spend` is in neither count: it is a shared helper the probes import,
+not an entry point.)
 """
 import logging
 import sys
+from typing import Optional, TextIO
 
 _FORMAT = "%(asctime)s %(levelname)-7s %(message)s"
 _DATE_FORMAT = "%H:%M:%S"
 
 
-def setup_logging(level: int = logging.INFO) -> None:
+def setup_logging(level: int = logging.INFO, stream: Optional[TextIO] = None) -> None:
     """
     Install a console handler on the root logger. Idempotent.
 
     Called from a script's ``main()``. Safe to call twice — a second call is a
-    no-op rather than a second handler, which would double every line.
+    no-op rather than a second handler, which would double every line. That
+    holds for ``stream`` too: the first call's stream is the one that stays.
+
+    ``stream`` defaults to `sys.stdout`, read at call time rather than bound to
+    the default argument, so a caller that has already redirected `sys.stdout`
+    gets the stream it installed and not the one that existed at import.
     """
     root = logging.getLogger()
     if any(getattr(h, "_clause_and_effect", False) for h in root.handlers):
         return
 
-    handler = logging.StreamHandler(sys.stdout)
+    handler = logging.StreamHandler(sys.stdout if stream is None else stream)
     handler.setFormatter(logging.Formatter(_FORMAT, datefmt=_DATE_FORMAT))
     # Marked so a second call recognises its own handler rather than counting
     # any StreamHandler — pytest and other harnesses install their own.

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,107 @@
+"""
+Tests for the console handler installed by the command-line entry points.
+
+The claim under test is *where a record goes*, which is the whole reason the
+parameter exists: `score_retrieval` prints its report to stdout by hand and logs
+only diagnostics, so a logger on stdout would drop progress lines into whatever
+a redirect of the report captures. The seven other callers — the five probe
+scripts, `src.scripts.index_documents` and `migrations/env.py` — log the report
+itself and must keep the stdout default.
+
+No expected value here is obtained by calling `setup_logging` — the streams are
+named directly and the handler count and level are literals.
+"""
+import io
+import logging
+import sys
+
+import pytest
+
+from src.logging_setup import setup_logging
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logger():
+    """
+    `setup_logging` clears and repopulates the root logger, which pytest also
+    uses. Put back exactly what was there, so one test cannot silence another's
+    captured output.
+    """
+    root = logging.getLogger()
+    handlers, level = list(root.handlers), root.level
+    yield
+    root.handlers.clear()
+    root.handlers.extend(handlers)
+    root.setLevel(level)
+
+
+def test_the_default_stream_is_stdout():
+    """
+    The seven default callers emit their report *through* the logger, and that
+    report was on stdout when it was `print`. Defaulting anywhere else would
+    silently change what a redirect of those scripts captures.
+    """
+    setup_logging()
+
+    root = logging.getLogger()
+    assert len(root.handlers) == 1
+    assert root.handlers[0].stream is sys.stdout
+
+
+def test_the_default_is_read_at_call_time_not_bound_at_import(monkeypatch):
+    """
+    `sys.stdout` as a default *argument* would be bound once, at import, and
+    every test above would still pass — so the distinction needs its own check.
+    It matters because a caller that has already replaced `sys.stdout` (a
+    harness capturing output, a script redirecting its own report) would
+    otherwise get the interpreter's original stream and write past the
+    redirection it just installed.
+    """
+    replacement = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", replacement)
+
+    setup_logging()
+
+    assert logging.getLogger().handlers[0].stream is replacement
+
+
+def test_a_named_stream_is_the_one_written_to():
+    """
+    Not merely stored on the handler — a record has to come out of the stream
+    that was asked for. `score_retrieval` depends on this: its diagnostics go to
+    stderr so that stdout carries the report alone.
+    """
+    stream = io.StringIO()
+
+    setup_logging(stream=stream)
+    logging.getLogger("scripts.score_retrieval").info("retrieved 25/433")
+
+    assert "retrieved 25/433" in stream.getvalue()
+    assert logging.getLogger().handlers[0].stream is stream
+
+
+def test_a_second_call_does_not_add_a_second_handler():
+    """
+    Idempotence, restated for the parameter: a second call with a *different*
+    stream is still a no-op. Two handlers would double every line, which is the
+    failure the marker on the handler was added to prevent.
+    """
+    first, second = io.StringIO(), io.StringIO()
+
+    setup_logging(stream=first)
+    setup_logging(stream=second)
+
+    root = logging.getLogger()
+    assert len(root.handlers) == 1
+    assert root.handlers[0].stream is first
+
+
+def test_the_level_asked_for_is_the_level_set():
+    """
+    `migrations/env.py` relies on the root level reaching INFO. Pinned as a
+    literal so a changed default is a failure here rather than a quiet loss of
+    every INFO record in an alembic run.
+    """
+    setup_logging(level=logging.WARNING, stream=io.StringIO())
+
+    assert logging.getLogger().level == 30


### PR DESCRIPTION
Closes the Standards finding in #85: `scripts/score_retrieval.py` was the one
`setup_logging`-shaped entry point that called neither `setup_logging()` nor
`getLogger`, and wrote its run banner and progress counter with `print` to
stderr — logging under another name, with no level, no timestamp and no logger
name.

## What changed

Both diagnostics now go through `logging.getLogger(__name__)`. **The report body
is untouched**: it stays `print` on stdout, so redirecting a run into
`docs/eval-reports/` still captures the report and nothing else.

Keeping that true is why `src/logging_setup.py` grew an optional `stream`. The
handler defaults to stdout, which is right for the seven callers whose report
goes *through* the logger; this script is the eighth and the only one whose
product is not the log, so it asks for `sys.stderr` — where those two lines
already were. Every existing caller is unchanged.

The parameter is recorded as **deferred, not settled**. The cheaper arrangement
is the probe siblings' — report through the logger, no parameter anywhere — and
#85 put that out of scope in as many words ("*The scope of this ticket is
diagnostics, not the report*"). A later change that moves the report onto the
logger should take the parameter out with it.

## Acceptance

- [x] `setup_logging()` once at the entry point, `logging.getLogger(__name__)` at module level
- [x] the progress callback and the run banner go through the logger
- [x] the report body still goes to stdout, unchanged
- [x] no `RichHandler`
- [x] `make test` is no redder than it was — 596 passed, the 5 recorded xfails

## Evidence

`tests/test_logging_setup.py` is new; the module had no tests. It pins the stdout
default, that the default is read at call time rather than bound at import, that
a named stream is the one actually written to, that idempotence holds for the
stream too, and that the level asked for is the level set (`migrations/env.py`
depends on that one).

Mutation-checked rather than assumed green — ignoring `stream`, ignoring
`level`, removing the idempotence guard, and rewriting the default as
`stream: TextIO = sys.stdout` each fail it. That last one is why the call-time
check exists: it is the single claim the other four tests leave green.

Nothing in `tests/` imports `score_retrieval` — it pulls the Qdrant client at
import time and the import-cost rule leaves that alone — so the script's own
wiring was checked out of tree against stubs: banner and both progress lines on
stderr, table and gap line on stdout, neither leaking into the other. **That
check is inspection, not a guard in the suite**, and the acceptance box about the
report stream rests on it.

## Known fragility, documented rather than fixed

Idempotence means the first call's stream wins. Anything that configured logging
before `main()` would take the stdout default and put the progress counter back
into the report, silently. Nothing on this import graph does; the call site now
says so, so the next person to add an import-time `setup_logging()` under `src/`
has been warned at the place it would break.

## Not run

`make upgrade-safe`. No dependency changed and the lock is untouched; `make
audit` is clean. It is still the gate before this closes.

---

Reviewed on both axes before pushing. The Spec axis came back faithful. The
Standards axis caught a claim in the first draft — "the one entry point whose
product is not the log" — that eleven other scripts under `scripts/` contradict,
and a test that did not actually pin the call-time default. Both are fixed in
the commit rather than left for review.

https://claude.ai/code/session_01Jw4yhn8VF1nSVWTj71MKTp
