### PR TITLE
Teach the wrapper rules the prefix words cs_split already strips

### DIFF
--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -146,18 +146,47 @@ ON_DEV="$FIXTURES/on-dev"
 mkdir -p "$FIXTURES/nolib"
 cp no-commit-to-main.sh "$FIXTURES/nolib/"
 
-# And a copy beside a library that loads, defines every function, and holds no
+# And a hook beside a library that loads, defines every function, and holds no
 # wrapper words. Since #79 the list cs_split strips is a variable rather than a
 # literal in its own regex, so this is a state the file can be in that probing
-# for the functions does not detect -- and one in which it strips no prefix and
-# the anchor admits none, silently and in the permitting direction. The
-# assignments are emptied by appending to the real library rather than by
-# rewriting it, so the fixture cannot drift from what it is a copy of.
-mkdir -p "$FIXTURES/emptylist/lib"
-cp no-commit-to-main.sh "$FIXTURES/emptylist/"
-cp lib/command-scan.sh "$FIXTURES/emptylist/lib/"
-printf 'CS_WRAP_OPTION_WORDS=""\nCS_WRAP_OPERAND_WORDS=""\nCS_WRAP_WORDS=""\n' \
-  >> "$FIXTURES/emptylist/lib/command-scan.sh"
+# for the functions does not detect -- every function is there and the strip
+# simply does nothing, silently and in the permitting direction.
+#
+# Written once and called per hook. Two copies of this builder, differing only
+# in the directory and the hook, was Duplicated Code inside the one change whose
+# subject is not answering a question in two places; found by review, not here.
+#
+# The assignments are emptied IN PLACE, not appended to. CS_WRAPPER_RE is
+# derived from them when the file is sourced, so an append lands after that
+# derivation, leaves the anchor built from the full list, and the fixture would
+# then test cs_split's strip while claiming to test the library's own fail-safe.
+# The first version of these checks appended, and that is what it measured.
+#
+# The sed is verified rather than assumed, for the reason the half-library
+# fixture beside it gives: one that silently changed nothing would leave every
+# check against it green and proving nothing.
+emptied_lib_fixture() {  # emptied_lib_fixture <name> <hook>
+  local dir="$FIXTURES/$1"
+  mkdir -p "$dir/lib"
+  cp "$2" "$dir/"
+  sed -E 's/^CS_WRAP_OPTION_WORDS=.*/CS_WRAP_OPTION_WORDS=""/;
+          s/^CS_WRAP_OPERAND_WORDS=.*/CS_WRAP_OPERAND_WORDS=""/' \
+      lib/command-scan.sh > "$dir/lib/command-scan.sh"
+  grep -q '^CS_WRAP_OPTION_WORDS=""$' "$dir/lib/command-scan.sh" \
+    && grep -q '^CS_WRAP_OPERAND_WORDS=""$' "$dir/lib/command-scan.sh" || {
+    echo "the $1 fixture did not empty the word list; its checks prove nothing" >&2
+    exit 1
+  }
+}
+#
+# All four hooks get one, because the fail-safe for an empty list is in the
+# library and therefore answers for all four at once. A per-hook probe would
+# have covered the two that already guard their load and left the other two
+# permitting -- which is what the first version of this did.
+emptied_lib_fixture emptylist       no-commit-to-main.sh
+emptied_lib_fixture emptylist-push  no-git-push.sh
+emptied_lib_fixture emptylist-pr    no-pr-decisions.sh
+emptied_lib_fixture emptylist-stale no-work-on-stale-branch.sh
 
 # check, with the hook's working directory named rather than inherited. The
 # hook is invoked by absolute path because it sources lib/ relative to $0.
@@ -960,6 +989,19 @@ unarmed 'nor no-pr-decisions.sh' \
         no-pr-decisions.sh "grep -qE '$WRAPRE"
 unarmed 'nor no-work-on-stale-branch.sh' \
         no-work-on-stale-branch.sh "grep -qE '$WRAPRE"
+# In either spelling. The four pins above name the single-quoted one, which is
+# how all four hooks wrote it; a re-derivation reached for with double quotes
+# would satisfy every one of them and answer the list a second time anyway.
+# Found by review of this change: a pin on one spelling of a literal is
+# evidence about that spelling and about nothing else.
+unarmed 'no-git-push.sh does not carry it double-quoted either' \
+        no-git-push.sh "grep -qE \"$WRAPRE"
+unarmed 'nor no-commit-to-main.sh' \
+        no-commit-to-main.sh "grep -qE \"$WRAPRE"
+unarmed 'nor no-pr-decisions.sh' \
+        no-pr-decisions.sh "grep -qE \"$WRAPRE"
+unarmed 'nor no-work-on-stale-branch.sh' \
+        no-work-on-stale-branch.sh "grep -qE \"$WRAPRE"
 
 echo "=== REGRESSION: issue #79, the wrapper rules did not know the prefix words ==="
 # cs_split has always stripped the words that run another command -- sudo, env,
@@ -997,6 +1039,14 @@ check no-git-push.sh BLOCK 'timeout -s KILL 30 + wrapped'   "timeout -s KILL 30 
 # point -- they measure the number rather than a command.
 check no-git-push.sh BLOCK 'three tokens before the wrapper'     "sudo a b c sh -c 'git push --all origin'"
 check no-git-push.sh ALLOW 'and four is past where it looks'     "sudo a b c d sh -c 'git push --all origin'"
+# What that run admits, where cs_split's tail would stop. cs_split breaks its
+# tail at a token opening a quote; this does not, because nothing here reads a
+# token as a command -- they are skipped on the way to a wrapper word that must
+# still appear. The asymmetry is deliberate, argued at CS_WRAP_TOKEN, and in
+# the refusing direction, so it is pinned as a BLOCK rather than left to be
+# rediscovered as a divergence.
+check no-git-push.sh BLOCK 'a quoted token does not end the run' \
+         "sudo \"x\" sh -c 'git push --all origin'"
 # On a dev branch, so that the branch cannot be what answers for the wrapper
 # rule -- the same care the #68 wrapped-commit check takes above.
 check_in "$ON_DEV" no-commit-to-main.sh BLOCK 'sudo + wrapped commit' \
@@ -1009,9 +1059,17 @@ check_in "$ON_DEV" no-commit-to-main.sh BLOCK 'env + wrapped push' \
          "env FOO=1 sh -c 'git push --all origin'"
 check_in "$ON_DEV" no-commit-to-main.sh BLOCK 'nohup + wrapped push' \
          "nohup sh -c 'git push --all origin'"
-# The third and fourth consumers. A decision and a commit on a branch whose life
-# is over are the two the other hooks answer for, and both carried the same
-# blind spot.
+# The third consumer. A decision is what this hook answers for, and it carried
+# the same blind spot.
+#
+# The fourth is no-work-on-stale-branch.sh, and it is NOT here: its verdicts
+# need a worktree on a branch whose life is over, and those fixtures are built
+# further down. Its prefix-word checks are in that section, beside its other
+# wrapper ones. This comment said "the third and fourth consumers" with three
+# no-pr-decisions checks under it and nothing for the fourth anywhere -- found
+# by review of this change, which is the letter of "no fix lands without a
+# check that fails without the fix" going unmet while an armed pin on
+# CS_WRAPPER_RE carried the substance.
 check no-pr-decisions.sh BLOCK 'timeout + wrapped merge'    "timeout 5 sh -c 'gh pr merge 5'"
 check no-pr-decisions.sh BLOCK 'sudo + wrapped release'     "sudo bash -c 'gh release create v1'"
 check no-pr-decisions.sh BLOCK 'nohup + wrapped eval merge' "nohup eval 'gh pr merge 5'"
@@ -1055,11 +1113,15 @@ check no-git-push.sh ALLOW 'find -exec sh -c is out of reach' \
 echo "=== issue #79: the soft spot the anchor keeps, and what widening cost it ==="
 # The anchor carries its own separator class, and that class knows nothing about
 # quoting -- so a verdict still turns on a sed delimiter, which is the complaint
-# #68 was filed about. #68 fixed it in cs_split and cannot fix it here: the fix
-# is to ask cs_split, and this rule must read raw text because a wrapped payload
-# has no command position and `bash <<EOF` is itself a wrapper. Both spellings
-# are pinned side by side, because it is the delimiter that decides the verdict
-# and that is the part that reads as arbitrary from inside a session.
+# #68 was filed about. It is deferred rather than impossible, and the reason is
+# argued once, at CS_WRAPPER_RE in lib/command-scan.sh: asking cs_split WOULD
+# answer it, and what stops this rule asking is that the pins above assert it is
+# handed the raw command. This banner said "cannot fix it here" and gave the
+# raw-text reason, which is the version that header examines and rejects --
+# found by review of this change, one file asserting what the other disowns,
+# which is the shape #63 found in CLAUDE.md and the header found in itself.
+# Both spellings are pinned side by side, because it is the delimiter that
+# decides the verdict and that is the part that reads as arbitrary in session.
 check no-git-push.sh BLOCK 'the pipe delimiter satisfies the anchor' \
          "sed -i 's|sh -c git push --all|X|' f.sh"
 check no-git-push.sh ALLOW 'the slash delimiter does not' \
@@ -1098,6 +1160,17 @@ armed 'cs_split strips whatever that variable holds' \
       lib/command-scan.sh 'match(line, "^(" wrapwords ")[[:space:]]+")'
 armed 'and the anchor admits whatever the union holds' \
       lib/command-scan.sh '($CS_WRAP_WORDS)[[:space:]]+'
+armed 'the intervening token is named once and used once' \
+      lib/command-scan.sh '($CS_WRAP_TOKEN){0,3}'
+# The fail-safe, as a property of the file. It is what answers for the two
+# hooks that do not guard their own load, so a change that built the anchor
+# unconditionally would leave those two permitting and every behavioural check
+# above still green -- the emptylist ones are what go red, and they can only go
+# red while this branch exists.
+armed 'the full anchor is built only when both halves are present' \
+      lib/command-scan.sh '[ -n "$CS_WRAP_OPTION_WORDS" ] && [ -n "$CS_WRAP_OPERAND_WORDS" ]'
+armed 'and an empty list answers with an empty anchor, which matches every line' \
+      lib/command-scan.sh 'CS_WRAPPER_RE=""'
 # The literal cs_split carried before #79. It is the second copy this fix
 # removes, and a re-derivation would restore it.
 unarmed 'cs_split no longer carries the list as a literal' \
@@ -2062,6 +2135,26 @@ check_in "$ON_MAIN" "$FIXTURES/emptylist/no-commit-to-main.sh" BLOCK \
   'a library with no wrapper words, commit on main' 'git commit -m "wip"'
 check_in "$ON_DEV"  "$FIXTURES/emptylist/no-commit-to-main.sh" BLOCK \
   'a library with no wrapper words, anything at all' 'ls'
+# The other two hooks source the library unguarded, so what refuses here is not
+# a probe but the library's own answer: with either half of the list gone
+# CS_WRAPPER_RE is the empty string, grep matches every line, and each hook's
+# wrapper conjunct is vacuously true. Reviewed and measured before this existed:
+# with the list empty and no fail-safe, no-git-push.sh permitted
+# `sudo git push --all origin` and no-pr-decisions.sh permitted
+# `sudo gh pr merge 5` -- the silent permit the fourth review had already fixed
+# once, arriving back through a variable.
+check_in "$PWD" "$FIXTURES/emptylist-push/no-git-push.sh" BLOCK \
+  'a library with no wrapper words, a prefixed push' 'sudo git push --all origin'
+check_in "$PWD" "$FIXTURES/emptylist-pr/no-pr-decisions.sh" BLOCK \
+  'a library with no wrapper words, a prefixed merge' 'sudo gh pr merge 5'
+# And scoped, not blanket: the vacuous conjunct refuses the verb each hook
+# answers for and leaves everything else alone. no-commit-to-main.sh above
+# refuses `ls` because it guards its load outright; these two do not, and a
+# fail-safe that refused every command from either would be a different defect.
+check_in "$PWD" "$FIXTURES/emptylist-push/no-git-push.sh" ALLOW \
+  'a library with no wrapper words, and no push named' 'ls'
+check_in "$PWD" "$FIXTURES/emptylist-pr/no-pr-decisions.sh" ALLOW \
+  'a library with no wrapper words, and no decision named' 'gh issue list'
 
 echo "=== the refusals still name main, which is why this file is kept ==="
 says "$ON_MAIN" no-commit-to-main.sh 'Blocked: committing to main.' \
@@ -2200,6 +2293,22 @@ check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'a commit wrapped in a shel
   "sh -c 'git commit -m \"wip\"'"
 check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'a cherry-pick wrapped in eval' \
   'eval "git cherry-pick 1234abc"'
+# The fourth consumer's share of issue #79: the same two commands behind a
+# prefix word this hook's wrapper rule could not see. Each was ALLOW before the
+# anchor was widened, and the #79 section above says these live here rather
+# than beside its own checks, because the verdicts need these fixtures.
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'sudo + a wrapped commit' \
+  "sudo sh -c 'git commit -m \"wip\"'"
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'timeout + a wrapped commit' \
+  "timeout 5 bash -c 'git commit -m \"wip\"'"
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'xargs + a wrapped cherry-pick' \
+  "xargs sh -c 'git cherry-pick 1234abc'"
+check_in "$WT_GONE" no-work-on-stale-branch.sh BLOCK 'nohup + a wrapped eval merge' \
+  "nohup eval 'git merge other-branch'"
+# And the control from the same section: a wrapper named in prose is not one,
+# so the widening did not cost this hook a read either.
+check_in "$WT_GONE" no-work-on-stale-branch.sh ALLOW 'grepping for the sudo sh -c rule' \
+  "grep -rn 'sudo sh -c .*git commit' .claude/hooks/"
 
 echo "--- the fallback: ahead == 0, behind > 0 against the active dev branch ---"
 check_in "$WT_STALE" no-work-on-stale-branch.sh BLOCK 'commit on a branch dev has moved past' \
@@ -2556,15 +2665,6 @@ check_in "$WT_STALE" "$FIXTURES/halflib/no-work-on-stale-branch.sh" BLOCK 'a lib
 # what it is a copy of, and the assignment is checked for before the verdict is
 # asked -- an append that landed in a file the hook does not read would leave
 # this check passing for the wrong reason.
-mkdir -p "$FIXTURES/emptylist-stale/lib"
-cp no-work-on-stale-branch.sh "$FIXTURES/emptylist-stale/"
-cp lib/command-scan.sh "$FIXTURES/emptylist-stale/lib/"
-printf 'CS_WRAP_OPTION_WORDS=""\nCS_WRAP_OPERAND_WORDS=""\nCS_WRAP_WORDS=""\n' \
-  >> "$FIXTURES/emptylist-stale/lib/command-scan.sh"
-grep -q '^CS_WRAP_WORDS=""$' "$FIXTURES/emptylist-stale/lib/command-scan.sh" || {
-  echo "the empty-list fixture did not empty the word list; the check below proves nothing" >&2
-  exit 1
-}
 #
 # The command is `sudo git commit`, and it has to be. A plain `git commit` on a
 # stale branch is refused whatever the word list holds, so a check written with
@@ -2577,6 +2677,17 @@ grep -q '^CS_WRAP_WORDS=""$' "$FIXTURES/emptylist-stale/lib/command-scan.sh" || 
 # shape that can tell the two apart.
 check_in "$WT_STALE" "$FIXTURES/emptylist-stale/no-work-on-stale-branch.sh" BLOCK \
   'a library with no wrapper words, on a stale branch' 'sudo git commit -m "wip"'
+# And the command that names this hook's own probe rather than the library's
+# fail-safe. The check above is carried by the fail-safe -- CS_WRAPPER_RE is the
+# empty string, the wrapper conjunct is vacuously true and the commit is
+# refused -- so it stays BLOCK with the probe removed, and mutation found it
+# saying nothing about the probe. `git status` names no verb this hook answers
+# for, so nothing but the blanket refusal its own guard raises can refuse it:
+# BLOCK here, ALLOW with the probe gone. The same shape as the `git status`
+# check in the no-lib pair above, and it is the only verdict that separates the
+# two mechanisms.
+check_in "$WT_STALE" "$FIXTURES/emptylist-stale/no-work-on-stale-branch.sh" BLOCK \
+  'a library with no wrapper words, anything at all' 'git status'
 # Scoped the same way the missing-library case is: a healthy worktree is not
 # refused because the library it would have used is incomplete.
 check_in "$WT_WORK" "$FIXTURES/emptylist-stale/no-work-on-stale-branch.sh" ALLOW \

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -1060,11 +1060,37 @@ check no-git-push.sh BLOCK 'timeout -s KILL 30 + wrapped'   "timeout -s KILL 30 
 # point -- they measure the number rather than a command.
 check no-git-push.sh BLOCK 'three tokens before the wrapper'     "sudo a b c sh -c 'git push --all origin'"
 check no-git-push.sh ALLOW 'and four is past where it looks'     "sudo a b c d sh -c 'git push --all origin'"
-# What that run admits, where cs_split's tail would stop. cs_split breaks its
-# tail at a token opening a quote; this does not, because nothing here reads a
-# token as a command -- they are skipped on the way to a wrapper word that must
-# still appear. The asymmetry is deliberate, argued at CS_WRAP_TOKEN, and in
-# the refusing direction, so it is pinned as a BLOCK rather than left to be
+# An OPTION standing after a separated option value. The options loop stops at
+# the first token that is not an option, so a second option behind the operand
+# falls to the token class -- and that class excluded a leading dash until
+# review of this branch, which made the anchor stop dead where cs_split walks
+# past and finds the command. Each pair below was BLOCK unwrapped and ALLOW
+# wrapped, which is #79's own asymmetry one option deeper and in the permitting
+# direction, inside the change that fixes it. The unwrapped halves are here too
+# because the pair is the evidence: a single verdict says nothing about which
+# half moved.
+check no-git-push.sh BLOCK 'sudo -n after a separated value, unwrapped' \
+         'sudo -u root -n git push --all origin'
+check no-git-push.sh BLOCK 'sudo -n after a separated value, wrapped' \
+         "sudo -u root -n sh -c 'git push --all origin'"
+check no-git-push.sh BLOCK 'the bare -- after a separated value, unwrapped' \
+         'nice -n 10 -- git push --all origin'
+check no-git-push.sh BLOCK 'the bare -- after a separated value, wrapped' \
+         "nice -n 10 -- sh -c 'git push --all origin'"
+check no-git-push.sh BLOCK 'a long option after an operand, unwrapped' \
+         'timeout -s KILL 30 --preserve-status git push --all origin'
+check no-git-push.sh BLOCK 'a long option after an operand, wrapped' \
+         "timeout -s KILL 30 --preserve-status bash -c 'git push --all origin'"
+# The control that was never broken: with no operand consumed yet, the options
+# loop still has the dash, so this was BLOCK throughout. It is what says the
+# three above are about the token class and not about `--`.
+check no-git-push.sh BLOCK 'a bare -- with no operand before it' \
+         "sudo -- sh -c 'git push --all origin'"
+# What that run admits, where cs_split's tail would stop. The class is now
+# cs_split's exactly; what still differs is the LOOP -- cs_split breaks at a
+# token opening a quote, because it offers candidates to read as commands, and
+# this does not, because nothing here reads a token at all. Deliberate, argued
+# at CS_WRAP_TOKEN, in the refusing direction, and pinned so that it is not
 # rediscovered as a divergence.
 check no-git-push.sh BLOCK 'a quoted token does not end the run' \
          "sudo \"x\" sh -c 'git push --all origin'"

--- a/.claude/hooks/check-hooks.sh
+++ b/.claude/hooks/check-hooks.sh
@@ -146,6 +146,19 @@ ON_DEV="$FIXTURES/on-dev"
 mkdir -p "$FIXTURES/nolib"
 cp no-commit-to-main.sh "$FIXTURES/nolib/"
 
+# And a copy beside a library that loads, defines every function, and holds no
+# wrapper words. Since #79 the list cs_split strips is a variable rather than a
+# literal in its own regex, so this is a state the file can be in that probing
+# for the functions does not detect -- and one in which it strips no prefix and
+# the anchor admits none, silently and in the permitting direction. The
+# assignments are emptied by appending to the real library rather than by
+# rewriting it, so the fixture cannot drift from what it is a copy of.
+mkdir -p "$FIXTURES/emptylist/lib"
+cp no-commit-to-main.sh "$FIXTURES/emptylist/"
+cp lib/command-scan.sh "$FIXTURES/emptylist/lib/"
+printf 'CS_WRAP_OPTION_WORDS=""\nCS_WRAP_OPERAND_WORDS=""\nCS_WRAP_WORDS=""\n' \
+  >> "$FIXTURES/emptylist/lib/command-scan.sh"
+
 # check, with the hook's working directory named rather than inherited. The
 # hook is invoked by absolute path because it sources lib/ relative to $0.
 check_in() {  # check_in <dir> <script|/absolute/hook> <want> <label> <cmd>
@@ -901,35 +914,199 @@ check no-pr-decisions.sh BLOCK 'wrapped merge, invisible to the split' "eval 'gh
 check_in "$ON_DEV" no-commit-to-main.sh BLOCK 'wrapped commit, invisible to the split' \
          "sh -c 'git commit -m x'"
 # And the same claim asserted as a property of the files rather than inferred
-# from three verdicts. WRAPRE is the distinctive head of the wrapper regex, so
-# each literal below pins both which rule it is and what that rule is handed.
-WRAPRE='(^[[:space:]]*|[;&|(`][[:space:]]*)'
-armed 'no-git-push.sh matches its wrapper rule on the raw command' \
-      no-git-push.sh "if echo \"\$COMMAND\" | grep -qE '$WRAPRE"
-armed 'no-commit-to-main.sh matches its wrapper rule on the raw command' \
-      no-commit-to-main.sh "if echo \"\$COMMAND\" | grep -qE '$WRAPRE"
+# from three verdicts. Each literal below pins both which rule it is and what
+# that rule is handed -- the raw command, never the fragments.
+#
+# Since #79 the expression itself is CS_WRAPPER_RE, derived once in
+# lib/command-scan.sh, so the literal names the shared variable rather than the
+# head of a regex each hook carried its own copy of. What is pinned is
+# unchanged: which text the rule reads.
+armed 'no-git-push.sh matches the shared wrapper rule on the raw command' \
+      no-git-push.sh 'if echo "$COMMAND" | grep -qE "$CS_WRAPPER_RE"'
+armed 'no-commit-to-main.sh matches the shared wrapper rule on the raw command' \
+      no-commit-to-main.sh 'if echo "$COMMAND" | grep -qE "$CS_WRAPPER_RE"'
 # no-pr-decisions.sh joins continuations first and matches on that, which is the
 # half of cs_normalise its wrapper rules do want; both halves are pinned.
 armed 'no-pr-decisions.sh derives its wrapper text from the raw command' \
       no-pr-decisions.sh "WRAPTEXT=\$(printf '%s\\n' \"\$COMMAND\" | cs_join)"
-armed 'no-pr-decisions.sh matches its wrapper rule on that text' \
-      no-pr-decisions.sh "if echo \"\$WRAPTEXT\" | grep -qE '$WRAPRE"
+armed 'no-pr-decisions.sh matches the shared wrapper rule on that text' \
+      no-pr-decisions.sh 'if echo "$WRAPTEXT" | grep -qE "$CS_WRAPPER_RE"'
 unarmed 'no-git-push.sh does not match its wrapper rule on the fragments' \
-        no-git-push.sh "echo \"\$CMDS\" | grep -qE '$WRAPRE"
+        no-git-push.sh 'echo "$CMDS" | grep -qE "$CS_WRAPPER_RE"'
 unarmed 'no-commit-to-main.sh does not match its wrapper rule on the fragments' \
-        no-commit-to-main.sh "echo \"\$CMDS\" | grep -qE '$WRAPRE"
+        no-commit-to-main.sh 'echo "$CMDS" | grep -qE "$CS_WRAPPER_RE"'
 unarmed 'no-pr-decisions.sh does not match its wrapper rule on the fragments' \
-        no-pr-decisions.sh "echo \"\$CMDS\" | grep -qE '$WRAPRE"
+        no-pr-decisions.sh 'echo "$CMDS" | grep -qE "$CS_WRAPPER_RE"'
 # The fourth consumer. It was covered behaviourally by the stale-branch section
 # below and not by a literal, which left "each wrapper detection" met in
 # substance and not in letter -- and this is the one hook where a lost fragment
 # retains a carve-out instead of dropping a refusal, so it is the last one that
 # should rest on an argument rather than a pin. See the header of
 # lib/command-scan.sh for why that shape is still safe.
-armed 'no-work-on-stale-branch.sh matches its wrapper rule on the raw command' \
-      no-work-on-stale-branch.sh "if echo \"\$COMMAND\" | grep -qE '$WRAPRE"
+armed 'no-work-on-stale-branch.sh matches the shared wrapper rule on the raw command' \
+      no-work-on-stale-branch.sh 'if echo "$COMMAND" | grep -qE "$CS_WRAPPER_RE"'
 unarmed 'no-work-on-stale-branch.sh does not match its wrapper rule on the fragments' \
-        no-work-on-stale-branch.sh "echo \"\$CMDS\" | grep -qE '$WRAPRE"
+        no-work-on-stale-branch.sh 'echo "$CMDS" | grep -qE "$CS_WRAPPER_RE"'
+# And that no hook carries its own copy of the anchor any more. WRAPRE is the
+# head each of the four wrote out before #79; four copies of one expression, in
+# the file whose header names that as the defect. A hook that re-derives it
+# would pass every check above and answer the list differently again.
+WRAPRE='(^[[:space:]]*|[;&|(`][[:space:]]*)'
+unarmed 'no-git-push.sh does not carry its own copy of the anchor' \
+        no-git-push.sh "grep -qE '$WRAPRE"
+unarmed 'nor no-commit-to-main.sh' \
+        no-commit-to-main.sh "grep -qE '$WRAPRE"
+unarmed 'nor no-pr-decisions.sh' \
+        no-pr-decisions.sh "grep -qE '$WRAPRE"
+unarmed 'nor no-work-on-stale-branch.sh' \
+        no-work-on-stale-branch.sh "grep -qE '$WRAPRE"
+
+echo "=== REGRESSION: issue #79, the wrapper rules did not know the prefix words ==="
+# cs_split has always stripped the words that run another command -- sudo, env,
+# xargs, nohup, nice, time, stdbuf, ionice, command, doas, setsid, chronic, and
+# timeout and flock with their operand. The four wrapper regexes did not consult
+# that list; they answered "is this a wrapper?" independently and anchored on ^
+# or on a separator, so sudo was recognised in one half of the library and
+# invisible in the other:
+#
+#   BLOCK   sudo git push --all origin            the push is at a command position
+#   ALLOW   sudo sh -c 'git push --all origin'    the wrapper is not at ^
+#
+# Every check in the first group below was ALLOW before the anchor was widened
+# to admit that list. They are asked of no-git-push.sh and of
+# no-commit-to-main.sh both, because the defect was in an expression all four
+# hooks carried a copy of, and a fix that reached one file would be the shape
+# this suite exists to catch.
+check no-git-push.sh BLOCK 'sudo + wrapped push'            "sudo sh -c 'git push --all origin'"
+check no-git-push.sh BLOCK 'timeout + wrapped push'         "timeout 5 bash -c 'git push --all origin'"
+check no-git-push.sh BLOCK 'xargs + wrapped push'           "xargs sh -c 'git push --all origin'"
+check no-git-push.sh BLOCK 'env + wrapped push'             "env FOO=1 sh -c 'git push --all origin'"
+check no-git-push.sh BLOCK 'nohup + wrapped push'           "nohup sh -c 'git push --all origin'"
+check no-git-push.sh BLOCK 'sudo + wrapped eval push'       "sudo eval 'git push --all origin'"
+# The separated option value, which is the shape cs_split answers by offering
+# its tail as further candidates rather than by trimming its head. The anchor
+# admits three further tokens for the same reason and to the same bound: `-u`,
+# `-n` and `-s` are consumed as options and leave `root`, `10` and `KILL 30`
+# standing where the wrapper word has to be.
+check no-git-push.sh BLOCK 'sudo -u root + wrapped push'    "sudo -u root sh -c 'git push --all origin'"
+check no-git-push.sh BLOCK 'nice -n 10 + wrapped push'      "nice -n 10 sh -c 'git push --all origin'"
+check no-git-push.sh BLOCK 'timeout -s KILL 30 + wrapped'   "timeout -s KILL 30 bash -c 'git push --all origin'"
+# And where that run stops, pinned from both sides. Three is the bound cs_split
+# already offers its tail to, and a bound is only a claim if the check names the
+# token past it: neither of these two is a shape anyone writes, and that is the
+# point -- they measure the number rather than a command.
+check no-git-push.sh BLOCK 'three tokens before the wrapper'     "sudo a b c sh -c 'git push --all origin'"
+check no-git-push.sh ALLOW 'and four is past where it looks'     "sudo a b c d sh -c 'git push --all origin'"
+# On a dev branch, so that the branch cannot be what answers for the wrapper
+# rule -- the same care the #68 wrapped-commit check takes above.
+check_in "$ON_DEV" no-commit-to-main.sh BLOCK 'sudo + wrapped commit' \
+         "sudo sh -c 'git commit -m x'"
+check_in "$ON_DEV" no-commit-to-main.sh BLOCK 'timeout + wrapped commit' \
+         "timeout 5 bash -c 'git commit -m x'"
+check_in "$ON_DEV" no-commit-to-main.sh BLOCK 'xargs + wrapped push' \
+         "xargs sh -c 'git push --all origin'"
+check_in "$ON_DEV" no-commit-to-main.sh BLOCK 'env + wrapped push' \
+         "env FOO=1 sh -c 'git push --all origin'"
+check_in "$ON_DEV" no-commit-to-main.sh BLOCK 'nohup + wrapped push' \
+         "nohup sh -c 'git push --all origin'"
+# The third and fourth consumers. A decision and a commit on a branch whose life
+# is over are the two the other hooks answer for, and both carried the same
+# blind spot.
+check no-pr-decisions.sh BLOCK 'timeout + wrapped merge'    "timeout 5 sh -c 'gh pr merge 5'"
+check no-pr-decisions.sh BLOCK 'sudo + wrapped release'     "sudo bash -c 'gh release create v1'"
+check no-pr-decisions.sh BLOCK 'nohup + wrapped eval merge' "nohup eval 'gh pr merge 5'"
+# The controls: the unwrapped shape the list already reached, and the wrapped
+# shape with no prefix in front of it. Both were BLOCK before and must stay so,
+# or the widening has moved the rule rather than extended it.
+check no-git-push.sh BLOCK 'the control: sudo + a bare push'   'sudo git push --all origin'
+check no-git-push.sh BLOCK 'the control: timeout + a push'     'timeout 30 git push --all origin'
+check no-git-push.sh BLOCK 'the control: a wrapper on its own' "bash -c 'git push --all origin'"
+check no-git-push.sh BLOCK 'the control: an assignment prefix' "FOO=1 sh -c 'git push --all origin'"
+
+echo "=== issue #79: the anchor was widened and not dropped ==="
+# The constraint that decides this fix. Dropping the anchor would pass every
+# check above and refuse a wrapper word named anywhere on a line that also names
+# a refused command -- which is exactly what a session working on these hooks
+# writes. The obvious example does not show it: `grep -rn "sh -c" .claude/` is
+# ALLOW either way, because the rule is a conjunction and that command names no
+# push. The shapes that regress name a wrapper word and a push on one line, and
+# each of these three is ALLOW with the anchor and BLOCK without it.
+check no-git-push.sh ALLOW 'grepping for the sh -c rule'  "grep -rn 'sh -c .*git push' .claude/hooks/"
+check no-git-push.sh ALLOW 'grepping for the eval rule'   "grep -rn 'eval .*git push' .claude/hooks/"
+check no-git-push.sh ALLOW 'a note about what eval does'  "echo 'the eval rule refuses git push --all origin' >> notes.md"
+check_in "$ON_DEV" no-commit-to-main.sh ALLOW 'grepping for the sh -c rule' \
+         "grep -rn 'sh -c .*git commit' .claude/hooks/"
+
+echo "=== issue #79: named and not closed -- the list cannot be complete ==="
+# A word that runs a command and is not a prefix word is out of reach, and the
+# header of lib/command-scan.sh says so rather than implying the set is
+# exhaustive. These are ALLOW and are pinned as ALLOW: a check that named them
+# and wanted BLOCK would be a claim the fix does not make.
+check no-git-push.sh ALLOW 'python3 -c is out of reach' \
+         "python3 -c 'import os; os.system(\"git push --all origin\")'"
+check no-git-push.sh ALLOW 'perl -e is out of reach' \
+         "perl -e 'system(\"git push --all origin\")'"
+# find runs its operand after -exec rather than as a prefix, so it is not one of
+# cs_split's words and adding it there would strip find and leave the path where
+# the command word has to be. Named with the family above rather than closed.
+check no-git-push.sh ALLOW 'find -exec sh -c is out of reach' \
+         "find . -exec sh -c 'git push --all origin' \\;"
+
+echo "=== issue #79: the soft spot the anchor keeps, and what widening cost it ==="
+# The anchor carries its own separator class, and that class knows nothing about
+# quoting -- so a verdict still turns on a sed delimiter, which is the complaint
+# #68 was filed about. #68 fixed it in cs_split and cannot fix it here: the fix
+# is to ask cs_split, and this rule must read raw text because a wrapped payload
+# has no command position and `bash <<EOF` is itself a wrapper. Both spellings
+# are pinned side by side, because it is the delimiter that decides the verdict
+# and that is the part that reads as arbitrary from inside a session.
+check no-git-push.sh BLOCK 'the pipe delimiter satisfies the anchor' \
+         "sed -i 's|sh -c git push --all|X|' f.sh"
+check no-git-push.sh ALLOW 'the slash delimiter does not' \
+         "sed -i 's/sh -c git push --all/X/' f.sh"
+# And the cost of widening, named so that it is a known trade rather than a
+# discovery: the prefix words are admitted after that same quote-blind
+# separator, so prose naming one of them in front of a wrapper is refused where
+# it was not before. It costs a refusal and never a permission, and the refusal
+# is visible and one edit away.
+check no-git-push.sh BLOCK 'a prefix word in prose, after a pipe (was ALLOW)' \
+         "sed -i 's|sudo sh -c git push --all|X|' f.sh"
+check no-git-push.sh ALLOW 'the same prose with the other delimiter' \
+         "sed -i 's/sudo sh -c git push --all/X/' f.sh"
+
+echo "=== issue #79: the prefix words are written once ==="
+# The point of the fix, asserted as a property of the file rather than inferred
+# from the verdicts above. A second copy of those fourteen words in four hook
+# regexes would be the same defect one more time, so the list is a variable that
+# cs_split reads through awk's -v and the anchor interpolates.
+#
+# `stdbuf` and `ionice` are counted because they appear in the assignment and
+# nowhere in the prose around it: sudo, timeout, xargs, nohup and env are named
+# in the header's worked example, so counting one of those would count the
+# explanation as a copy.
+tok 'the option words are written once in the library' \
+    '1' "$(prose_count "$HOOKS/lib/command-scan.sh" 'stdbuf')"
+tok 'and so is the second of them' \
+    '1' "$(prose_count "$HOOKS/lib/command-scan.sh" 'ionice')"
+armed 'the union is derived rather than written a third time' \
+      lib/command-scan.sh 'CS_WRAP_WORDS="$CS_WRAP_OPTION_WORDS|$CS_WRAP_OPERAND_WORDS"'
+armed 'cs_split reads the option words as a variable' \
+      lib/command-scan.sh '-v wrapwords="$CS_WRAP_OPTION_WORDS"'
+armed 'and the operand words the same way' \
+      lib/command-scan.sh '-v operandwords="$CS_WRAP_OPERAND_WORDS"'
+armed 'cs_split strips whatever that variable holds' \
+      lib/command-scan.sh 'match(line, "^(" wrapwords ")[[:space:]]+")'
+armed 'and the anchor admits whatever the union holds' \
+      lib/command-scan.sh '($CS_WRAP_WORDS)[[:space:]]+'
+# The literal cs_split carried before #79. It is the second copy this fix
+# removes, and a re-derivation would restore it.
+unarmed 'cs_split no longer carries the list as a literal' \
+        lib/command-scan.sh '/^(env|command|xargs'
+# What these pins are NOT evidence of, named because a check is evidence about
+# what it names: they read the derivation, not the verdict. A list that is
+# written once and is wrong is wrong in both places at once, which is what the
+# header of lib/command-scan.sh says this file keeps costing. The behavioural
+# groups above are what say the list is right for the words they name.
 
 echo "=== REGRESSION: PR #35 review, a command after a control word ==="
 # A separator is not the only thing a command can follow. Splitting on ; left
@@ -1877,6 +2054,14 @@ check_in "$ON_MAIN" "$FIXTURES/nolib/no-commit-to-main.sh" BLOCK 'no lib/, commi
   'git commit -m "wip"'
 check_in "$ON_DEV"  "$FIXTURES/nolib/no-commit-to-main.sh" BLOCK 'no lib/, anything at all' \
   'ls'
+# The same failure arriving through a variable rather than a missing file, which
+# is what #79 added a way to be wrong about. Probing for cs_split cannot see it:
+# the function is there and strips nothing. Both verdicts are the nolib ones,
+# because the hook cannot read the command either way.
+check_in "$ON_MAIN" "$FIXTURES/emptylist/no-commit-to-main.sh" BLOCK \
+  'a library with no wrapper words, commit on main' 'git commit -m "wip"'
+check_in "$ON_DEV"  "$FIXTURES/emptylist/no-commit-to-main.sh" BLOCK \
+  'a library with no wrapper words, anything at all' 'ls'
 
 echo "=== the refusals still name main, which is why this file is kept ==="
 says "$ON_MAIN" no-commit-to-main.sh 'Blocked: committing to main.' \
@@ -2363,6 +2548,39 @@ grep -q '^cs_renamed_away()' "$FIXTURES/halflib/lib/command-scan.sh" || {
 }
 check_in "$WT_STALE" "$FIXTURES/halflib/no-work-on-stale-branch.sh" BLOCK 'a library missing only cs_git_args' \
   'git commit -m "wip"'
+# And a library complete in its functions and empty in its word list, which is
+# the way #79 added to be wrong about this: cs_split reads the prefix words from
+# a variable now rather than carrying them as a literal, so probing the three
+# functions cannot see a list that strips nothing. Emptied by appending to the
+# real library rather than by rewriting it, so the fixture cannot drift from
+# what it is a copy of, and the assignment is checked for before the verdict is
+# asked -- an append that landed in a file the hook does not read would leave
+# this check passing for the wrong reason.
+mkdir -p "$FIXTURES/emptylist-stale/lib"
+cp no-work-on-stale-branch.sh "$FIXTURES/emptylist-stale/"
+cp lib/command-scan.sh "$FIXTURES/emptylist-stale/lib/"
+printf 'CS_WRAP_OPTION_WORDS=""\nCS_WRAP_OPERAND_WORDS=""\nCS_WRAP_WORDS=""\n' \
+  >> "$FIXTURES/emptylist-stale/lib/command-scan.sh"
+grep -q '^CS_WRAP_WORDS=""$' "$FIXTURES/emptylist-stale/lib/command-scan.sh" || {
+  echo "the empty-list fixture did not empty the word list; the check below proves nothing" >&2
+  exit 1
+}
+#
+# The command is `sudo git commit`, and it has to be. A plain `git commit` on a
+# stale branch is refused whatever the word list holds, so a check written with
+# one passes without the guard it is named after ever running -- measured: this
+# check was written that way first, and the mutant that removes the guard left
+# it green. `sudo git commit` is refused only because cs_split strips sudo and
+# finds the commit behind it, so with the list empty and the guard gone the
+# fragment head is `sudo`, no commit is found, and the hook leaves without an
+# opinion. That is the verdict the guard has to prevent, and the only command
+# shape that can tell the two apart.
+check_in "$WT_STALE" "$FIXTURES/emptylist-stale/no-work-on-stale-branch.sh" BLOCK \
+  'a library with no wrapper words, on a stale branch' 'sudo git commit -m "wip"'
+# Scoped the same way the missing-library case is: a healthy worktree is not
+# refused because the library it would have used is incomplete.
+check_in "$WT_WORK" "$FIXTURES/emptylist-stale/no-work-on-stale-branch.sh" ALLOW \
+  'a library with no wrapper words, on a branch carrying work' 'sudo git commit -m "wip"'
 
 echo "=== append-only: which docs directories are guarded, and which are not ==="
 # First coverage for append-only-docs.sh and its Edit/Write companion. It was

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -119,6 +119,19 @@
 # anything this library does, so the honest phrasing is SWEPT AND NOT FOUND,
 # never "cannot happen". Any future hook that judges a verb by a free-text
 # argument reopens the question.
+#
+# A sixth review, of that fix, found the list of prefix words known in one half
+# of this library and invisible in the other. cs_split had stripped sudo, env,
+# xargs, timeout and the rest since the fourth review; the four wrapper regexes
+# in the hooks never consulted it, so `sudo git push --all origin` was refused
+# and `sudo sh -c 'git push --all origin'` was not. One question, two places,
+# two answers -- which is the sentence this header opens with. It is one layer
+# out from PR #35's defect #2:
+# wrapper re-admission sufficed for a heredoc and did nothing for `sh -c`, and
+# then handled `sh -c` and did nothing for `sudo sh -c`. Issue #79 made the
+# words a variable that both halves read, and moved the four copies of the
+# wrapper expression into the one CS_WRAPPER_RE below. Where that anchor stops,
+# what it cannot reach, and the soft spot it keeps are argued there.
 
 # Reduce a raw command to lines that can be scanned: heredoc bodies dropped,
 # line continuations joined, redirections dropped -- in that order, so that
@@ -325,6 +338,127 @@ cs_join() {
     }'
 }
 
+# The words that run another command with their own options. Two questions are
+# asked of this list, which is why it is a variable and not a regular expression
+# written where it is needed: cs_split strips these to find the command word
+# behind them, and CS_WRAPPER_RE below admits them in front of a wrapper.
+#
+# A sixth review, of #68, found the second question answered by not asking it.
+# The four wrapper regexes in the hooks anchored on ^ or on a separator and knew
+# nothing of this list, so sudo was recognised in one half of this library and
+# invisible in the other, measured:
+#
+#   BLOCK   sudo git push --all origin          cs_split strips sudo, the push is at ^
+#   ALLOW   sudo sh -c 'git push --all origin'  cs_split strips sudo, leaves sh -c
+#                                               where no anchor admits it
+#
+# That is the same question answered in two places with two different answers,
+# which is the defect class the header of this file opens by naming, and it is
+# one layer out from PR #35's defect #2 -- wrapper re-admission sufficed for a
+# heredoc and did nothing for `sh -c`, and then handled `sh -c` and did nothing
+# for `sudo sh -c`. The same held for timeout, xargs, nohup and env. Issue #79.
+#
+# Split in two because cs_split does two different things with them: the first
+# group takes options only, the second takes an operand of its own as well. The
+# union is derived rather than written a third time.
+CS_WRAP_OPTION_WORDS='env|command|xargs|nohup|nice|time|stdbuf|ionice|sudo|doas|setsid|chronic'
+CS_WRAP_OPERAND_WORDS='timeout|flock'
+CS_WRAP_WORDS="$CS_WRAP_OPTION_WORDS|$CS_WRAP_OPERAND_WORDS"
+
+# Is there a shell wrapper at a command position? Derived once here and grepped
+# by all four hooks, which each carried their own copy of it before #79 -- four
+# copies of one expression, in the file whose header says that is the defect.
+#
+# It is matched against RAW command text, before cs_normalise and before
+# cs_split, and that ordering is load-bearing: a wrapped payload sits in quotes
+# where there is no command position for the tokeniser to find, and
+# cs_normalise drops heredoc bodies while `bash <<EOF` is itself one of these
+# wrappers, so the payload would go with the body. That is why this is an
+# anchored regular expression rather than a pass over cs_split's output.
+#
+# Which is also why the anchor has to say what a command position is a second
+# time, and what it now admits between the position and the wrapper word: an
+# environment assignment, as it always did, and a prefix word from the list
+# above with its options and up to three further tokens.
+#
+# More than one, because the operand a wrapper takes is not always one token.
+# `timeout -s KILL 30 bash -c` leaves KILL and 30 once the option is consumed,
+# `sudo -u root sh -c` leaves root, and `nice -n 10 sh -c` leaves 10 -- the
+# separated option value, which is the case cs_split answers by offering its
+# tail as further candidates rather than by trimming its head. Three rather
+# than some other number because three is the bound cs_split offers that tail
+# to, for this same case and this same reason. A different number here would be
+# the divergence this whole change is about, arriving inside its own fix.
+#
+# WIDENED, NOT DROPPED, and the difference is the whole of the constraint. The
+# anchor cannot simply go: a wrapper word named anywhere on a line that also
+# names a refused command would then refuse the line, and the shapes that
+# regress are exactly the ones a session working on these hooks writes --
+# `grep -rn 'sh -c .*git push' .claude/hooks/` and
+# `echo 'the eval rule refuses git push' >> notes.md` are ALLOW with the anchor
+# and BLOCK without it. Four such shapes are checks, and the mutant that drops
+# the anchor turns exactly those red.
+#
+# NAMED AND NOT CLOSED. The list cannot be complete and this does not pretend
+# to be. A word that runs a command and is not a prefix word is still out of
+# reach: `python3 -c 'import os; os.system("git push --all origin")'` is the
+# example, and `perl -e`, `find . -exec sh -c ... \;`, a make target, and a
+# script written to a file and then run are the rest of the family. The
+# stopping rule is the one already in these files -- a wrapper's payload is
+# refused rather than parsed, and the wrapper words are the ones this library
+# can already name. Everything past that is out of reach, in the manner of the
+# soft spot at no-git-push.sh:153, and not a claim the set is exhaustive.
+#
+# ONE SOFT SPOT, named rather than closed, and it is #68's complaint reaching
+# this rule. The separator class below carries its own idea of what ends a
+# command and knows nothing about quoting, so a verdict still turns on a sed
+# delimiter:
+#
+#   BLOCK   sed -i 's|sh -c git push --all|X|' f.sh   the | satisfies the anchor
+#   ALLOW   sed -i 's/sh -c git push --all/X/' f.sh   same command, other delimiter
+#
+# Why it is left, and stated without the convenient version. The convenient
+# version is that this one cannot be fixed because the rule must read raw text.
+# That is not true, and writing it down would be the kind of claim this file
+# keeps having to correct. cs_split is quote-aware since #68; it does NOT drop
+# heredoc bodies, which is cs_normalise; and a wrapper word sits OUTSIDE the
+# payload's quotes, so `bash -c '...'` and `bash <<EOF` both stand at the head
+# of a fragment where an anchor at ^ would find them. Asking cs_split would
+# answer the quote question here, and would answer it once.
+#
+# What stops it is not that it cannot work. It is that the check suite pins, as
+# a property of all four files, that this rule is handed the raw command and
+# not the fragments -- and inverting that is a different change from widening
+# an anchor, with its own sweep to do over every shape the two texts differ on.
+# Issue #79 scoped it out in as many words. So the soft spot stays, on two
+# grounds that hold meanwhile: it costs refusals and never permits, and the
+# refusal is visible and one edit away. It is a candidate for a ticket of its
+# own rather than a limit of the design, and this paragraph is the record of
+# that decision rather than of an obstacle.
+#
+# Widening the anchor widens this with it -- `sed -i 's|sudo sh -c git push|X|'
+# f.sh` was ALLOW and is now BLOCK -- named here so that it is a known cost
+# rather than a discovery. Both spellings of each pair above are checks.
+#
+# TWO WAYS THE LIST CAN BE MISSING, and they do not fail the same way, which is
+# the thing making it a variable added to this library.
+#
+# If the library does not load at all, this is the empty string, `grep -qE ''`
+# matches every line, the wrapper conjunct is always true, and a command naming
+# a refused verb is refused. That is the direction a guard's own breakage has to
+# take, and it needs no guard of its own.
+#
+# A library that loads with an empty list is the other way and is not the safe
+# one. cs_split then strips no prefix at all, so `sudo git push --all origin` is
+# permitted again -- the very verdict the fourth review fixed, and silent.
+# Probing for cs_split cannot see it, because the function is there and does
+# less. So the two hooks that probe for the functions probe for CS_WRAP_WORDS as
+# well, and check-hooks.sh builds a library with the list emptied rather than
+# arguing that it cannot happen. Both of those checks had to be written against
+# a command that ONLY the strip reaches: written with a plain `git commit` the
+# stale-branch one was green with its own guard removed.
+CS_WRAPPER_RE="(^[[:space:]]*|[;&|(\`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|($CS_WRAP_WORDS)[[:space:]]+(-[^[:space:]]*[[:space:]]+)*([^-[:space:]][^[:space:]]*[[:space:]]+){0,3})*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|\$))"
+
 # Print one command per line, with anything that precedes the command word
 # removed, so a caller matches on ^ and never has to describe a command
 # position again.
@@ -470,7 +604,8 @@ cs_split() {
       if (qopen != "" || dq_substitution) out = cut($0, 0)
       print out
     }' \
-  | awk '
+  | awk -v wrapwords="$CS_WRAP_OPTION_WORDS" \
+        -v operandwords="$CS_WRAP_OPERAND_WORDS" '
     {
       line = $0
       sub(/^[[:space:]]+/, "", line)
@@ -486,7 +621,10 @@ cs_split() {
           line = substr(line, RSTART + RLENGTH)
           changed = 1
         }
-        if (match(line, /^(env|command|xargs|nohup|nice|time|stdbuf|ionice|sudo|doas|setsid|chronic)[[:space:]]+/)) {
+        # The list arrives as a variable rather than standing here as a literal,
+        # so that the wrapper anchor can admit the same words without a second
+        # copy of them. Issue #79; see CS_WRAP_OPTION_WORDS above.
+        if (match(line, "^(" wrapwords ")[[:space:]]+")) {
           line = substr(line, RSTART + RLENGTH)
           while (match(line, /^-[^[:space:]]*[[:space:]]+/)) {
             line = substr(line, RSTART + RLENGTH)
@@ -500,7 +638,7 @@ cs_split() {
         # `timeout 30 git push --all origin` invisible to every hook. The
         # operand is stripped with the word, one token and only if it is not
         # itself an option.
-        if (match(line, /^(timeout|flock)[[:space:]]+/)) {
+        if (match(line, "^(" operandwords ")[[:space:]]+")) {
           line = substr(line, RSTART + RLENGTH)
           while (match(line, /^-[^[:space:]]*[[:space:]]+/)) {
             line = substr(line, RSTART + RLENGTH)

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -401,10 +401,13 @@ CS_WRAP_WORDS="$CS_WRAP_OPTION_WORDS|$CS_WRAP_OPERAND_WORDS"
 # to, for this same case and this same reason. A different number here would be
 # the divergence this whole change is about, arriving inside its own fix.
 #
-# The COUNT is what is shared, and not the token class. Review of this change
-# found this paragraph claiming both, when cs_split stops its tail at a token
-# opening a quote and this does not. The difference is deliberate and is argued
-# at CS_WRAP_TOKEN below; what is claimed here is the bound alone.
+# THE CLASS AND THE COUNT, both. The token admitted between the prefix word and
+# the wrapper is cs_split's tail token exactly, and three is cs_split's bound.
+# This paragraph has now been wrong about that twice and in both directions --
+# claiming the classes matched when this one was wider, then claiming only the
+# count was shared when this one had also been narrower in a second respect
+# nobody had noticed. What is left differing is the loop and not the class, and
+# CS_WRAP_TOKEN below is where that is set out.
 #
 # WIDENED, NOT DROPPED, and the difference is the whole of the constraint. The
 # anchor cannot simply go: a wrapper word named anywhere on a line that also
@@ -456,28 +459,46 @@ CS_WRAP_WORDS="$CS_WRAP_OPTION_WORDS|$CS_WRAP_OPERAND_WORDS"
 # f.sh` was ALLOW and is now BLOCK -- named here so that it is a known cost
 # rather than a discovery. Both spellings of each pair above are checks.
 #
-# A token that may stand between the prefix word and the wrapper word. Not an
-# option -- those are consumed by the loop in front of this one -- and anything
-# else.
+# A token that may stand between the prefix word and the wrapper word: any word
+# at all, which is cs_split's tail token exactly -- `^[^[:space:]]+[[:space:]]+`
+# there, the same class here. Both the class and the bound of three are shared,
+# and that is the whole claim.
 #
-# WIDER THAN cs_split's TAIL TOKEN, deliberately, and this is the one place the
-# two answers differ on purpose. cs_split stops offering candidates at a token
-# that opens a quote, because what follows one is the text of an argument and
-# reading text as a command is the mistake cs_normalise has made three times.
-# Nothing here reads a token as a command: these are skipped, on the way to a
-# wrapper word that has to appear after them. So the reason to stop does not
-# transfer, and stopping anyway would narrow a guard for a reason that does not
-# apply to it.
+# IT EXCLUDED A LEADING DASH UNTIL REVIEW OF THIS BRANCH, and that was #79
+# reproduced inside its own fix, one option deeper and in the permitting
+# direction. The options loop in front of this one stops at the first token
+# that is not an option, so an option appearing AFTER a separated option value
+# was left for this class to admit -- and it refused to. cs_split walks past it
+# and finds the command; the anchor stopped dead. Measured on the branch that
+# had it:
 #
-# Which leaves the direction as the argument, and it is the one this file takes
-# everywhere: admitting a token too many can only refuse more, never hide a
-# wrapper. `sudo "x" sh -c 'git push --all origin'` is refused here and offers
-# no candidate in cs_split, and that asymmetry is in the refusing direction.
+#   BLOCK   sudo -u root -n git push --all origin
+#   ALLOW   sudo -u root -n sh -c 'git push --all origin'
+#   BLOCK   nice -n 10 -- git push --all origin
+#   ALLOW   nice -n 10 -- sh -c 'git push --all origin'
 #
-# Named because review of this change found the comment claiming the token
-# classes matched when only the counts did. The counts matching is the claim;
-# this paragraph is what makes the rest of it true.
-CS_WRAP_TOKEN="[^-[:space:]][^[:space:]]*[[:space:]]+"
+# `sudo -n`, `nice -n 10 --` and `timeout --preserve-status` are ordinary
+# spellings, and `--` defeats an exclusion like that whenever it follows a
+# separated option value. `sudo -- sh -c` was refused throughout, because
+# nothing had consumed an operand yet and the options loop still had the dash.
+#
+# Worse than the gap: the paragraph here named a deliberate difference from
+# cs_split, argued it was safe because admitting a token too many can only
+# refuse more, and did not mention this one, which runs the other way and which
+# that argument does not license. A comment claiming the classes differ in one
+# respect while they differed in two is the shape this file exists to stop,
+# arriving in the change whose subject it is. All three shapes are checks now.
+#
+# ONE DIFFERENCE REMAINS, and it is in the loop rather than the class.
+# cs_split's tail also breaks at a token that OPENS A QUOTE, because it is
+# offering candidates to read as commands and what follows a quote is the text
+# of an argument -- the mistake cs_normalise has made three times. Nothing here
+# reads a token as a command: these are skipped, on the way to a wrapper word
+# that must still appear after them. So the reason to stop does not transfer,
+# and `sudo "x" sh -c 'git push --all origin'` is refused here while cs_split
+# offers no candidate for it. That asymmetry is in the refusing direction and
+# is pinned as a check.
+CS_WRAP_TOKEN="[^[:space:]]+[[:space:]]+"
 
 # TWO WAYS THE LIST CAN BE MISSING, and the second is the one that needed
 # building for. It is the cost of making the list a variable, and it is paid

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -390,6 +390,11 @@ CS_WRAP_WORDS="$CS_WRAP_OPTION_WORDS|$CS_WRAP_OPERAND_WORDS"
 # to, for this same case and this same reason. A different number here would be
 # the divergence this whole change is about, arriving inside its own fix.
 #
+# The COUNT is what is shared, and not the token class. Review of this change
+# found this paragraph claiming both, when cs_split stops its tail at a token
+# opening a quote and this does not. The difference is deliberate and is argued
+# at CS_WRAP_TOKEN below; what is claimed here is the bound alone.
+#
 # WIDENED, NOT DROPPED, and the difference is the whole of the constraint. The
 # anchor cannot simply go: a wrapper word named anywhere on a line that also
 # names a refused command would then refuse the line, and the shapes that
@@ -440,24 +445,64 @@ CS_WRAP_WORDS="$CS_WRAP_OPTION_WORDS|$CS_WRAP_OPERAND_WORDS"
 # f.sh` was ALLOW and is now BLOCK -- named here so that it is a known cost
 # rather than a discovery. Both spellings of each pair above are checks.
 #
-# TWO WAYS THE LIST CAN BE MISSING, and they do not fail the same way, which is
-# the thing making it a variable added to this library.
+# A token that may stand between the prefix word and the wrapper word. Not an
+# option -- those are consumed by the loop in front of this one -- and anything
+# else.
 #
-# If the library does not load at all, this is the empty string, `grep -qE ''`
-# matches every line, the wrapper conjunct is always true, and a command naming
-# a refused verb is refused. That is the direction a guard's own breakage has to
-# take, and it needs no guard of its own.
+# WIDER THAN cs_split's TAIL TOKEN, deliberately, and this is the one place the
+# two answers differ on purpose. cs_split stops offering candidates at a token
+# that opens a quote, because what follows one is the text of an argument and
+# reading text as a command is the mistake cs_normalise has made three times.
+# Nothing here reads a token as a command: these are skipped, on the way to a
+# wrapper word that has to appear after them. So the reason to stop does not
+# transfer, and stopping anyway would narrow a guard for a reason that does not
+# apply to it.
 #
-# A library that loads with an empty list is the other way and is not the safe
-# one. cs_split then strips no prefix at all, so `sudo git push --all origin` is
-# permitted again -- the very verdict the fourth review fixed, and silent.
-# Probing for cs_split cannot see it, because the function is there and does
-# less. So the two hooks that probe for the functions probe for CS_WRAP_WORDS as
-# well, and check-hooks.sh builds a library with the list emptied rather than
-# arguing that it cannot happen. Both of those checks had to be written against
-# a command that ONLY the strip reaches: written with a plain `git commit` the
-# stale-branch one was green with its own guard removed.
-CS_WRAPPER_RE="(^[[:space:]]*|[;&|(\`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|($CS_WRAP_WORDS)[[:space:]]+(-[^[:space:]]*[[:space:]]+)*([^-[:space:]][^[:space:]]*[[:space:]]+){0,3})*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|\$))"
+# Which leaves the direction as the argument, and it is the one this file takes
+# everywhere: admitting a token too many can only refuse more, never hide a
+# wrapper. `sudo "x" sh -c 'git push --all origin'` is refused here and offers
+# no candidate in cs_split, and that asymmetry is in the refusing direction.
+#
+# Named because review of this change found the comment claiming the token
+# classes matched when only the counts did. The counts matching is the claim;
+# this paragraph is what makes the rest of it true.
+CS_WRAP_TOKEN="[^-[:space:]][^[:space:]]*[[:space:]]+"
+
+# TWO WAYS THE LIST CAN BE MISSING, and the second is the one that needed
+# building for. It is the cost of making the list a variable, and it is paid
+# here rather than in the hooks.
+#
+# If the library does not load at all, CS_WRAPPER_RE is unset, `grep -qE ''`
+# matches every line, the wrapper conjunct is vacuously true, and every command
+# naming a refused verb is refused. That is the direction a guard's own
+# breakage has to take, and it needs nothing else.
+#
+# A library that LOADS with an empty list is the unsafe way round, and probing
+# for the functions cannot see it: every function is there and cs_split simply
+# strips no prefix, so `sudo git push --all origin` is permitted again -- the
+# verdict the fourth review fixed, silently un-fixed.
+#
+# So the empty case is given the same answer as the missing one, in the one
+# place both are decided. With either half of the list gone, CS_WRAPPER_RE is
+# the empty string, every hook's wrapper conjunct is vacuously true, and each
+# of the four refuses the verb it answers for. Reviewed before this was done
+# and found to matter: no-git-push.sh and no-pr-decisions.sh source this file
+# unguarded, so a per-hook probe would have covered two of four and left
+# `sudo git push --all origin` and `sudo gh pr merge 5` permitted -- a guard
+# half-fitted, which is worse than none because its own comment says it is
+# fitted. The two hooks that already probe for the functions probe for the list
+# too, and that is for the message rather than for the verdict: they say why
+# they refused instead of refusing unexplained.
+#
+# Checked, not argued: check-hooks.sh builds a library with the list emptied in
+# place and asks all four. Those checks have to name a command that ONLY the
+# strip reaches -- written with a plain `git commit`, the stale-branch one was
+# green with its own guard removed.
+if [ -n "$CS_WRAP_OPTION_WORDS" ] && [ -n "$CS_WRAP_OPERAND_WORDS" ]; then
+  CS_WRAPPER_RE="(^[[:space:]]*|[;&|(\`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|($CS_WRAP_WORDS)[[:space:]]+(-[^[:space:]]*[[:space:]]+)*($CS_WRAP_TOKEN){0,3})*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|\$))"
+else
+  CS_WRAPPER_RE=""
+fi
 
 # Print one command per line, with anything that precedes the command word
 # removed, so a caller matches on ^ and never has to describe a command

--- a/.claude/hooks/no-commit-to-main.sh
+++ b/.claude/hooks/no-commit-to-main.sh
@@ -58,9 +58,17 @@
 # The file is tested for before it is sourced, and the functions after: a
 # missing file makes `.` end the shell where an `if` around it never runs, so
 # the guard would have been a comment.
+#
+# The wrapper words are probed with the function since #79, because cs_split
+# now reads them from a variable rather than carrying them as a literal -- so a
+# library whose functions are all present and whose list is empty strips no
+# prefix and admits none, silently and in the permitting direction. That is the
+# shape of nine of the defects this library has already had, arriving through a
+# variable rather than a regex, and it is the reason the pin exists rather than
+# an argument that it cannot happen.
 LIB="$(dirname "$0")/lib/command-scan.sh"
 [ -r "$LIB" ] && . "$LIB"
-if ! command -v cs_split >/dev/null 2>&1; then
+if ! command -v cs_split >/dev/null 2>&1 || [ -z "$CS_WRAP_WORDS" ]; then
   echo "Blocked: no-commit-to-main.sh could not load lib/command-scan.sh, so it cannot tell whether this command touches main. Refusing rather than permitting." >&2
   exit 2
 fi
@@ -90,7 +98,12 @@ ELSEWHERE_REFUSE="Blocked: this command moves git somewhere else before committi
 # The trade, taken knowingly: an `sh -c` anywhere in a command that also commits
 # plainly is refused for the company it keeps. That is the direction this file
 # takes throughout -- a blocked command is visible and one edit away.
-if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))' \
+#
+# The expression is CS_WRAPPER_RE, derived once in lib/command-scan.sh since
+# #79 -- one copy where all four hooks carried their own, and none of the four
+# admitted the prefix words cs_split already strips, so a wrapped commit behind
+# `sudo` or `timeout` was invisible to every one of them.
+if echo "$COMMAND" | grep -qE "$CS_WRAPPER_RE" \
    && echo "$COMMAND" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?(commit|push)([^-A-Za-z0-9_]|$)'; then
   echo "Blocked: git commit or push inside a shell wrapper. Whether it lands on main cannot be read through a quoted payload. Run it plainly." >&2
   exit 2

--- a/.claude/hooks/no-commit-to-main.sh
+++ b/.claude/hooks/no-commit-to-main.sh
@@ -62,13 +62,21 @@
 # The wrapper words are probed with the function since #79, because cs_split
 # now reads them from a variable rather than carrying them as a literal -- so a
 # library whose functions are all present and whose list is empty strips no
-# prefix and admits none, silently and in the permitting direction. That is the
-# shape of nine of the defects this library has already had, arriving through a
-# variable rather than a regex, and it is the reason the pin exists rather than
-# an argument that it cannot happen.
+# prefix, silently and in the permitting direction. That is the shape of nine of
+# the defects this library has already had, arriving through a variable rather
+# than a regex, and it is the reason the pin exists rather than an argument that
+# it cannot happen.
+#
+# The two halves are probed, not the union CS_WRAP_WORDS derives from them: with
+# both halves empty that union is the string "|", which is not empty and would
+# satisfy a probe written against it. What refuses a verb here even without this
+# probe is the library's own fail-safe -- an empty CS_WRAPPER_RE matches every
+# line -- and that covers all four hooks. This probe adds the message: it says
+# the library is the reason rather than leaving the refusal unexplained.
 LIB="$(dirname "$0")/lib/command-scan.sh"
 [ -r "$LIB" ] && . "$LIB"
-if ! command -v cs_split >/dev/null 2>&1 || [ -z "$CS_WRAP_WORDS" ]; then
+if ! command -v cs_split >/dev/null 2>&1 \
+   || [ -z "$CS_WRAP_OPTION_WORDS" ] || [ -z "$CS_WRAP_OPERAND_WORDS" ]; then
   echo "Blocked: no-commit-to-main.sh could not load lib/command-scan.sh, so it cannot tell whether this command touches main. Refusing rather than permitting." >&2
   exit 2
 fi

--- a/.claude/hooks/no-git-push.sh
+++ b/.claude/hooks/no-git-push.sh
@@ -74,7 +74,14 @@ REFUSE="Blocked: git push. An agent may push only the branch of the linked workt
 # no command word for the tokeniser to find, so the question would answer no and
 # the hook would leave. Ordering it the other way let all four wrapper forms
 # through, which the check suite caught.
-if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))' \
+#
+# The expression is CS_WRAPPER_RE, derived once in lib/command-scan.sh since
+# #79. All four hooks wrote out their own copy of it before that, and none of
+# the four admitted the prefix words cs_split already strips -- so this file
+# refused `sudo git push --all origin` and permitted
+# `sudo sh -c 'git push --all origin'`. What the anchor admits, where it stops,
+# and the soft spot it keeps are argued there rather than restated here.
+if echo "$COMMAND" | grep -qE "$CS_WRAPPER_RE" \
    && echo "$COMMAND" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?push([^-A-Za-z0-9_]|$)'; then
   echo "Blocked: git push inside a shell wrapper. The destination cannot be read through a quoted payload, so the worktree exception does not apply. Push plainly from the worktree, or leave it to Bertan." >&2
   exit 2

--- a/.claude/hooks/no-pr-decisions.sh
+++ b/.claude/hooks/no-pr-decisions.sh
@@ -428,7 +428,13 @@ gql_bases() {
 # do want, and cs_join is that half on its own.
 WRAPTEXT=$(printf '%s\n' "$COMMAND" | cs_join)
 
-if echo "$WRAPTEXT" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))'; then
+# Whether there is a wrapper at all is CS_WRAPPER_RE, derived once in
+# lib/command-scan.sh since #79 -- one copy where all four hooks carried their
+# own, and none of the four admitted the prefix words cs_split already strips,
+# so `timeout 5 sh -c 'gh pr merge 5'` was permitted. The rules below are still
+# this file's own, and still answer the subcommand question one level too late;
+# issue #51 carries that and the header says so.
+if echo "$WRAPTEXT" | grep -qE "$CS_WRAPPER_RE"; then
   if echo "$WRAPTEXT" | grep -qE "$GH_SURFACE_ANYWHERE" \
      || echo "$WRAPTEXT" | grep -qE '/pulls/[^ ]*/(merge|reviews)' \
      || echo "$WRAPTEXT" | grep -qE '/releases([^A-Za-z0-9_-]|$)' \

--- a/.claude/hooks/no-work-on-stale-branch.sh
+++ b/.claude/hooks/no-work-on-stale-branch.sh
@@ -271,13 +271,17 @@ LIB="$(dirname "$0")/lib/command-scan.sh"
 #
 # And the wrapper words with them, since #79. cs_split reads them from a
 # variable now rather than carrying them as a literal, so a library whose three
-# functions are all present and whose list is empty strips no prefix and admits
-# none -- silent, and in the permitting direction, which is the one property
-# every defect in this library has had in common.
+# functions are all present and whose list is empty strips no prefix -- silent,
+# and in the permitting direction, which is the one property every defect in
+# this library has had in common. The two halves are probed and not the union
+# they derive: with both empty that union is the string "|", which is not empty.
+# The verdict is carried by the library's own fail-safe either way; this probe
+# is what makes the refusal say why.
 if ! command -v cs_split >/dev/null 2>&1 \
    || ! command -v cs_normalise >/dev/null 2>&1 \
    || ! command -v cs_git_args >/dev/null 2>&1 \
-   || [ -z "$CS_WRAP_WORDS" ]; then
+   || [ -z "$CS_WRAP_OPTION_WORDS" ] \
+   || [ -z "$CS_WRAP_OPERAND_WORDS" ]; then
   refuse "(This hook could not load lib/command-scan.sh, so it cannot read what this command does. Refusing rather than permitting.)"
 fi
 

--- a/.claude/hooks/no-work-on-stale-branch.sh
+++ b/.claude/hooks/no-work-on-stale-branch.sh
@@ -268,9 +268,16 @@ LIB="$(dirname "$0")/lib/command-scan.sh"
 # cannot tell "not this verb" from "no such function", so a library holding
 # cs_split but not cs_git_args would leave every verb permitted through the very
 # check written to stop that.
+#
+# And the wrapper words with them, since #79. cs_split reads them from a
+# variable now rather than carrying them as a literal, so a library whose three
+# functions are all present and whose list is empty strips no prefix and admits
+# none -- silent, and in the permitting direction, which is the one property
+# every defect in this library has had in common.
 if ! command -v cs_split >/dev/null 2>&1 \
    || ! command -v cs_normalise >/dev/null 2>&1 \
-   || ! command -v cs_git_args >/dev/null 2>&1; then
+   || ! command -v cs_git_args >/dev/null 2>&1 \
+   || [ -z "$CS_WRAP_WORDS" ]; then
   refuse "(This hook could not load lib/command-scan.sh, so it cannot read what this command does. Refusing rather than permitting.)"
 fi
 
@@ -283,7 +290,11 @@ VERBS="commit cherry-pick revert merge am rebase"
 # tokeniser finds nothing -- so this runs on the raw text and before the search
 # for a command word, exactly as the three sibling hooks do. Ordering it the
 # other way would let every wrapped commit through.
-if echo "$COMMAND" | grep -qE '(^[[:space:]]*|[;&|(`][[:space:]]*)([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*((ba|z|)sh[[:space:]]+(-c|<<)|eval([^-A-Za-z0-9_]|$))' \
+#
+# The expression is CS_WRAPPER_RE, derived once in lib/command-scan.sh since
+# #79 -- one copy where all four hooks carried their own, and none of the four
+# admitted the prefix words cs_split already strips.
+if echo "$COMMAND" | grep -qE "$CS_WRAPPER_RE" \
    && echo "$COMMAND" | grep -qE 'git[[:space:]]+([^;&|]*[[:space:]])?(commit|cherry-pick|revert|merge|am|rebase)([^-A-Za-z0-9_]|$)'; then
   refuse "(That command is wrapped in a shell, so what it would write cannot be read through a quoted payload. Run it plainly.)"
 fi


### PR DESCRIPTION
Closes #79. (The keyword does not link on a `dev-NN` base — the Development
section stays empty, so the issue needs closing by hand on merge.)

## What was wrong

`cs_split` has stripped the words that run another command since the fourth
review. The four wrapper regexes in the hooks never consulted that list, so one
word was recognised in one half of `lib/command-scan.sh` and invisible in the
other:

```
BLOCK   sudo git push --all origin            the push is at a command position
ALLOW   sudo sh -c 'git push --all origin'    the wrapper is not at ^
```

The same held for `timeout`, `xargs`, `nohup` and `env`, against all four
hooks. One question, two places, two answers — the defect class the header of
that file opens by naming.

## What changed

- The list is a variable. `cs_split` reads it through `awk -v`; `CS_WRAPPER_RE`
  interpolates it. One copy, not two.
- `CS_WRAPPER_RE` itself is derived once and grepped by all four hooks, which
  each carried their own copy of it before.
- The anchor admits a prefix word with its options and up to three further
  tokens — the bound `cs_split` already offers its tail to.

## The trade, recorded

- **Named and not closed.** `python3 -c`, `perl -e`, `find -exec sh -c`, a make
  target, a script written and then run: all still ALLOW, each pinned as a
  check that *wants* ALLOW so the limit is recorded rather than discovered.
- **Widened, not dropped.** `grep -rn 'sh -c .*git push' .claude/hooks/` stays
  ALLOW — dropping the anchor would refuse it, and that is what a session
  working on these files writes.
- **The quote-blind anchor** stays a soft spot, named in the header with the
  decision rather than an excuse: asking `cs_split` *would* answer it, and what
  stops this rule asking is that the suite pins it as reading raw text. A
  candidate for its own ticket.
- **Cost of widening:** `sed -i 's|sudo sh -c git push|X|' f.sh` was ALLOW and
  is now BLOCK. Both spellings pinned.

## One defect this change would have introduced

Making the list a variable added a state that probing for the functions cannot
detect: every function present, list empty, `cs_split` stripping nothing,
`sudo git push --all origin` permitted again. The first answer covered two of
four hooks under a comment saying the state was handled. The fail-safe is in
the library now — an empty list gives an empty `CS_WRAPPER_RE`, which `grep`
matches against every line, so all four refuse. Found by review of the first
commit; the second commit is that answer.

## Verification

- `bash .claude/hooks/check-hooks.sh` — **ALL CHECKS PASSED**.
- **Nine mutants, no survivors**: anchor reverted, anchor dropped, either word
  list emptied, `cs_split` carrying the list as a literal again, the empty-list
  fail-safe removed, the intervening token narrowed, either hook's probe
  removed.
- Two checks exist because mutation found the first version of them silent.
- `make test`: 590 passed, 5 xfailed, 1 failed — `test_environment_sync.py`,
  pre-existing venv drift (`alembic`, `mako` from the `migrations` group), not
  touched by this branch, which is six shell files.
- `make upgrade-safe` not run: no dependency, lockfile or Python change here.

https://claude.ai/code/session_01PGuqGrYJD4tBbuafJD6tFP
