### PR TITLE
Correct the design's account of the pre-registration's append mechanism

### DIFF
--- a/docs/design/llm-call-log.md
+++ b/docs/design/llm-call-log.md
@@ -90,8 +90,11 @@ disconfirming one — are fixed in
 written before the log held a single provider-attributed row. **This document
 cites that entry and never repeats its numerals.** A threshold copied into a file
 that is revised in place is a threshold that drifts, and `docs/design/` is the
-copy that can be edited; the report is append-only, and amendments to it are dated
-appends naming the old value and the reason.
+copy that can be edited; the report is append-only, and it grows by dated appends
+of two kinds — amendments, which owe an old value, and registrations, which have
+none — under the shared timing rule that entry's own
+[§The two kinds of append](../eval-reports/2026-09-05-provider-acceptance-pre-registration.md#the-two-kinds-of-append)
+states and this document does not restate.
 
 The MiniMax table above has a second job under that registration: reproducing it
 from the log's own rows — in rank and direction, on terms the entry fixes — is the


### PR DESCRIPTION
Resolves [#33](https://github.com/bgunyel/clause-and-effect/issues/33), a `wayfinder:task` ticket under map [#6](https://github.com/bgunyel/clause-and-effect/issues/6). One paragraph in `docs/design/llm-call-log.md`; no code.

## The falsified clause

`:92-95`, closing *What counts as good enough is pre-registered elsewhere*:

> the report is append-only, and amendments to it are dated appends naming the old value and the reason.

True when written, and half the mechanism since [#28](https://github.com/bgunyel/clause-and-effect/issues/28) gave the pre-registration a `## The two kinds of append` section (landed in `32350ab`). **Both** kinds are dated appends under one shared timing rule; only an amendment owes an old value. A registration has none — that is what makes it a registration rather than an amendment.

Left standing, a reader of the design doc alone concludes every append to the pre-registration owes an old value, and the two registrations already in that file read as improperly filed.

## The replacement

> copy that can be edited; the report is append-only, and it grows by dated appends of two kinds — amendments, which owe an old value, and registrations, which have none — under the shared timing rule that entry's own [§The two kinds of append](docs/eval-reports/2026-09-05-provider-acceptance-pre-registration.md) states and this document does not restate.

The sentence this correction lives in **is** the repo's cite-never-restate rule, so the correction must not become the thing it warns about. It names the two kinds and their one distinguishing property, and points at the entry for the timing rule and the classification guard rather than copying either into the file that is revised in place.

## Verification

| check | result |
|---|---|
| paragraph's relative links | 2, **both resolve**; the pre-existing one is byte-identical |
| `#the-two-kinds-of-append` | resolves against a real `## The two kinds of append` heading |
| numerals introduced | **none** — the clause states no threshold, n, seed or digest |
| rest of the paragraph | unchanged |
| `make test` | 590 passed, 5 xfailed, **1 failed** — `test_environment_sync.py::test_installed_packages_match_uv_lock`, pre-existing venv drift from `uv.lock`, the same failure [#28](https://github.com/bgunyel/clause-and-effect/issues/28) recorded; unrelated to a docs-only change |

## One consequence for an open ticket

The edit is **+3 lines at `:93`**, so every line citation into this file below that point shifts by three. [#24](https://github.com/bgunyel/clause-and-effect/issues/24) cites `:780`, `:781`, `:787` and `:942`; those read `:783`, `:784`, `:790` and `:945` once this lands. Nothing in the working tree cites `llm-call-log.md:<n>` — grepped across `*.py`, `*.md`, `*.sh` — so the drift is confined to ticket bodies, and a note is on #24.

https://claude.ai/code/session_01JjoEnBUXVhiADLsGnQ48wr
